### PR TITLE
Add bake_dictionary option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 *.dic
+README*.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,11 +83,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -136,6 +152,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -146,6 +163,16 @@ dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -167,6 +194,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +224,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -222,18 +272,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum nom 4.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22293d25d3f33a8567cc8a1dc20f40c7eeb761ce83d0fcca059858580790cac3"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
 "checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
+"checksum syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+"checksum thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,11 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "clap"
 version = "2.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +127,7 @@ dependencies = [
 name = "sudachi"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -202,6 +208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "aab692d7759f5cd8c859e169db98ae5b52c924add2af5fbbca11d12fefb567c1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +133,7 @@ name = "sudachi"
 version = "0.1.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -211,6 +217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "aab692d7759f5cd8c859e169db98ae5b52c924add2af5fbbca11d12fefb567c1"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum nom 4.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22293d25d3f33a8567cc8a1dc20f40c7eeb761ce83d0fcca059858580790cac3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,9 @@ license = "Apache-2.0"
 
 [dependencies]
 cfg-if = "0.1"
-structopt = "0.2"
 nom = "4.2.2"
+structopt = "0.2"
+thiserror = "1.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ cfg-if = "0.1"
 structopt = "0.2"
 nom = "4.2.2"
 
+[dev-dependencies]
+lazy_static = "1.4.0"
+
 [features]
 # Compile dictionary into executable (specifying dictionary becomes optional)
 bake_dictionary = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,10 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
+cfg-if = "0.1"
 structopt = "0.2"
 nom = "4.2.2"
