### PR TITLE
add MacOS to CI

### DIFF
--- a/.github/workflows/rust-noncached.yml
+++ b/.github/workflows/rust-noncached.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ] # add macOS-latest later
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
 
     runs-on: ${{ matrix.os }}
 
@@ -21,9 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Download dictionary
         run: bash fetch_dictionary.sh
-      - name: Build release
-        run: cargo build --verbose --all --release
-      - name: Build debug
-        run: cargo build --verbose --all
-      - name: Run tests
+      - name: Run tests (Debug)
+        run: cargo test --verbose
+      - name: Run tests (Release)
         run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ] # add macOS-latest later
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
 
     runs-on: ${{ matrix.os }}
 
@@ -33,9 +33,5 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Build release
-      run: cargo build --verbose --all --release
-    - name: Build debug
-      run: cargo build --verbose --all
-    - name: Run tests
+    - name: Run tests (Debug)
       run: cargo test --verbose


### PR DESCRIPTION
fixes #34

1. Do not perform simple compiles (they are not useful now, probably)
2. Add macOS to CI test matrix
3. Run also tests in release mode nightly