### PR TITLE
Fix __getitem__ of PyMorphemeList

### DIFF
--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -80,19 +80,19 @@ impl pyo3::sequence::PySequenceProtocol for PyMorphemeListWrapper {
     }
 
     fn __getitem__(&self, idx: isize) -> PyResult<PyMorpheme> {
+        // pyo3 automatically adds len when a negative idx is given
         let len = self.__len__() as isize;
-        if idx < -len || len <= idx {
+        if idx < 0 || len <= idx {
             return Err(PyErr::new::<exceptions::PyIndexError, _>(format!(
-                "index out of range: the len is {} but the index is {}",
+                "morphemelist index out of range: the len is {} but the index is {}",
                 self.__len__(),
                 idx
             )));
         }
-        let index = if idx < 0 { idx + len } else { idx } as usize;
 
         Ok(PyMorpheme {
             list: self.inner.clone(),
-            index,
+            index: idx as usize,
         })
     }
 }


### PR DESCRIPTION
fix #69.

pyo3 automatically adjusts negative indexing by increasing given index by `__len__`. (i.e. `idx + len(list)` is provided when `idx` is negative)
We still need to handle error.

ref: [pyo3 guide: note for `__getitem__`](https://pyo3.rs/v0.14.3/class/protocols.html#:~:text=Note%3A%20Negative%20integer%20indexes%20are%20handled%20as%20follows%3A%20if%20__len__()%20is%20defined%2C%20it%20is%20called%20and%20the%20sequence%20length%20is%20used%20to%20compute%20a%20positive%20index%2C%20which%20is%20passed%20to%20__getitem__().%20If%20__len__()%20is%20not%20defined%2C%20the%20index%20is%20passed%20as%20is%20to%20the%20function.)