### PR TITLE
Arrange python binding import path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ README*.html
 
 # python binding
 python/dist
+__pycache__/
 .env
 *.egg-info
 *.so

--- a/python/README.md
+++ b/python/README.md
@@ -14,7 +14,7 @@ This project is under development and specifications may change drastically.
 1. Install python module `setuptools` and `setuptools-rust`.
 2. Run `python3 setup.py develop`.
     - `develop` will create a debug build, while `install` will create a release build.
-3. Now you can import the module by `import sudachi.sudachi`.
+3. Now you can import the module by `import sudachi`.
 
 ref: [setuptools-rust](https://github.com/PyO3/setuptools-rust)
 
@@ -22,16 +22,16 @@ ref: [setuptools-rust](https://github.com/PyO3/setuptools-rust)
 # Example
 
 ```python
-import sudachi.sudachi as ss
+from sudachi import Dictionary, SplitMode
 
-dictionary = ss.Dictionary()
+dictionary = Dictionary()
 tokenizer = dictionary.create()
 morphemes = tokenizer.tokenize("国会議事堂前駅")
 print(morphemes[0].surface())  # '国会議事堂前駅'
 print(morphemes[0].reading_form())  # 'コッカイギジドウマエエキ'
 print(morphemes[0].part_of_speech())  # ['名詞', '固有名詞', '一般', '*', '*', '*']
 
-tokenizer = dictionary.create(ss.SplitMode.A)
+tokenizer = dictionary.create(SplitMode.A)
 morphemes = tokenizer.tokenize("国会議事堂前駅")
 print(list(map(str, morphemes)))  # ['国会', '議事', '堂', '前', '駅']
 ```

--- a/python/py_src/sudachi/__init__.py
+++ b/python/py_src/sudachi/__init__.py
@@ -1,0 +1,1 @@
+from .sudachi import *

--- a/python/py_src/sudachi/__init__.py
+++ b/python/py_src/sudachi/__init__.py
@@ -1,1 +1,8 @@
-from .sudachi import *
+from .sudachi import (
+    Dictionary,
+    Tokenizer,
+    SplitMode,
+    MorphemeList,
+    Morpheme,
+    WordInfo
+)


### PR DESCRIPTION
#56.

We can import the module with `import sudachi`, instead of `import sudachi.sudachi`.