+
+[features]
+# Compile dictionary into executable (specifying dictionary becomes optional)
+bake_dictionary = []

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 
 形態素解析器 [Sudachi](https://github.com/WorksApplications/Sudachi)  - 非公式 Rust 🦀 クローン
 
-[English README](#sudachirs)
+[English README](README.md)
 
 ## 注意
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -75,7 +75,7 @@ sudachi 0.1.0
 A Japanese tokenizer
 
 USAGE:
-    sudachi [FLAGS] [OPTIONS] [file]
+    sudachi [FLAGS] [OPTIONS] --dict <dictionary_path> [file]
 
 FLAGS:
     -d, --debug      Debug mode: Dumps lattice
@@ -85,7 +85,8 @@ FLAGS:
     -w, --wakati     Outputs only surface form
 
 OPTIONS:
-    -m, --mode <mode>    Split unit: "A" (short), "B" (middle), or "C" (Named Entity) [default: C]
+    -l, --dict <dictionary_path>    Path to sudachi dictionary
+    -m, --mode <mode>               Split unit: "A" (short), "B" (middle), or "C" (Named Entity) [default: C]
 
 ARGS:
     <file>    Input text file: If not present, read from STDIN
@@ -99,26 +100,56 @@ ARGS:
 $ git clone https://github.com/sorami/sudachi.rs.git
 ```
 
-### 2. Sudachi辞書のダウンロード 
+### 2. Sudachi辞書のダウンロード
 
+<!-- START: translate from english -->
 [WorksApplications/SudachiDict](https://github.com/WorksApplications/SudachiDict)から辞書のzipファイル（ `small` 、 `core` 、 `full` から一つ選択）し、解凍して、中にある `system_*.dic` ファイルを `src/resources/system.dic` として置いてください （ファイル名が `system.dic` に変わっていることに注意）。
 
 上記のように手動で設置する以外に、レポジトリにあるスクリプトを使って自動的に `core` 辞書をダウンロードし `src/resources/system.dic` として設置することもできます。
+
+#### Convenience Script
+
+Optionally, you can use the [`fetch_dictionary.sh`](fetch_dictionary.sh) shell script to download the `core` dictionary and install it to `src/resources/system.dic`.
 
 ```
 $ ./fetch_dictionary.sh
 ```
 
-### 3. ビルド、インストール
+### 3. ビルド
 
+#### Build (default)
+
+```
+$ cargo build --release
+```
+
+#### Build (bake dictionary into binary)
+
+Specify the `bake_dictionary` feature to avoid the requirement for the `--dict` argument with each invocation.
 ビルドされた実行ファイルは、**辞書バイナリを内包しています**。
+The `--dict` option will be optional (default to using the integrated dictionary).
 
+You must specify the path the dictionary file in the `SUDACHI_DICT_PATH` environment variable when building.
+`SUDACHI_DICT_PATH` is relative to the `src/` directory (or absolute).
+
+Example on Unix-like system:
+```sh
+# Download dictionary to src/resources/system.dic
+$ ./fetch_dictionary.sh
+
+# Build with bake_dictionary feature (relative to src/ path)
+$ env SUDACHI_DICT_PATH=resources/system.dic cargo build --release --features bake_dictionary
+
+# もしくは
+
+# Build with bake_dictionary feature (absolute path)
+$ env SUDACHI_DICT_PATH=/path/to/my-sudachi.dic cargo build --release --features bake_dictionary
 ```
-$ cargo build
-```
 
-もしくは
+<!-- END: translate from english -->
 
+
+### 4. インストール
 ```
 sudachi.rs/ $ cargo install --path .
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,15 +1,14 @@
-# sudachi.rs
+# sudachi.rs - 日本語README
 
 <p align="center"><img width="100" src="logo.png" alt="sudachi.rs logo"></p>
 
-An unofficial [Sudachi](https://github.com/WorksApplications/Sudachi) clone in Rust 🦀
+形態素解析器 [Sudachi](https://github.com/WorksApplications/Sudachi)  - 非公式 Rust 🦀 クローン
 
-[日本語 README](#sudachirs---日本語readme)
+[English README](#sudachirs)
 
+## 注意
 
-## Caution
-
-This is my hobby project to try out Rust, and the implementation is incomplete; One fatal problem is that it will throw an error when there is an Out-of-Vocabulary word (i.e., when there is no lattice path from the beginning to the end).
+これはRust勉強のための趣味実装で、実装が未完の部分があります。特に、未知語が存在するときにエラーが発生します（ラティスで最初から最後までパスが存在しない場合）。
 
 ```sh
 $ echo "あ" | sudachi
@@ -21,12 +20,12 @@ thread 'main' panicked at 'EOS isn't connected to BOS', src/lattice.rs:70:13
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ```
 
-Please also have a look at an alternative by another person, [Yasu-umi/sudachiclone-rs](https://github.com/Yasu-umi/sudachiclone-rs).
+他の方によるRust実装も参照ください; [Yasu-umi/sudachiclone-rs](https://github.com/Yasu-umi/sudachiclone-rs)
 
 
-## Example
+## 利用例
 
-Multi-granular Tokenization
+複数粒度での分割
 
 ```
 $ echo 選挙管理委員会 | sudachi
@@ -41,7 +40,7 @@ $ echo 選挙管理委員会 | sudachi --mode A
 EOS
 ```
 
-Normalized Form
+正規化表記
 
 ```
 $ echo 打込む かつ丼 附属 vintage | sudachi
@@ -54,7 +53,7 @@ $ echo 打込む かつ丼 附属 vintage | sudachi
 vintage	名詞,普通名詞,一般,*,*,*	ビンテージ
 ```
 
-Wakati (space-delimited surface form) Output
+分かち書き出力
 
 ```
 $ cat lemon.txt
@@ -68,7 +67,7 @@ $ sudachi --wakati lemon.txt
 それ が 来 た の だ 。 これ は ちょっと いけ なかっ た 。
 ```
 
-## Usage
+## 利用方法
 
 ```
 $ sudachi -h
@@ -92,33 +91,33 @@ ARGS:
     <file>    Input text file: If not present, read from STDIN
 ```
 
-## Setup
+## セットアップ
 
-### 1. Get the source code
+### 1. ソースコードの取得
 
 ```
 $ git clone https://github.com/sorami/sudachi.rs.git
 ```
 
-### 2. Download a Sudachi Dictionary
+### 2. Sudachi辞書のダウンロード 
 
-You can download a dictionary zip file from [WorksApplications/SudachiDict](https://github.com/WorksApplications/SudachiDict) (choose one from `small`, `core`, or `full`), unzip it, and place the `system_*.dic` file to `src/resources/system.dic` (Note that the file name is changed to `system.dic`) .
+[WorksApplications/SudachiDict](https://github.com/WorksApplications/SudachiDict)から辞書のzipファイル（ `small` 、 `core` 、 `full` から一つ選択）し、解凍して、中にある `system_*.dic` ファイルを `src/resources/system.dic` として置いてください （ファイル名が `system.dic` に変わっていることに注意）。
 
-Alternatively, you can use a quick shell script in the source code; This script will download the `core` dictionary and place it to `src/resources/system.dic`.
+上記のように手動で設置する以外に、レポジトリにあるスクリプトを使って自動的に `core` 辞書をダウンロードし `src/resources/system.dic` として設置することもできます。
 
 ```
 $ ./fetch_dictionary.sh
 ```
 
-### 3. Build, Install
+### 3. ビルド、インストール
 
-The built executable will **contain the dictionary binary**.
+ビルドされた実行ファイルは、**辞書バイナリを内包しています**。
 
 ```
 $ cargo build
 ```
 
-or
+もしくは
 
 ```
 sudachi.rs/ $ cargo install --path .
@@ -135,12 +134,12 @@ A Japanese tokenizer
 
 ## ToDo
 
-- [ ] Out of Vocabulary handling
-- [ ] Easy dictionary file install & management, [similar to SudachiPy](https://github.com/WorksApplications/SudachiPy/issues/73)
-- [ ] Registration to crates.io
+- [ ] 未知語処理
+- [ ] 簡単な辞書ファイルのインストール、管理（[SudachiPyでの方式を参考に](https://github.com/WorksApplications/SudachiPy/issues/73)）
+- [ ] crates.io への登録
 
 
-## References
+## リファレンス
 
 ### Sudachi
 
@@ -149,13 +148,12 @@ A Japanese tokenizer
 - [WorksApplications/SudachiPy](https://github.com/WorksApplications/SudachiPy)
 - [msnoigrs/gosudachi](https://github.com/msnoigrs/gosudachi)
 
-
-### Morphological Analyzers in Rust
+### Rustによる形態素解析器の実装
 
 - [agatan/yoin: A Japanese Morphological Analyzer written in pure Rust](https://github.com/agatan/yoin)
 - [wareya/notmecab-rs: notmecab-rs is a very basic mecab clone, designed only to do parsing, not training.](https://github.com/wareya/notmecab-rs)
 
-### Logo
+### ロゴ
 
-- [Sudachi Logo](https://github.com/WorksApplications/Sudachi/blob/develop/docs/Sudachi.png)
-- Crab illustration: [Pixabay](https://pixabay.com/ja/vectors/%E5%8B%95%E7%89%A9-%E3%82%AB%E3%83%8B-%E7%94%B2%E6%AE%BB%E9%A1%9E-%E6%B5%B7-2029728/)
+- [Sudachiのロゴ](https://github.com/WorksApplications/Sudachi/blob/develop/docs/Sudachi.png)
+- カニのイラスト: [Pixabay](https://pixabay.com/ja/vectors/%E5%8B%95%E7%89%A9-%E3%82%AB%E3%83%8B-%E7%94%B2%E6%AE%BB%E9%A1%9E-%E6%B5%B7-2029728/)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# sudachi.rs
+# sudachi.rs - English README
 
 <p align="center"><img width="100" src="logo.png" alt="sudachi.rs logo"></p>
 
 An unofficial [Sudachi](https://github.com/WorksApplications/Sudachi) clone in Rust 🦀
 
-[日本語 README](#sudachirs---日本語readme)
-
+[日本語 README](README.ja.md)
 
 ## Caution
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ sudachi 0.1.0
 A Japanese tokenizer
 
 USAGE:
-    sudachi [FLAGS] [OPTIONS] [file]
+    sudachi [FLAGS] [OPTIONS] --dict <dictionary_path> [file]
 
 FLAGS:
     -d, --debug      Debug mode: Dumps lattice
@@ -85,7 +85,8 @@ FLAGS:
     -w, --wakati     Outputs only surface form
 
 OPTIONS:
-    -m, --mode <mode>    Split unit: "A" (short), "B" (middle), or "C" (Named Entity) [default: C]
+    -l, --dict <dictionary_path>    Path to sudachi dictionary
+    -m, --mode <mode>               Split unit: "A" (short), "B" (middle), or "C" (Named Entity) [default: C]
 
 ARGS:
     <file>    Input text file: If not present, read from STDIN
@@ -101,23 +102,50 @@ $ git clone https://github.com/sorami/sudachi.rs.git
 
 ### 2. Download a Sudachi Dictionary
 
-You can download a dictionary zip file from [WorksApplications/SudachiDict](https://github.com/WorksApplications/SudachiDict) (choose one from `small`, `core`, or `full`), unzip it, and place the `system_*.dic` file to `src/resources/system.dic` (Note that the file name is changed to `system.dic`) .
+Sudachi requires a dictionary to operate.
+You can download a dictionary ZIP file from [WorksApplications/SudachiDict](https://github.com/WorksApplications/SudachiDict) (choose one from `small`, `core`, or `full`), unzip it, and place the `system_*.dic` file somewhere.
 
-Alternatively, you can use a quick shell script in the source code; This script will download the `core` dictionary and place it to `src/resources/system.dic`.
+#### Convenience Script
+
+Optionally, you can use the [`fetch_dictionary.sh`](fetch_dictionary.sh) shell script to download the `core` dictionary and install it to `src/resources/system.dic`.
 
 ```
 $ ./fetch_dictionary.sh
 ```
 
-### 3. Build, Install
+### 3. Build
 
-The built executable will **contain the dictionary binary**.
+#### Build (default)
 
 ```
-$ cargo build
+$ cargo build --release
 ```
 
-or
+#### Build (bake dictionary into binary)
+
+Specify the `bake_dictionary` feature to avoid the requirement for the `--dict` argument with each invocation.
+The `sudachi` executable will **contain the dictionary binary**.
+The `--dict` option will be optional (default to using the integrated dictionary).
+
+You must specify the path the dictionary file in the `SUDACHI_DICT_PATH` environment variable when building.
+`SUDACHI_DICT_PATH` is relative to the `src/` directory (or absolute).
+
+Example on Unix-like system:
+```sh
+# Download dictionary to src/resources/system.dic
+$ ./fetch_dictionary.sh
+
+# Build with bake_dictionary feature (relative to src/ path)
+$ env SUDACHI_DICT_PATH=resources/system.dic cargo build --release --features bake_dictionary
+
+# or
+
+# Build with bake_dictionary feature (absolute path)
+$ env SUDACHI_DICT_PATH=/path/to/my-sudachi.dic cargo build --release --features bake_dictionary
+```
+
+
+### 4. Install
 
 ```
 sudachi.rs/ $ cargo install --path .

--- a/src/dic.rs
+++ b/src/dic.rs
@@ -1,3 +1,20 @@
+use nom::{le_u16, le_u8};
+
+use crate::error::SudachiNomCustomError;
+
 pub mod grammar;
 pub mod header;
 pub mod lexicon;
+
+named!(
+    utf16_string<&[u8], String>,
+    do_parse!(
+        length: le_u8 >>
+        v: count!(le_u16, length as usize) >>
+
+        (String::from_utf16(&v)
+            .map_err(|_| nom::Err::Failure(
+                nom::Context::Code(&[] as &[u8], nom::ErrorKind::Custom(SudachiNomCustomError::FromUtf16Nom as u32))))?
+        )
+    )
+);

--- a/src/dic/grammar.rs
+++ b/src/dic/grammar.rs
@@ -5,7 +5,7 @@ pub struct Grammar<'a> {
     pub pos_list: Vec<Vec<String>>,
     connect_table_offset: usize,
     left_id_size: i16,
-    right_id_size: i16,
+    _right_id_size: i16,
 
     pub storage_size: usize,
 }
@@ -28,7 +28,7 @@ impl<'a> Grammar<'a> {
             pos_list,
             connect_table_offset,
             left_id_size,
-            right_id_size,
+            _right_id_size: right_id_size,
             storage_size,
         }
     }

--- a/src/dic/header.rs
+++ b/src/dic/header.rs
@@ -1,36 +1,105 @@
-use std::str;
-
 use nom::le_u64;
+use thiserror::Error;
 
+/// Sudachi error
+#[derive(Error, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum HeaderError {
+    #[error("Invalid header")]
+    InvalidVersion,
+
+    #[error("Unable to parse")]
+    CannotParse,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Header {
     pub version: u64,
     _create_time: u64,
-    _description: String,
+    description: String,
 }
 
 impl Header {
     const DESCRIPTION_SIZE: usize = 256;
+    const EXPECTED_VERSION: u64 = 0x7366d3f18bd111e7;
     pub const STORAGE_SIZE: usize = 8 + 8 + Header::DESCRIPTION_SIZE;
 
-    pub fn new(bytes: &[u8], offset: usize) -> Header {
-        let (_rest, header) = header_parser(bytes, offset).unwrap();
-        assert_eq!(header.version, 0x7366d3f18bd111e7);
+    pub fn new(bytes: &[u8]) -> Result<(&[u8], Header), HeaderError> {
+        let (rest, header) = header_parser(bytes).map_err(|_| HeaderError::CannotParse)?;
 
-        header
+        if header.version != Self::EXPECTED_VERSION {
+            return Err(HeaderError::InvalidVersion);
+        }
+
+        Ok((rest, header))
     }
 }
 
+/// Create String from UTF-8 bytes up to NUL byte or end of slice (whichever is first)
+fn nul_terminated_str_from_slice(buf: &[u8]) -> String {
+    let str_bytes: &[u8] = if let Some(nul_idx) = buf.iter().position(|b| *b == 0) {
+        &buf[..nul_idx]
+    } else {
+        &buf
+    };
+    String::from_utf8_lossy(str_bytes).to_string()
+}
+
 named_args!(
-    header_parser(offset: usize)<&[u8], Header>,
+    header_parser()<&[u8], Header>,
     do_parse!(
-        _seek: take!(offset) >>
         version: le_u64 >>
         create_time: le_u64 >>
         desc_buf: take!(Header::DESCRIPTION_SIZE) >>
 
         (Header{ version,
                  _create_time: create_time,
-                 _description: str::from_utf8(&desc_buf).unwrap().to_string() })
-                 // alternative: lossy_utf8, unchecked
+                 description: nul_terminated_str_from_slice(&desc_buf) })
     )
 );
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn header_from_parts<T: AsRef<[u8]>>(
+        version: u64,
+        create_time: u64,
+        description: T,
+    ) -> Result<Header, HeaderError> {
+        let mut bytes = Vec::new();
+        bytes.extend(&version.to_le_bytes());
+        bytes.extend(&create_time.to_le_bytes());
+        bytes.extend(description.as_ref());
+
+        Header::new(&bytes).map(|(_rest, header)| header)
+    }
+
+    #[test]
+    fn graceful_failure() {
+        // Too small
+        assert_eq!(Header::new(&[]), Err(HeaderError::CannotParse));
+
+        assert_eq!(
+            header_from_parts(42, 0, vec![0; Header::DESCRIPTION_SIZE]),
+            Err(HeaderError::InvalidVersion)
+        );
+    }
+
+    #[test]
+    fn simple_header() {
+        let mut description: Vec<u8> = Vec::new();
+        let description_str = "My Description";
+        description.extend(description_str.bytes());
+        description.extend(&vec![0; Header::DESCRIPTION_SIZE]);
+
+        assert_eq!(
+            header_from_parts(Header::EXPECTED_VERSION, 1337, &description),
+            Ok(Header {
+                version: Header::EXPECTED_VERSION,
+                description: description_str.to_string(),
+                _create_time: 1337,
+            })
+        );
+    }
+}

--- a/src/dic/header.rs
+++ b/src/dic/header.rs
@@ -4,8 +4,8 @@ use nom::le_u64;
 
 pub struct Header {
     pub version: u64,
-    create_time: u64,
-    description: String,
+    _create_time: u64,
+    _description: String,
 }
 
 impl Header {
@@ -29,8 +29,8 @@ named_args!(
         desc_buf: take!(Header::DESCRIPTION_SIZE) >>
 
         (Header{ version,
-                 create_time,
-                 description: str::from_utf8(&desc_buf).unwrap().to_string() })
+                 _create_time: create_time,
+                 _description: str::from_utf8(&desc_buf).unwrap().to_string() })
                  // alternative: lossy_utf8, unchecked
     )
 );

--- a/src/dic/lexicon/trie.rs
+++ b/src/dic/lexicon/trie.rs
@@ -1,3 +1,5 @@
+use crate::prelude::*;
+
 pub struct Trie {
     array: Vec<u32>,
     size: u32, // number of elements
@@ -12,32 +14,48 @@ impl Trie {
         4 * self.size as usize
     }
 
-    pub fn common_prefix_search(&self, input: &[u8], offset: usize) -> Vec<(usize, usize)> {
+    pub fn common_prefix_search(
+        &self,
+        input: &[u8],
+        offset: usize,
+    ) -> SudachiResult<Vec<(usize, usize)>> {
         let mut result = Vec::new();
 
         let mut node_pos: usize = 0;
-        let mut unit: usize = *self.array.get(node_pos).unwrap() as usize;
+        let mut unit: usize = *self
+            .array
+            .get(node_pos)
+            .ok_or(SudachiError::MissingDictionaryTrie)? as usize;
         node_pos ^= Trie::offset(unit);
 
         for i in offset..input.len() {
-            let k = input.get(i).unwrap();
+            let k = input.get(i).ok_or(SudachiError::MissingDictionaryTrie)?;
             node_pos ^= *k as usize;
-            unit = *self.array.get(node_pos).unwrap() as usize;
+            unit = *self
+                .array
+                .get(node_pos)
+                .ok_or(SudachiError::MissingDictionaryTrie)? as usize;
             if Trie::label(unit) != *k as usize {
-                return result;
+                return Ok(result);
             }
 
             node_pos ^= Trie::offset(unit);
             if Trie::has_leaf(unit) {
                 let r = (
-                    Trie::value(*self.array.get(node_pos).unwrap() as usize),
+                    Trie::value(
+                        *self
+                            .array
+                            .get(node_pos)
+                            .ok_or(SudachiError::MissingDictionaryTrie)?
+                            as usize,
+                    ),
                     i + 1,
                 );
                 result.push(r);
             }
         }
 
-        result
+        Ok(result)
     }
 
     fn has_leaf(unit: usize) -> bool {

--- a/src/dic/lexicon/word_id_table.rs
+++ b/src/dic/lexicon/word_id_table.rs
@@ -1,5 +1,7 @@
 use nom::{le_u32, le_u8};
 
+use crate::prelude::*;
+
 pub struct WordIdTable<'a> {
     bytes: &'a [u8],
     size: u32,
@@ -19,9 +21,9 @@ impl<'a> WordIdTable<'a> {
         4 + self.size as usize
     }
 
-    pub fn get(&self, index: usize) -> Vec<u32> {
-        let (_rest, result) = word_id_table_parser(self.bytes, self.offset, index).unwrap();
-        result
+    pub fn get(&self, index: usize) -> SudachiResult<Vec<u32>> {
+        let (_rest, result) = word_id_table_parser(self.bytes, self.offset, index)?;
+        Ok(result)
     }
 }
 

--- a/src/dic/lexicon/word_infos.rs
+++ b/src/dic/lexicon/word_infos.rs
@@ -1,5 +1,8 @@
 use nom::{le_i32, le_u16, le_u32, le_u8};
 
+use crate::dic::utf16_string;
+use crate::prelude::*;
+
 pub struct WordInfos<'a> {
     bytes: &'a [u8],
     offset: usize,
@@ -15,33 +18,21 @@ impl<'a> WordInfos<'a> {
         }
     }
 
-    pub fn get_word_info(&self, word_id: usize) -> WordInfo {
-        let index = le_u32(&self.bytes[self.offset + (4 * word_id)..])
-            .unwrap()
-            .1 as usize; // wordIdToOffset()
-        let mut word_info = word_info_parser(self.bytes, index).unwrap().1;
+    pub fn get_word_info(&self, word_id: usize) -> SudachiResult<WordInfo> {
+        let index = le_u32(&self.bytes[self.offset + (4 * word_id)..])?.1 as usize; // wordIdToOffset()
+        let mut word_info = word_info_parser(self.bytes, index)?.1;
 
         // TODO: can we set dictionary_form within the word_info_parser?
         let dfwi = word_info.dictionary_form_word_id;
         if (dfwi >= 0) & (dfwi != word_id as i32) {
-            word_info.dictionary_form = self.get_word_info(dfwi as usize).surface;
+            word_info.dictionary_form = self.get_word_info(dfwi as usize)?.surface;
         };
 
-        word_info
+        Ok(word_info)
     }
 
     // TODO: is_valid_split()
 }
-
-named!(
-    utf16_string<&[u8], String>,
-    do_parse!(
-        length: le_u8 >>
-        v: count!(le_u16, length as usize) >>
-
-        (String::from_utf16(&v).unwrap())
-    )
-);
 
 named_args!(
     word_info_parser(index: usize)<&[u8], WordInfo>,

--- a/src/dic/lexicon/word_infos.rs
+++ b/src/dic/lexicon/word_infos.rs
@@ -3,15 +3,15 @@ use nom::{le_i32, le_u16, le_u32, le_u8};
 pub struct WordInfos<'a> {
     bytes: &'a [u8],
     offset: usize,
-    word_size: u32,
+    _word_size: u32,
 }
 
 impl<'a> WordInfos<'a> {
-    pub fn new(bytes: &'a [u8], offset: usize, word_size: u32) -> WordInfos {
+    pub fn new(bytes: &'a [u8], offset: usize, _word_size: u32) -> WordInfos {
         WordInfos {
             bytes,
             offset,
-            word_size,
+            _word_size,
         }
     }
 

--- a/src/dic/lexicon/word_params.rs
+++ b/src/dic/lexicon/word_params.rs
@@ -1,5 +1,7 @@
 use nom::le_i16;
 
+use crate::prelude::*;
+
 pub struct WordParams<'a> {
     bytes: &'a [u8],
     size: u32,
@@ -25,28 +27,26 @@ impl<'a> WordParams<'a> {
         self.size
     }
 
-    pub fn get_left_id(&self, word_id: usize) -> i16 {
+    pub fn get_left_id(&self, word_id: usize) -> SudachiResult<i16> {
         let (_rest, num) =
-            i16_parser(self.bytes, self.offset + WordParams::ELEMENT_SIZE * word_id).unwrap();
-        num
+            i16_parser(self.bytes, self.offset + WordParams::ELEMENT_SIZE * word_id)?;
+        Ok(num)
     }
 
-    pub fn get_right_id(&self, word_id: usize) -> i16 {
+    pub fn get_right_id(&self, word_id: usize) -> SudachiResult<i16> {
         let (_rest, num) = i16_parser(
             self.bytes,
             self.offset + WordParams::ELEMENT_SIZE * word_id + 2,
-        )
-        .unwrap();
-        num
+        )?;
+        Ok(num)
     }
 
-    pub fn get_cost(&self, word_id: usize) -> i16 {
+    pub fn get_cost(&self, word_id: usize) -> SudachiResult<i16> {
         let (_rest, num) = i16_parser(
             self.bytes,
             self.offset + WordParams::ELEMENT_SIZE * word_id + 4,
-        )
-        .unwrap();
-        num
+        )?;
+        Ok(num)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,18 @@
+use std::fmt::Debug;
+
+use thiserror::Error;
+
+use crate::dic::header::HeaderError;
+
+pub type SudachiResult<T> = Result<T, SudachiError>;
+
+/// Sudachi error
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum SudachiError {
+    #[error("IO Error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Invalid header: {0}")]
+    InvalidHeader(#[from] HeaderError),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::fmt::Debug;
 
 use thiserror::Error;
@@ -15,4 +16,71 @@ pub enum SudachiError {
 
     #[error("Invalid header: {0}")]
     InvalidHeader(#[from] HeaderError),
+
+    #[error("Invalid header")]
+    InvalidDictionaryGrammar,
+
+    #[error("Error parsing nom: {}", .0.description())]
+    NomParse(nom::ErrorKind<u32>),
+
+    #[error("Missing word_id")]
+    MissingWordId,
+
+    #[error("Missing part of speech")]
+    MissingPartOfSpeech,
+
+    #[error("Missing latice path")]
+    MissingLaticePath,
+
+    #[error("Missing dictionary trie")]
+    MissingDictionaryTrie,
+
+    #[error("Invalid UTF-16: {0}")]
+    FromUtf16(#[from] std::string::FromUtf16Error),
+
+    #[error("Invalid UTF-16 from nom")]
+    FromUtf16Nom,
+
+    #[error("EOS isn't connected to BOS")]
+    EosBosDisconnect,
+}
+
+/// Define `SudachiNomCustomError` error and conversion to `SudachiError`.
+/// The variants that can be converted will have the same name.
+macro_rules! define_nom_error_enum {
+    (
+        $( $name:ident = $value_int:literal , )*
+    ) => {
+        #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+        pub(crate) enum SudachiNomCustomError {
+            $($name = $value_int , )*
+        }
+
+        impl TryFrom<u32> for SudachiError {
+            type Error = ();
+            fn try_from(x: u32) -> Result<Self, Self::Error> {
+                match x {
+                    $( $value_int => Ok(SudachiError::$name) , )*
+                    _ => Err(()),
+                }
+            }
+        }
+    };
+}
+
+define_nom_error_enum! {
+    FromUtf16Nom = 0,
+}
+
+impl<I> From<nom::Err<I, u32>> for SudachiError {
+    fn from(err: nom::Err<I, u32>) -> Self {
+        if let nom::Err::Failure(nom::Context::Code(_v, nom::ErrorKind::Custom(custom_error))) =
+            &err
+        {
+            if let Ok(sudachi_error) = SudachiError::try_from(*custom_error) {
+                return sudachi_error;
+            }
+        }
+        SudachiError::NomParse(err.into_error_kind())
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,7 +41,7 @@ pub enum SudachiError {
     #[error("Invalid UTF-16 from nom")]
     FromUtf16Nom,
 
-    #[error("EOS isn't connected to BOS")]
+    #[error("End of sentence (EOS) is not connected to beginning of sentence (BOS)")]
     EosBosDisconnect,
 }
 

--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -4,6 +4,7 @@ use std::i32;
 
 use self::node::Node;
 use crate::dic::grammar::Grammar;
+use crate::prelude::*;
 
 pub struct Lattice<'a> {
     grammar: &'a Grammar<'a>,
@@ -25,7 +26,7 @@ impl<'a> Lattice<'a> {
         }
     }
 
-    fn connect_node(&self, r_node: &mut Node) {
+    fn connect_node(&self, r_node: &mut Node) -> SudachiResult<()> {
         let begin = r_node.begin;
         r_node.total_cost = i32::MAX;
 
@@ -36,7 +37,7 @@ impl<'a> Lattice<'a> {
 
             let connect_cost = self
                 .grammar
-                .get_connect_cost(l_node.right_id, r_node.left_id);
+                .get_connect_cost(l_node.right_id, r_node.left_id)?;
             let cost = l_node.total_cost + connect_cost as i32;
             if cost < r_node.total_cost {
                 r_node.total_cost = cost;
@@ -46,39 +47,49 @@ impl<'a> Lattice<'a> {
         r_node.total_cost += r_node.cost as i32;
 
         r_node.is_connected_to_bos = r_node.best_previous_node_index.is_some();
+
+        Ok(())
     }
 
-    pub fn insert(&mut self, begin: usize, end: usize, mut node: Node) {
+    pub fn insert(&mut self, begin: usize, end: usize, mut node: Node) -> SudachiResult<()> {
         node.set_range(begin, end);
-        self.connect_node(&mut node);
+        self.connect_node(&mut node)?;
         self.end_lists[end].push(node);
+
+        Ok(())
     }
 
-    pub fn connect_eos_node(&mut self) {
+    pub fn connect_eos_node(&mut self) -> SudachiResult<()> {
         let eos_node = Node::new_eos(self.size);
-        self.insert(eos_node.begin, eos_node.end, eos_node);
+        self.insert(eos_node.begin, eos_node.end, eos_node)
     }
 
-    pub fn get_best_path(&self) -> Vec<&Node> {
+    pub fn get_best_path(&self) -> SudachiResult<Vec<&Node>> {
         // TODO: reference of eos_node in struct `Lattice` ?
-        let eos_node = self.end_lists[self.size].last().unwrap();
+        let eos_node = self.end_lists[self.size]
+            .last()
+            .ok_or(SudachiError::MissingLaticePath)?;
 
         if !eos_node.is_connected_to_bos {
-            panic!("EOS isn't connected to BOS");
+            return Err(SudachiError::EosBosDisconnect);
         }
 
         let mut path = Vec::new();
 
         let mut node = eos_node;
         // todo
-        let (i, j) = node.best_previous_node_index.unwrap();
+        let (i, j) = node
+            .best_previous_node_index
+            .ok_or(SudachiError::MissingLaticePath)?;
         let mut i = i;
         let mut j = j;
         while (i, j) != (0, 0) {
             path.push(node);
 
             // todo
-            let (a, b) = node.best_previous_node_index.unwrap();
+            let (a, b) = node
+                .best_previous_node_index
+                .ok_or(SudachiError::MissingLaticePath)?;
             i = a;
             j = b;
             node = &self.end_lists[i][j];
@@ -87,6 +98,6 @@ impl<'a> Lattice<'a> {
         path.reverse();
         path.pop(); // EOS
 
-        path
+        Ok(path)
     }
 }

--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -45,10 +45,7 @@ impl<'a> Lattice<'a> {
         }
         r_node.total_cost += r_node.cost as i32;
 
-        r_node.is_connected_to_bos = match r_node.best_previous_node_index {
-            Some(_) => true,
-            None => false,
-        };
+        r_node.is_connected_to_bos = r_node.best_previous_node_index.is_some();
     }
 
     pub fn insert(&mut self, begin: usize, end: usize, mut node: Node) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ mod tests;
 
 pub mod prelude {
     pub use crate::{
+        morpheme::Morpheme,
         tokenizer::{Mode, Tokenize, Tokenizer},
         SudachiError, SudachiResult,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 //! Clone of [Sudachi](https://github.com/WorksApplications/Sudachi),
 //! a Japanese morphological analyzer
+//!
+//! The main entry point of the library is the
+//! [`Tokenizer`](tokenizer/struct.Tokenizer.html) struct, which
+//! implements [`Tokenize`](tokenizer/trait.Tokenize.html).
 
 #[cfg(test)]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,15 +8,20 @@ extern crate lazy_static;
 #[macro_use]
 extern crate nom;
 
+pub mod dic;
+pub mod error;
+pub mod lattice;
 pub mod morpheme;
 pub mod tokenizer;
 
-pub mod dic;
-pub mod lattice;
+pub use error::*;
 
 #[cfg(test)]
 mod tests;
 
 pub mod prelude {
-    pub use crate::tokenizer::{Mode, Tokenize, Tokenizer};
+    pub use crate::{
+        tokenizer::{Mode, Tokenize, Tokenizer},
+        SudachiError, SudachiResult,
+    };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ mod tests;
 pub mod prelude {
     pub use crate::{
         morpheme::Morpheme,
-        tokenizer::{Mode, Tokenize, Tokenizer},
+        tokenizer::{dictionary_bytes_from_path, Mode, Tokenize, Tokenizer},
         SudachiError, SudachiResult,
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+//! Clone of [Sudachi](https://github.com/WorksApplications/Sudachi),
+//! a Japanese morphological analyzer
+
+#[cfg(test)]
+#[macro_use]
+extern crate lazy_static;
+
 #[macro_use]
 extern crate nom;
 
@@ -6,3 +13,10 @@ pub mod tokenizer;
 
 pub mod dic;
 pub mod lattice;
+
+#[cfg(test)]
+mod tests;
+
+pub mod prelude {
+    pub use crate::tokenizer::{Mode, Tokenize, Tokenizer};
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,12 +74,10 @@ fn get_dictionary_bytes(args: &Cli) -> Cow<'static, [u8]> {
 
 fn main() {
     let args = Cli::from_args();
-    let mode = match args.mode.as_str() {
-        "A" | "a" => Mode::A,
-        "B" | "b" => Mode::B,
-        "C" | "c" => Mode::C,
-        _ => {
-            eprintln!("Invalid mode: Mode must be one of \"A\", \"B\", or \"C\" (in lower or upper case).");
+    let mode = match args.mode.as_str().parse() {
+        Ok(mode) => mode,
+        Err(err) => {
+            eprintln!("Invalid mode: {}", err);
             process::exit(1);
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,10 +66,12 @@ fn main() {
         let morpheme_list = tokenizer.tokenize(&input, &mode, enable_debug);
 
         if wakati {
-            let surface_list = morpheme_list.iter().map(|m| m.surface().to_string()).collect::<Vec<_>>();
+            let surface_list = morpheme_list
+                .iter()
+                .map(|m| m.surface().to_string())
+                .collect::<Vec<_>>();
             println!("{}", surface_list.join(" "));
-        }
-        else {
+        } else {
             for morpheme in morpheme_list {
                 print!(
                     "{}\t{}\t{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ fn main() {
 
     for line in reader.lines() {
         let input = line.unwrap().to_string();
-        let morpheme_list = tokenizer.tokenize(&input, &mode, enable_debug);
+        let morpheme_list = tokenizer.tokenize(&input, mode, enable_debug);
 
         if wakati {
             let surface_list = morpheme_list

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use sudachi::tokenizer::Mode;
 use sudachi::tokenizer::Tokenizer;
 
 #[cfg(feature = "bake_dictionary")]
-const BAKED_DICTIONARY_BYTES: &[u8] = include_bytes!("resources/system.dic");
+const BAKED_DICTIONARY_BYTES: &[u8] = include_bytes!(env!("SUDACHI_DICT_PATH"));
 
 /// A Japanese tokenizer
 #[derive(StructOpt)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,12 +96,17 @@ fn main() {
     // input: stdin or file
     let reader: Box<dyn BufRead> = match args.file {
         None => Box::new(BufReader::new(io::stdin())),
-        Some(input_path) => Box::new(BufReader::new(fs::File::open(input_path).unwrap())),
+        Some(input_path) => Box::new(BufReader::new(
+            fs::File::open(&input_path)
+                .unwrap_or_else(|_| panic!("Failed to open file {:?}", &input_path)),
+        )),
     };
 
     for line in reader.lines() {
-        let input = line.unwrap().to_string();
-        let morpheme_list = tokenizer.tokenize(&input, mode, enable_debug);
+        let input = line.expect("Failed to reead line").to_string();
+        let morpheme_list = tokenizer
+            .tokenize(&input, mode, enable_debug)
+            .expect("failed to tokenize input");
 
         if wakati {
             let surface_list = morpheme_list
@@ -114,7 +119,7 @@ fn main() {
                 print!(
                     "{}\t{}\t{}",
                     morpheme.surface(),
-                    morpheme.pos().join(","),
+                    morpheme.pos().expect("Missing part of speech").join(","),
                     morpheme.normalized_form(),
                 );
                 if print_all {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::process;
 use structopt::StructOpt;
 
 use sudachi::tokenizer::Mode;
-use sudachi::tokenizer::Tokenizer;
+use sudachi::tokenizer::{Tokenize, Tokenizer};
 
 #[cfg(feature = "bake_dictionary")]
 const BAKED_DICTIONARY_BYTES: &[u8] = include_bytes!(env!("SUDACHI_DICT_PATH"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
-use std::fs::{self, File};
-use std::io::{self, BufRead, BufReader, Read};
+use std::fs;
+use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
 use std::process;
 
@@ -63,12 +63,8 @@ fn get_dictionary_bytes(args: &Cli) -> Cow<'static, [u8]> {
         }
     };
 
-    let dictionary_stat = fs::metadata(&dictionary_path).expect("Unable to stat dictionary");
-    let mut dictionary_file = File::open(dictionary_path).expect("Unable to open dictionary");
-    let mut storage_buf = Vec::with_capacity(dictionary_stat.len() as usize);
-    dictionary_file
-        .read_to_end(&mut storage_buf)
-        .expect("Failed to read from dictionary file");
+    let storage_buf = dictionary_bytes_from_path(&dictionary_path)
+        .expect("Failed to get dictionary bytes from file");
     Cow::Owned(storage_buf)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,7 @@ use std::process;
 
 use structopt::StructOpt;
 
-use sudachi::tokenizer::Mode;
-use sudachi::tokenizer::{Tokenize, Tokenizer};
+use sudachi::prelude::*;
 
 #[cfg(feature = "bake_dictionary")]
 const BAKED_DICTIONARY_BYTES: &[u8] = include_bytes!(env!("SUDACHI_DICT_PATH"));
@@ -91,7 +90,8 @@ fn main() {
     // load and parse dictionary binary to create a tokenizer
 
     let dictionary_bytes = get_dictionary_bytes(&args);
-    let tokenizer = Tokenizer::from_dictionary_bytes(&dictionary_bytes);
+    let tokenizer = Tokenizer::from_dictionary_bytes(&dictionary_bytes)
+        .expect("Failed to create Tokenizer from dictionary bytes");
 
     // input: stdin or file
     let reader: Box<dyn BufRead> = match args.file {

--- a/src/morpheme.rs
+++ b/src/morpheme.rs
@@ -2,6 +2,7 @@ use crate::dic::grammar::Grammar;
 use crate::dic::lexicon::word_infos::WordInfo;
 use crate::dic::lexicon::Lexicon;
 
+/// Basic semantic unit of language
 pub struct Morpheme<'a> {
     word_info: WordInfo,
     grammar: &'a Grammar<'a>,

--- a/src/morpheme.rs
+++ b/src/morpheme.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::dic::grammar::Grammar;
 use crate::dic::lexicon::word_infos::WordInfo;
 use crate::dic::lexicon::Lexicon;
@@ -57,5 +59,17 @@ impl<'a> Morpheme<'a> {
     /// "Dictionary form" means a word's lemma and "終止形" in Japanese.
     pub fn dictionary_form(&self) -> &String {
         &self.word_info.dictionary_form
+    }
+}
+
+impl<'a> fmt::Debug for Morpheme<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Morpheme")
+            .field("surface", self.surface())
+            .field("pos", &self.pos())
+            .field("normalized_form", self.normalized_form())
+            .field("reading_form", self.reading_form())
+            .field("dictionary_form", self.dictionary_form())
+            .finish()
     }
 }

--- a/src/morpheme.rs
+++ b/src/morpheme.rs
@@ -1,6 +1,7 @@
 use crate::dic::grammar::Grammar;
 use crate::dic::lexicon::word_infos::WordInfo;
 use crate::dic::lexicon::Lexicon;
+use crate::prelude::*;
 
 /// Basic semantic unit of language
 pub struct Morpheme<'a> {
@@ -9,21 +10,26 @@ pub struct Morpheme<'a> {
 }
 
 impl<'a> Morpheme<'a> {
-    pub fn new(word_id: usize, grammar: &'a Grammar<'a>, lexicon: &Lexicon) -> Morpheme<'a> {
-        let word_info = lexicon.get_word_info(word_id);
-        Morpheme { word_info, grammar }
+    pub fn new(
+        word_id: usize,
+        grammar: &'a Grammar<'a>,
+        lexicon: &Lexicon,
+    ) -> SudachiResult<Morpheme<'a>> {
+        let word_info = lexicon.get_word_info(word_id)?;
+        Ok(Morpheme { word_info, grammar })
     }
 
     pub fn surface(&self) -> &String {
         &self.word_info.surface
     }
 
-    pub fn pos(&self) -> &Vec<String> {
-        &self
+    pub fn pos(&self) -> SudachiResult<&Vec<String>> {
+        let res = &self
             .grammar
             .pos_list
             .get(self.word_info.pos_id as usize)
-            .unwrap()
+            .ok_or(SudachiError::MissingPartOfSpeech)?;
+        Ok(res)
     }
 
     pub fn normalized_form(&self) -> &String {

--- a/src/morpheme.rs
+++ b/src/morpheme.rs
@@ -3,13 +3,14 @@ use crate::dic::lexicon::word_infos::WordInfo;
 use crate::dic::lexicon::Lexicon;
 use crate::prelude::*;
 
-/// Basic semantic unit of language
+/// A morpheme (basic semantic unit of language)
 pub struct Morpheme<'a> {
     word_info: WordInfo,
     grammar: &'a Grammar<'a>,
 }
 
 impl<'a> Morpheme<'a> {
+    /// Create a new `Morpheme`
     pub fn new(
         word_id: usize,
         grammar: &'a Grammar<'a>,
@@ -19,10 +20,14 @@ impl<'a> Morpheme<'a> {
         Ok(Morpheme { word_info, grammar })
     }
 
+    /// Returns the text of morpheme.
+    ///
+    /// When the input text is normalized, some morphemes have the same surface.
     pub fn surface(&self) -> &String {
         &self.word_info.surface
     }
 
+    /// Part of speech
     pub fn pos(&self) -> SudachiResult<&Vec<String>> {
         let res = &self
             .grammar
@@ -32,14 +37,24 @@ impl<'a> Morpheme<'a> {
         Ok(res)
     }
 
+    /// Normalized form of morpheme
+    ///
+    /// This method returns the form normalizing inconsistent spellings and
+    /// inflected forms.
     pub fn normalized_form(&self) -> &String {
         &self.word_info.normalized_form
     }
 
+    /// Returns the reading form of morpheme.
+    ///
+    /// Returns Japanese syllabaries 'フリガナ' in katakana.
     pub fn reading_form(&self) -> &String {
         &self.word_info.reading_form
     }
 
+    /// Returns the dictionary form of morpheme.
+    ///
+    /// "Dictionary form" means a word's lemma and "終止形" in Japanese.
     pub fn dictionary_form(&self) -> &String {
         &self.word_info.dictionary_form
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,21 +1,15 @@
 //! Crate tests
 
 use std::env;
-use std::fs::{self, File};
-use std::io::Read;
 
 use crate::prelude::*;
 
 lazy_static! {
     static ref DICTIONARY_BYTES: Vec<u8> = {
         let dictionary_path = env::var_os("SUDACHI_DICT_PATH").expect("Must set env var SUDACHI_DICT_PATH with path to Sudachi dictionary (relative to current dir)");
-        let dictionary_stat = fs::metadata(&dictionary_path).expect("Unable to stat dictionary");
-        let mut dictionary_file = File::open(dictionary_path).expect("Unable to open dictionary");
-        let mut storage_buf = Vec::with_capacity(dictionary_stat.len() as usize);
-        dictionary_file
-            .read_to_end(&mut storage_buf)
-            .expect("Failed to read from dictionary file");
-        storage_buf
+        let dictionary_bytes = dictionary_bytes_from_path(dictionary_path)
+            .expect("Failed to read dictionary from path");
+        dictionary_bytes
     };
     static ref TOKENIZER: Tokenizer<'static> = Tokenizer::from_dictionary_bytes(&DICTIONARY_BYTES)
         .expect("Failed to create Tokenizer for tests");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,7 +31,9 @@ struct ChunkExpectation<'a> {
 
 /// Get text chunks from text
 fn tokenized_chunks(text: &str, mode: Mode) -> Vec<String> {
-    let tokens = TOKENIZER.tokenize(text, mode, false);
+    let tokens = TOKENIZER
+        .tokenize(text, mode, false)
+        .expect("Failed to get tokens");
     tokens
         .iter()
         .map(|tok| tok.surface().clone())

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,7 +17,8 @@ lazy_static! {
             .expect("Failed to read from dictionary file");
         storage_buf
     };
-    static ref TOKENIZER: Tokenizer<'static> = Tokenizer::from_dictionary_bytes(&DICTIONARY_BYTES);
+    static ref TOKENIZER: Tokenizer<'static> = Tokenizer::from_dictionary_bytes(&DICTIONARY_BYTES)
+        .expect("Failed to create Tokenizer for tests");
 }
 
 /// Expected chunks for a text in a given mode

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,98 @@
+//! Crate tests
+
+use std::env;
+use std::fs::{self, File};
+use std::io::Read;
+
+use crate::prelude::*;
+
+lazy_static! {
+    static ref DICTIONARY_BYTES: Vec<u8> = {
+        let dictionary_path = env::var_os("SUDACHI_DICT_PATH").expect("Must set env var SUDACHI_DICT_PATH with path to Sudachi dictionary (relative to current dir)");
+        let dictionary_stat = fs::metadata(&dictionary_path).expect("Unable to stat dictionary");
+        let mut dictionary_file = File::open(dictionary_path).expect("Unable to open dictionary");
+        let mut storage_buf = Vec::with_capacity(dictionary_stat.len() as usize);
+        dictionary_file
+            .read_to_end(&mut storage_buf)
+            .expect("Failed to read from dictionary file");
+        storage_buf
+    };
+    static ref TOKENIZER: Tokenizer<'static> = Tokenizer::from_dictionary_bytes(&DICTIONARY_BYTES);
+}
+
+/// Expected chunks for a text in a given mode
+#[derive(Debug, Clone)]
+struct ChunkExpectation<'a> {
+    a: &'a [&'a str],
+    b: &'a [&'a str],
+    c: &'a [&'a str],
+}
+
+/// Get text chunks from text
+fn tokenized_chunks(text: &str, mode: Mode) -> Vec<String> {
+    let tokens = TOKENIZER.tokenize(text, mode, false);
+    tokens
+        .iter()
+        .map(|tok| tok.surface().clone())
+        .collect::<Vec<String>>()
+}
+
+fn assert_tokenized_chunk_modes(text: &str, expected_chunks: ChunkExpectation) {
+    assert_eq!(
+        tokenized_chunks(text, Mode::A),
+        expected_chunks.a,
+        "failed for mode A, text={:?}",
+        text
+    );
+    assert_eq!(
+        tokenized_chunks(text, Mode::B),
+        expected_chunks.b,
+        "failed for mode B, text={:?}",
+        text
+    );
+    assert_eq!(
+        tokenized_chunks(text, Mode::C),
+        expected_chunks.c,
+        "failed for mode C, text={:?}",
+        text
+    );
+}
+
+#[test]
+fn chunks() {
+    assert_tokenized_chunk_modes(
+        "選挙管理委員会",
+        ChunkExpectation {
+            a: &["選挙", "管理", "委員", "会"],
+            b: &["選挙", "管理", "委員会"],
+            c: &["選挙管理委員会"],
+        },
+    );
+
+    assert_tokenized_chunk_modes(
+        "客室乗務員",
+        ChunkExpectation {
+            a: &["客室", "乗務", "員"],
+            b: &["客室", "乗務員"],
+            c: &["客室乗務員"],
+        },
+    );
+
+    assert_tokenized_chunk_modes(
+        "労働者協同組合",
+        ChunkExpectation {
+            a: &["労働", "者", "協同", "組合"],
+            b: &["労働者", "協同", "組合"],
+            c: &["労働者協同組合"],
+        },
+    );
+
+    assert_tokenized_chunk_modes(
+        "機能性食品",
+        ChunkExpectation {
+            a: &["機能", "性", "食品"],
+            b: &["機能性", "食品"],
+            c: &["機能性食品"],
+        },
+    );
+}

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -4,6 +4,7 @@ use crate::dic::lexicon::Lexicon;
 use crate::lattice::node::Node;
 use crate::lattice::Lattice;
 use crate::morpheme::Morpheme;
+use crate::SudachiResult;
 
 /// Able to tokenize Japanese text
 pub trait Tokenize {
@@ -53,10 +54,9 @@ pub enum Mode {
 }
 
 impl<'a> Tokenizer<'a> {
-    pub fn from_dictionary_bytes(dictionary_bytes: &'a [u8]) -> Tokenizer<'a> {
+    pub fn from_dictionary_bytes(dictionary_bytes: &'a [u8]) -> SudachiResult<Tokenizer<'a>> {
+        let (_rest, _header) = Header::new(&dictionary_bytes[..Header::STORAGE_SIZE])?;
         let mut offset = 0;
-
-        let _header = Header::new(dictionary_bytes, offset);
         offset += Header::STORAGE_SIZE;
 
         let grammar = Grammar::new(dictionary_bytes, offset);
@@ -64,7 +64,7 @@ impl<'a> Tokenizer<'a> {
 
         let lexicon = Lexicon::new(dictionary_bytes, offset);
 
-        Tokenizer { grammar, lexicon }
+        Ok(Tokenizer { grammar, lexicon })
     }
 }
 impl<'a> Tokenize for Tokenizer<'a> {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::dic::grammar::Grammar;
 use crate::dic::header::Header;
 use crate::dic::lexicon::Lexicon;
@@ -52,6 +54,19 @@ pub enum Mode {
 
     /// Named Entity
     C,
+}
+
+impl FromStr for Mode {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "A" | "a" => Ok(Mode::A),
+            "B" | "b" => Ok(Mode::B),
+            "C" | "c" => Ok(Mode::C),
+            _ => Err("Mode must be one of \"A\", \"B\", or \"C\" (in lower or upper case)."),
+        }
+    }
 }
 
 impl<'a> Tokenizer<'a> {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -65,7 +65,7 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
-    pub fn tokenize(&self, input: &str, mode: &Mode, enable_debug: bool) -> Vec<Morpheme> {
+    pub fn tokenize(&self, input: &str, mode: Mode, enable_debug: bool) -> Vec<Morpheme> {
         let input_bytes = input.as_bytes();
 
         // build_lattice
@@ -109,7 +109,7 @@ impl<'a> Tokenizer<'a> {
         let node_list = lattice.get_best_path();
 
         let mut word_id_list = Vec::new();
-        if *mode == Mode::C {
+        if mode == Mode::C {
             word_id_list = node_list
                 .iter()
                 .map(|node| node.word_id.unwrap() as usize)
@@ -117,7 +117,7 @@ impl<'a> Tokenizer<'a> {
         } else {
             for node in &node_list {
                 let node_word_id = node.word_id.unwrap() as usize;
-                let word_ids = match *mode {
+                let word_ids = match mode {
                     Mode::A => self.lexicon.get_word_info(node_word_id).a_unit_split,
                     Mode::B => self.lexicon.get_word_info(node_word_id).b_unit_split,
                     _ => panic!(),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -11,10 +11,38 @@ pub struct Tokenizer<'a> {
     pub lexicon: Lexicon<'a>,
 }
 
-#[derive(PartialEq)]
+/// Unit to split text
+///
+/// Some examples:
+/// ```text
+/// A：選挙/管理/委員/会
+/// B：選挙/管理/委員会
+/// C：選挙管理委員会
+///
+/// A：客室/乗務/員
+/// B：客室/乗務員
+/// C：客室乗務員
+///
+/// A：労働/者/協同/組合
+/// B：労働者/協同/組合
+/// C：労働者協同組合
+///
+/// A：機能/性/食品
+/// B：機能性/食品
+/// C：機能性食品
+/// ```
+///
+/// See [Sudachi documentation](https://github.com/WorksApplications/Sudachi#the-modes-of-splitting)
+/// for more details
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Mode {
+    /// Short
     A,
+
+    /// Middle (similar to "word")
     B,
+
+    /// Named Entity
     C,
 }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,3 +1,6 @@
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::Path;
 use std::str::FromStr;
 
 use crate::dic::grammar::Grammar;
@@ -83,6 +86,18 @@ impl<'a> Tokenizer<'a> {
         Ok(Tokenizer { grammar, lexicon })
     }
 }
+
+/// Return bytes of a `dictionary_path`
+pub fn dictionary_bytes_from_path<P: AsRef<Path>>(dictionary_path: P) -> SudachiResult<Vec<u8>> {
+    let dictionary_path = dictionary_path.as_ref();
+    let dictionary_stat = fs::metadata(&dictionary_path)?;
+    let mut dictionary_file = File::open(dictionary_path)?;
+    let mut dictionary_bytes = Vec::with_capacity(dictionary_stat.len() as usize);
+    dictionary_file.read_to_end(&mut dictionary_bytes)?;
+
+    Ok(dictionary_bytes)
+}
+
 impl<'a> Tokenize for Tokenizer<'a> {
     fn tokenize(
         &self,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -5,9 +5,14 @@ use crate::lattice::node::Node;
 use crate::lattice::Lattice;
 use crate::morpheme::Morpheme;
 
+/// Able to tokenize Japanese text
+pub trait Tokenize {
+    /// Break text into `Morpheme`s
+    fn tokenize(&self, input: &str, mode: Mode, enable_debug: bool) -> Vec<Morpheme>;
+}
+
 /// Tokenizes Japanese text
 pub struct Tokenizer<'a> {
-    _dictionary_bytes: &'a [u8],
     pub grammar: Grammar<'a>,
     pub lexicon: Lexicon<'a>,
 }
@@ -59,14 +64,11 @@ impl<'a> Tokenizer<'a> {
 
         let lexicon = Lexicon::new(dictionary_bytes, offset);
 
-        Tokenizer {
-            _dictionary_bytes: dictionary_bytes,
-            grammar,
-            lexicon,
-        }
+        Tokenizer { grammar, lexicon }
     }
-
-    pub fn tokenize(&self, input: &str, mode: Mode, enable_debug: bool) -> Vec<Morpheme> {
+}
+impl<'a> Tokenize for Tokenizer<'a> {
+    fn tokenize(&self, input: &str, mode: Mode, enable_debug: bool) -> Vec<Morpheme> {
         let input_bytes = input.as_bytes();
 
         // build_lattice

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -6,7 +6,7 @@ use crate::lattice::Lattice;
 use crate::morpheme::Morpheme;
 
 pub struct Tokenizer<'a> {
-    bytes: &'a [u8],
+    _bytes: &'a [u8],
     pub grammar: Grammar<'a>,
     pub lexicon: Lexicon<'a>,
 }
@@ -31,13 +31,13 @@ impl<'a> Tokenizer<'a> {
         let lexicon = Lexicon::new(bytes, offset);
 
         Tokenizer {
-            bytes,
+            _bytes: bytes,
             grammar,
             lexicon,
         }
     }
 
-    pub fn tokenize(&self, input: &String, mode: &Mode, enable_debug: bool) -> Vec<Morpheme> {
+    pub fn tokenize(&self, input: &str, mode: &Mode, enable_debug: bool) -> Vec<Morpheme> {
         let input_bytes = input.as_bytes();
 
         // build_lattice
@@ -95,7 +95,7 @@ impl<'a> Tokenizer<'a> {
                     _ => panic!(),
                 };
 
-                if (word_ids.len() == 0) | (word_ids.len() == 1) {
+                if word_ids.is_empty() | (word_ids.len() == 1) {
                     word_id_list.push(node_word_id);
                 } else {
                     for word_id in word_ids {
@@ -105,11 +105,9 @@ impl<'a> Tokenizer<'a> {
             }
         };
 
-        let morpheme_list = word_id_list
+        word_id_list
             .iter()
             .map(|word_id| Morpheme::new(*word_id, &self.grammar, &self.lexicon))
-            .collect::<Vec<_>>();
-
-        morpheme_list
+            .collect::<Vec<_>>()
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -55,6 +55,7 @@ pub enum Mode {
 }
 
 impl<'a> Tokenizer<'a> {
+    /// Create `Tokenizer` from the raw bytes of a Sudachi dictionary.
     pub fn from_dictionary_bytes(dictionary_bytes: &'a [u8]) -> SudachiResult<Tokenizer<'a>> {
         let (_rest, _header) = Header::new(&dictionary_bytes[..Header::STORAGE_SIZE])?;
         let mut offset = Header::STORAGE_SIZE;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -5,8 +5,9 @@ use crate::lattice::node::Node;
 use crate::lattice::Lattice;
 use crate::morpheme::Morpheme;
 
+/// Tokenizes Japanese text
 pub struct Tokenizer<'a> {
-    _bytes: &'a [u8],
+    _dictionary_bytes: &'a [u8],
     pub grammar: Grammar<'a>,
     pub lexicon: Lexicon<'a>,
 }
@@ -47,19 +48,19 @@ pub enum Mode {
 }
 
 impl<'a> Tokenizer<'a> {
-    pub fn new(bytes: &'a [u8]) -> Tokenizer<'a> {
+    pub fn from_dictionary_bytes(dictionary_bytes: &'a [u8]) -> Tokenizer<'a> {
         let mut offset = 0;
 
-        let _header = Header::new(bytes, offset);
+        let _header = Header::new(dictionary_bytes, offset);
         offset += Header::STORAGE_SIZE;
 
-        let grammar = Grammar::new(bytes, offset);
+        let grammar = Grammar::new(dictionary_bytes, offset);
         offset += grammar.storage_size;
 
-        let lexicon = Lexicon::new(bytes, offset);
+        let lexicon = Lexicon::new(dictionary_bytes, offset);
 
         Tokenizer {
-            _bytes: bytes,
+            _dictionary_bytes: dictionary_bytes,
             grammar,
             lexicon,
         }


### PR DESCRIPTION
Originally, the dictionary at `src/resources/system.dic` needed to exist to compile the crate.
With this change, you can get the same behavior by enabling the `bake_dictionary` feature, but it is not enabled by default.
This makes compiles faster and will 

I documented this in the English README. The Japanese README still needs some translations--my 日本語 skills are too basic :sweat_smile:.

Other changes:
- Code formatting
- `Mode` enum: add documentation and `Copy` trait derive

Please let me know your thoughts--I'm open to suggestions.
Thanks!