### PR TITLE
implement analysis memory reuse via output parameters

### DIFF
--- a/python/py_src/sudachipy/sudachipy.pyi
+++ b/python/py_src/sudachipy/sudachipy.pyi
@@ -153,7 +153,7 @@ class Morpheme:
         """
         ...
 
-    def split(self, mode: SplitMode) -> MorphemeList:
+    def split(self, mode: SplitMode, out: Optional[MorphemeList] = None) -> MorphemeList:
         """
         Returns a list of morphemes splitting itself with given split mode.
         """
@@ -229,15 +229,17 @@ class SplitMode:
     B: ClassVar[SplitMode] = ...
     C: ClassVar[SplitMode] = ...
     @classmethod
-    def __init__(self) -> None: ...
+    def __init__(cls) -> None: ...
 
 
 class Tokenizer:
     SplitMode: ClassVar[sudachipy.SplitMode] = ...
     @classmethod
-    def __init__(self) -> None: ...
+    def __init__(cls) -> None: ...
 
-    def tokenize(self, text: str, mode: sudachipy.SplitMode = ...) -> MorphemeList:
+    def tokenize(self, text: str,
+                 mode: sudachipy.SplitMode = ...,
+                 out: Optional[MorphemeList] = None) -> MorphemeList:
         """
         Break text into morphemes.
 

--- a/python/src/pos_matcher.rs
+++ b/python/src/pos_matcher.rs
@@ -115,8 +115,8 @@ impl PyPosMatcher {
 
 #[pymethods]
 impl PyPosMatcher {
-    pub fn __call__(&self, m: &PyMorpheme) -> bool {
-        let pos_id = m.part_of_speech_id();
+    pub fn __call__<'py>(&'py self, py: Python<'py>, m: &'py PyMorpheme) -> bool {
+        let pos_id = m.part_of_speech_id(py);
         self.matcher.matches_id(pos_id)
     }
 

--- a/python/src/pretokenizer.rs
+++ b/python/src/pretokenizer.rs
@@ -62,7 +62,7 @@ impl PerThreadPreTokenizer {
             Some(ms) => ms.borrow_mut(py),
         };
         mlist
-            .internal_mut()
+            .internal_mut(py)
             .collect_results(&mut self.tokenizer)
             .unwrap();
         Ok(())
@@ -137,7 +137,7 @@ impl PyPretokenizer {
             None => {
                 let result = PyList::empty(py);
                 let py_ref = morphs.borrow(py);
-                let morphs = py_ref.internal();
+                let morphs = py_ref.internal(py);
                 for idx in 0..morphs.len() {
                     let node = morphs.get(idx);
                     let slice = PySlice::new(py, node.begin_c() as isize, node.end_c() as isize, 1);

--- a/python/src/tokenizer.rs
+++ b/python/src/tokenizer.rs
@@ -95,37 +95,48 @@ impl PyTokenizer {
     /// By default tokenizer's split mode is used.
     /// The logger provided is ignored.
     #[pyo3(
-        text_signature = "($self, text: str, mode: SplitMode = None, logger = None) -> sudachipy.MorphemeList"
+        text_signature = "($self, text: str, mode: SplitMode = None, logger = None, out = None) -> sudachipy.MorphemeList"
     )]
     #[args(text, mode = "None", logger = "None")]
     #[allow(unused_variables)]
-    fn tokenize(
-        &mut self,
-        text: &str,
+    fn tokenize<'py>(
+        &'py mut self,
+        py: Python<'py>,
+        text: &'py str,
         mode: Option<PySplitMode>,
         logger: Option<PyObject>,
-    ) -> PyResult<PyMorphemeListWrapper> {
+        out: Option<&'py PyCell<PyMorphemeListWrapper>>,
+    ) -> PyResult<&'py PyCell<PyMorphemeListWrapper>> {
         // keep default mode to restore later
         let default_mode = mode.map(|m| self.tokenizer.set_mode(m.into()));
 
         self.tokenizer.reset().push_str(text);
-        self.tokenizer.do_tokenize().map_err(|e| {
-            PyException::new_err(format!("Error while tokenization: {}", e.to_string()))
-        })?;
+        self.tokenizer
+            .do_tokenize()
+            .map_err(|e| PyException::new_err(format!("Tokenization error: {}", e.to_string())))?;
 
-        let mut morphemes = MorphemeList::empty(self.tokenizer.dict_clone());
+        let out_list = match out {
+            None => {
+                let morphemes = MorphemeList::empty(self.tokenizer.dict_clone());
+                let wrapper = PyMorphemeListWrapper::from(morphemes);
+                PyCell::new(py, wrapper)?
+            }
+            Some(list) => list,
+        };
+
+        let mut borrow = out_list.try_borrow_mut();
+        let morphemes = match borrow {
+            Ok(ref mut ms) => ms.internal_mut(),
+            Err(e) => return Err(PyException::new_err("out was used twice at the same time")),
+        };
 
         morphemes
             .collect_results(&mut self.tokenizer)
-            .map_err(|e| {
-                PyException::new_err(format!("Error while tokenization: {}", e.to_string()))
-            })?;
+            .map_err(|e| PyException::new_err(format!("Tokenization error: {}", e.to_string())))?;
 
         // restore default mode
         default_mode.map(|m| self.tokenizer.set_mode(m));
 
-        let wrapper = PyMorphemeListWrapper::from(morphemes);
-
-        Ok(wrapper)
+        Ok(out_list)
     }
 }

--- a/python/src/tokenizer.rs
+++ b/python/src/tokenizer.rs
@@ -126,7 +126,7 @@ impl PyTokenizer {
 
         let mut borrow = out_list.try_borrow_mut();
         let morphemes = match borrow {
-            Ok(ref mut ms) => ms.internal_mut(),
+            Ok(ref mut ms) => ms.internal_mut(py),
             Err(e) => return Err(PyException::new_err("out was used twice at the same time")),
         };
 

--- a/python/tests/test_morpheme.py
+++ b/python/tests/test_morpheme.py
@@ -132,6 +132,22 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(m[1].begin(), 2)
         self.assertEqual(len(m[0]), 2)
 
+    def test_morpheme_split_out(self):
+        ms = self.tokenizer_obj.tokenize('東京都', SplitMode.C)
+        self.assertEqual(1, ms.size())
+        self.assertEqual(ms[0].surface(), '東京都')
+
+        ms_a = ms[0].split(SplitMode.A, out=None)
+        self.assertEqual(2, ms_a.size())
+        self.assertEqual(ms_a[0].surface(), '東京')
+        self.assertEqual(ms_a[1].surface(), '都')
+
+        ms = self.tokenizer_obj.tokenize("京都東京都京都", SplitMode.C)
+        ms_b = ms[1].split(SplitMode.A, out=ms_a)
+        self.assertEqual(id(ms_a), id(ms_b))
+        self.assertEqual(ms_a[0].surface(), '東京')
+        self.assertEqual(ms_a[1].surface(), '都')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/test_tokenizer.py
+++ b/python/tests/test_tokenizer.py
@@ -130,6 +130,15 @@ class TestTokenizer(unittest.TestCase):
         ms2 = tok.tokenize('東京都')
         self.assertEqual(ms1[0].part_of_speech_id(), ms2[0].part_of_speech_id())
 
+    def test_tokenizer_out_param(self):
+        ms1 = self.tokenizer_obj.tokenize('東京都東京府')
+        m = ms1[0]
+        self.assertEqual(m.surface(), '東京都')
+
+        ms2 = self.tokenizer_obj.tokenize('すだち', out=ms1)
+        self.assertEqual(id(ms1), id(ms2))
+        self.assertEqual(m.surface(), 'すだち')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/sudachi-cli/src/output.rs
+++ b/sudachi-cli/src/output.rs
@@ -109,7 +109,7 @@ fn write_morpheme_basic<T: DictionaryAccess>(
 ) -> SudachiResult<()> {
     writer.write_all(morpheme.surface().as_bytes())?;
     writer.write_all(b"\t")?;
-    let all_pos = morpheme.part_of_speech()?;
+    let all_pos = morpheme.part_of_speech();
     for (idx, pos) in all_pos.iter().enumerate() {
         writer.write_all(pos.as_bytes())?;
         if idx + 1 != all_pos.len() {

--- a/sudachi/src/analysis/mlist.rs
+++ b/sudachi/src/analysis/mlist.rs
@@ -25,7 +25,7 @@ use crate::input_text::InputBuffer;
 use std::cell::{Ref, RefCell};
 use std::iter::FusedIterator;
 use std::ops::{Deref, DerefMut, Index};
-use std::sync::Arc;
+use std::rc::Rc;
 
 struct InputPart {
     input: InputBuffer,
@@ -56,7 +56,7 @@ impl Nodes {
 
 pub struct MorphemeList<T> {
     dict: T,
-    input: Arc<RefCell<InputPart>>,
+    input: Rc<RefCell<InputPart>>,
     nodes: Nodes,
 }
 
@@ -66,7 +66,7 @@ impl<T: DictionaryAccess> MorphemeList<T> {
         let input = Default::default();
         Self {
             dict,
-            input: Arc::new(RefCell::new(input)),
+            input: Rc::new(RefCell::new(input)),
             nodes: Default::default(),
         }
     }
@@ -81,7 +81,7 @@ impl<T: DictionaryAccess> MorphemeList<T> {
         let input = InputPart { input, subset };
         Self {
             dict,
-            input: Arc::new(RefCell::new(input)),
+            input: Rc::new(RefCell::new(input)),
             nodes: Nodes { data: path },
         }
     }

--- a/sudachi/src/analysis/mlist.rs
+++ b/sudachi/src/analysis/mlist.rs
@@ -1,0 +1,252 @@
+/*
+ *  Copyright (c) 2021 Works Applications Co., Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+use crate::analysis::morpheme::Morpheme;
+use crate::analysis::node::{PathCost, ResultNode};
+use crate::analysis::stateful_tokenizer::StatefulTokenizer;
+use crate::analysis::stateless_tokenizer::DictionaryAccess;
+use crate::analysis::Mode;
+use crate::dic::subset::InfoSubset;
+use crate::error::{SudachiError, SudachiResult};
+use crate::input_text::InputBuffer;
+use std::cell::{Ref, RefCell};
+use std::iter::FusedIterator;
+use std::ops::{Deref, DerefMut, Index};
+use std::sync::Arc;
+
+struct InputPart {
+    input: InputBuffer,
+    subset: InfoSubset,
+}
+
+impl Default for InputPart {
+    fn default() -> Self {
+        let mut input = InputBuffer::new();
+        input.start_build().unwrap();
+        Self {
+            input,
+            subset: Default::default(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct Nodes {
+    data: Vec<ResultNode>,
+}
+
+impl Nodes {
+    fn mut_data(&mut self) -> &mut Vec<ResultNode> {
+        &mut self.data
+    }
+}
+
+pub struct MorphemeList<T> {
+    dict: T,
+    input: Arc<RefCell<InputPart>>,
+    nodes: Nodes,
+}
+
+impl<T: DictionaryAccess> MorphemeList<T> {
+    /// Returns an empty morpheme list
+    pub fn empty(dict: T) -> Self {
+        let input = Default::default();
+        Self {
+            dict,
+            input: Arc::new(RefCell::new(input)),
+            nodes: Default::default(),
+        }
+    }
+
+    /// Creates MorphemeList from components
+    pub fn from_components(
+        dict: T,
+        input: InputBuffer,
+        path: Vec<ResultNode>,
+        subset: InfoSubset,
+    ) -> Self {
+        let input = InputPart { input, subset };
+        Self {
+            dict,
+            input: Arc::new(RefCell::new(input)),
+            nodes: Nodes { data: path },
+        }
+    }
+
+    pub fn collect_results<U: DictionaryAccess>(
+        &mut self,
+        analyzer: &mut StatefulTokenizer<U>,
+    ) -> SudachiResult<()> {
+        match self.input.try_borrow_mut() {
+            Ok(mut i) => {
+                let mref = i.deref_mut();
+                analyzer.swap_result(
+                    &mut mref.input,
+                    &mut self.nodes.mut_data(),
+                    &mut mref.subset,
+                );
+                Ok(())
+            }
+            Err(_) => Err(SudachiError::MorphemeListBorrowed),
+        }
+    }
+
+    /// Splits morphemes and writes them into the resulting list
+    /// The resulting list is _not_ cleared before that
+    /// Returns true if split produced more than two elements
+    pub fn split_into(&self, mode: Mode, index: usize, out: &mut Self) -> SudachiResult<bool> {
+        let node = self.node(index);
+        let num_splits = node.num_splits(mode);
+
+        if num_splits == 0 {
+            Ok(false)
+        } else {
+            out.assign_input(self);
+            let data = out.nodes.mut_data();
+            let input = self.input();
+            let subset = self.subset();
+            data.reserve(num_splits);
+            for n in node.split(mode, self.dict().lexicon(), subset, input.deref()) {
+                data.push(n);
+            }
+            Ok(true)
+        }
+    }
+
+    /// Clears morphemes from analysis result
+    pub fn clear(&mut self) {
+        self.nodes.mut_data().clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.nodes.data.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.nodes.data.is_empty()
+    }
+
+    pub fn get(&self, idx: usize) -> Morpheme<T> {
+        return Morpheme::for_list(self, idx);
+    }
+
+    pub fn surface(&self) -> Ref<str> {
+        let inp = self.input();
+        Ref::map(inp, |i| i.current())
+    }
+
+    pub fn iter(&self) -> MorphemeIter<T> {
+        MorphemeIter {
+            index: 0,
+            list: self,
+        }
+    }
+
+    /// Gets the whole cost of the path
+    pub fn get_internal_cost(&self) -> i32 {
+        let len = self.len();
+        if len == 0 {
+            return 0;
+        }
+
+        let first_node = self.node(0);
+        let last_node = self.node(len - 1);
+        last_node.total_cost() - first_node.total_cost()
+    }
+
+    pub(crate) fn node(&self, idx: usize) -> &ResultNode {
+        self.nodes.data.index(idx)
+    }
+
+    pub fn dict(&self) -> &T {
+        &self.dict
+    }
+
+    pub(crate) fn input(&self) -> Ref<InputBuffer> {
+        Ref::map(self.input.deref().borrow(), |x| &x.input)
+    }
+
+    /// Makes this point to the input of another MorphemeList
+    pub(crate) fn assign_input(&mut self, other: &Self) {
+        if self.input.as_ptr() != other.input.as_ptr() {
+            self.input = other.input.clone();
+        }
+    }
+
+    pub fn subset(&self) -> InfoSubset {
+        self.input.deref().borrow().subset
+    }
+
+    pub fn copy_slice(&self, start: usize, end: usize, out: &mut Self) {
+        let out_data = out.nodes.mut_data();
+        out_data.extend_from_slice(&self.nodes.data[start..end]);
+    }
+}
+
+impl<T: DictionaryAccess + Clone> MorphemeList<T> {
+    pub fn empty_clone(&self) -> Self {
+        Self {
+            dict: self.dict.clone(),
+            input: self.input.clone(),
+            nodes: Default::default(),
+        }
+    }
+
+    /// Returns a new morpheme list splitting the morpheme with a given mode.
+    /// Returns an empty list if there was no splits
+    #[deprecated(note = "use split_into", since = "0.6.1")]
+    pub fn split(&self, mode: Mode, index: usize) -> SudachiResult<MorphemeList<T>> {
+        let mut list = self.empty_clone();
+        if !self.split_into(mode, index, &mut list)? {
+            list.nodes.mut_data().push(self.node(index).clone())
+        }
+        Ok(list)
+    }
+}
+
+/// Iterates over morpheme list
+pub struct MorphemeIter<'a, T> {
+    list: &'a MorphemeList<T>,
+    index: usize,
+}
+
+impl<'a, T: DictionaryAccess> Iterator for MorphemeIter<'a, T> {
+    type Item = Morpheme<'a, T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.list.len() {
+            return None;
+        }
+
+        let morpheme = Morpheme::for_list(self.list, self.index);
+
+        self.index += 1;
+        Some(morpheme)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let rem = self.list.len() - self.index;
+        (rem, Some(rem))
+    }
+}
+
+impl<'a, T: DictionaryAccess> FusedIterator for MorphemeIter<'a, T> {}
+
+impl<'a, T: DictionaryAccess> ExactSizeIterator for MorphemeIter<'a, T> {
+    fn len(&self) -> usize {
+        self.size_hint().0
+    }
+}

--- a/sudachi/src/analysis/mod.rs
+++ b/sudachi/src/analysis/mod.rs
@@ -17,12 +17,13 @@
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
-use morpheme::MorphemeList;
+use mlist::MorphemeList;
 
 use crate::error::SudachiResult;
 
 mod inner;
 pub mod lattice;
+pub mod mlist;
 pub mod morpheme;
 pub mod node;
 pub mod stateful_tokenizer;

--- a/sudachi/src/analysis/stateful_tokenizer.rs
+++ b/sudachi/src/analysis/stateful_tokenizer.rs
@@ -283,9 +283,12 @@ impl<D: DictionaryAccess> StatefulTokenizer<D> {
     pub fn into_morpheme_list(self) -> SudachiResult<MorphemeList<D>> {
         match self.top_path {
             None => Err(SudachiError::EosBosDisconnect),
-            Some(path) => {
-                MorphemeList::from_components(self.dictionary, self.input, path, self.subset)
-            }
+            Some(path) => Ok(MorphemeList::from_components(
+                self.dictionary,
+                self.input,
+                path,
+                self.subset,
+            )),
         }
     }
 }

--- a/sudachi/src/analysis/stateless_tokenizer.rs
+++ b/sudachi/src/analysis/stateless_tokenizer.rs
@@ -27,7 +27,7 @@ use crate::plugin::input_text::InputTextPlugin;
 use crate::plugin::oov::OovProviderPlugin;
 use crate::plugin::path_rewrite::PathRewritePlugin;
 
-use super::morpheme::MorphemeList;
+use super::mlist::MorphemeList;
 use super::{Mode, Tokenize};
 
 /// Provides access to dictionary data

--- a/sudachi/src/dic/build/test/with_analysis.rs
+++ b/sudachi/src/dic/build/test/with_analysis.rs
@@ -172,7 +172,7 @@ fn system_plus_user_2() {
     let result = tok.tokenize("かぼすにいく", Mode::C, false).unwrap();
     assert_eq!(result.len(), 3);
     assert_eq!(result.get(0).word_id().dic(), 2);
-    assert_eq!(result.get(0).part_of_speech().unwrap()[0], "被子植物門");
+    assert_eq!(result.get(0).part_of_speech()[0], "被子植物門");
 }
 
 #[test]
@@ -193,5 +193,5 @@ fn split_with_subset() {
     res.collect_results(&mut tok).unwrap();
     assert_eq!(res.len(), 2);
     //assert_eq!(res.get_end(0), 6);
-    assert_eq!(res.get_end(1), 9);
+    assert_eq!(res.get(1).end(), 9);
 }

--- a/sudachi/src/dic/grammar.rs
+++ b/sudachi/src/dic/grammar.rs
@@ -24,6 +24,7 @@ use nom::{
     bytes::complete::take,
     number::complete::{le_i16, le_u16},
 };
+use std::ops::Index;
 
 /// Dictionary grammar
 ///
@@ -115,6 +116,12 @@ impl<'a> Grammar<'a> {
             }
         }
         None
+    }
+
+    /// Gets POS components for POS ID.
+    /// Panics if out of bounds.
+    pub fn pos_components(&self, pos_id: u16) -> &[String] {
+        self.pos_list.index(pos_id as usize)
     }
 
     /// Merge a another grammar into this grammar

--- a/sudachi/src/error.rs
+++ b/sudachi/src/error.rs
@@ -110,6 +110,9 @@ pub enum SudachiError {
 
     #[error(transparent)]
     DictionaryCompilationError(#[from] DicBuildError),
+
+    #[error("MorphemeList is borrowed, make sure that all Ref<> are dropped")]
+    MorphemeListBorrowed,
 }
 
 pub type SudachiNomResult<I, O> = nom::IResult<I, O, SudachiNomError<I>>;

--- a/sudachi/src/lib.rs
+++ b/sudachi/src/lib.rs
@@ -40,9 +40,7 @@ pub mod test;
 
 pub mod prelude {
     pub use crate::{
-        analysis::morpheme::MorphemeList,
-        analysis::{Mode, Tokenize},
-        error::SudachiError,
-        error::SudachiResult,
+        analysis::mlist::MorphemeList, analysis::morpheme::Morpheme, analysis::Mode,
+        error::SudachiError, error::SudachiResult,
     };
 }

--- a/sudachi/tests/common/mod.rs
+++ b/sudachi/tests/common/mod.rs
@@ -31,6 +31,7 @@ use sudachi::dic::{grammar::Grammar, header::Header, lexicon::Lexicon, Dictionar
 use sudachi::prelude::*;
 
 use lazy_static::lazy_static;
+use sudachi::analysis::Tokenize;
 use sudachi::dic::build::DictBuilder;
 use sudachi::dic::storage::{Storage, SudachiDicData};
 

--- a/sudachi/tests/morpheme.rs
+++ b/sudachi/tests/morpheme.rs
@@ -17,8 +17,8 @@
 extern crate lazy_static;
 extern crate sudachi;
 
-use sudachi::analysis::morpheme::MorphemeList;
-use sudachi::prelude::Mode;
+use std::ops::Deref;
+use sudachi::prelude::*;
 
 mod common;
 use crate::common::TestTokenizer;
@@ -28,7 +28,7 @@ fn empty_morpheme_list() {
     let tok = TestTokenizer::new();
     let empty = MorphemeList::empty(tok.dict());
 
-    assert_eq!("", empty.surface());
+    assert_eq!("", empty.surface().deref());
     assert_eq!(0, empty.len());
 }
 
@@ -40,9 +40,9 @@ fn morpheme_attributes() {
 
     assert_eq!(0, ms[0].begin());
     assert_eq!(6, ms[0].end());
-    assert_eq!("京都", ms[0].surface());
+    assert_eq!("京都", ms[0].surface().deref());
 
-    let pos = ms[0].part_of_speech().expect("failed to get pos");
+    let pos = ms[0].part_of_speech();
     assert_eq!(["名詞", "固有名詞", "地名", "一般", "*", "*"], &pos[..]);
     assert_eq!(3, ms[0].part_of_speech_id());
 
@@ -62,15 +62,14 @@ fn split_morpheme() {
     let tok = TestTokenizer::new();
     let ms = tok.tokenize("京都東京都", Mode::C);
     assert_eq!(2, ms.len());
-    let ms: Vec<_> = ms.iter().collect();
-    assert_eq!("京都", ms[0].surface());
-    assert_eq!("東京都", ms[1].surface());
+    assert_eq!("京都", ms.get(0).surface().deref());
+    assert_eq!("東京都", ms.get(1).surface().deref());
 
-    let ms = ms[1].split(Mode::A).expect("failed to split morpheme");
+    #[allow(deprecated)]
+    let ms = ms.get(1).split(Mode::A).expect("failed to split morpheme");
     assert_eq!(2, ms.len());
-    let ms: Vec<_> = ms.iter().collect();
-    assert_eq!("東京", ms[0].surface());
-    assert_eq!(6, ms[0].begin()); // keep index for the whole input text
-    assert_eq!(12, ms[0].end());
-    assert_eq!("都", ms[1].surface());
+    assert_eq!("東京", ms.get(0).surface().deref());
+    assert_eq!(6, ms.get(0).begin()); // keep index for the whole input text
+    assert_eq!(12, ms.get(0).end());
+    assert_eq!("都", ms.get(1).surface().deref());
 }

--- a/sudachi/tests/morpheme.rs
+++ b/sudachi/tests/morpheme.rs
@@ -36,25 +36,26 @@ fn empty_morpheme_list() {
 fn morpheme_attributes() {
     let tok = TestTokenizer::new();
     let ms = tok.tokenize("京都", Mode::C);
-    let ms: Vec<_> = ms.iter().collect();
 
-    assert_eq!(0, ms[0].begin());
-    assert_eq!(6, ms[0].end());
-    assert_eq!("京都", ms[0].surface().deref());
+    assert_eq!(0, ms.get(0).begin());
+    assert_eq!(6, ms.get(0).end());
+    assert_eq!("京都", ms.get(0).surface().deref());
 
-    let pos = ms[0].part_of_speech();
-    assert_eq!(["名詞", "固有名詞", "地名", "一般", "*", "*"], &pos[..]);
-    assert_eq!(3, ms[0].part_of_speech_id());
+    assert_eq!(
+        ["名詞", "固有名詞", "地名", "一般", "*", "*"],
+        ms.get(0).part_of_speech()
+    );
+    assert_eq!(3, ms.get(0).part_of_speech_id());
 
-    assert_eq!("京都", ms[0].dictionary_form());
-    assert_eq!("京都", ms[0].normalized_form());
-    assert_eq!("キョウト", ms[0].reading_form());
+    assert_eq!("京都", ms.get(0).dictionary_form());
+    assert_eq!("京都", ms.get(0).normalized_form());
+    assert_eq!("キョウト", ms.get(0).reading_form());
 
-    assert_eq!(false, ms[0].is_oov());
+    assert_eq!(false, ms.get(0).is_oov());
 
-    assert_eq!(3, ms[0].word_id().word());
-    assert_eq!(0, ms[0].dictionary_id());
-    assert_eq!([1, 5], ms[0].synonym_group_ids());
+    assert_eq!(3, ms.get(0).word_id().word());
+    assert_eq!(0, ms.get(0).dictionary_id());
+    assert_eq!([1, 5], ms.get(0).synonym_group_ids());
 }
 
 #[test]

--- a/sudachi/tests/split.rs
+++ b/sudachi/tests/split.rs
@@ -15,6 +15,7 @@
  */
 
 use crate::common::TestStatefulTokenizer;
+use std::ops::Deref;
 use sudachi::prelude::Mode;
 
 mod common;
@@ -26,8 +27,8 @@ fn split_at_analysis_time() {
     let mut tok = TestStatefulTokenizer::builder(AB_DIC).mode(Mode::A).build();
     let res = tok.tokenize("ＡＢ");
     assert_eq!(res.len(), 2);
-    assert_eq!(res.get(0).surface(), "Ａ");
-    assert_eq!(res.get(1).surface(), "Ｂ");
+    assert_eq!(res.get(0).surface().deref(), "Ａ");
+    assert_eq!(res.get(1).surface().deref(), "Ｂ");
 }
 
 #[test]
@@ -35,7 +36,8 @@ fn split_after_analysis() {
     let mut tok = TestStatefulTokenizer::builder(AB_DIC).build();
     let res = tok.tokenize("ＡＢ");
     assert_eq!(res.len(), 1);
-    let res2 = res.get(0).split(Mode::A).unwrap();
-    assert_eq!(res2.get(0).surface(), "Ａ");
-    assert_eq!(res2.get(1).surface(), "Ｂ");
+    let mut res2 = res.empty_clone();
+    assert!(res.get(0).split_into(Mode::A, &mut res2).unwrap());
+    assert_eq!(res2.get(0).surface().deref(), "Ａ");
+    assert_eq!(res2.get(1).surface().deref(), "Ｂ");
 }

--- a/sudachi/tests/stateful_tokenizer.rs
+++ b/sudachi/tests/stateful_tokenizer.rs
@@ -58,19 +58,16 @@ fn get_word_id() {
 fn get_dictionary_id() {
     let mut tok = TestTokenizer::new_built(Mode::C);
     let ms = tok.tokenize("京都");
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    assert_eq!(0, ms[0].dictionary_id());
+    assert_eq!(0, ms.get(0).dictionary_id());
 
     let ms = tok.tokenize("ぴらる");
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    assert_eq!(1, ms[0].dictionary_id());
+    assert_eq!(1, ms.get(0).dictionary_id());
 
     let ms = tok.tokenize("京");
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    assert!(ms[0].dictionary_id() < 0);
+    assert!(ms.get(0).dictionary_id() < 0);
 }
 
 #[test]
@@ -130,7 +127,7 @@ fn split_middle() {
     let ms = tok.tokenize("京都東京都京都");
     assert_eq!(ms.len(), 3);
     let m = ms.get(1);
-    assert_eq!(m.surface().deref().deref(), "東京都");
+    assert_eq!(m.surface().deref(), "東京都");
 
     let mut ms_a = ms.empty_clone();
     assert!(m.split_into(Mode::A, &mut ms_a).expect("works"));

--- a/sudachi/tests/stateful_tokenizer.rs
+++ b/sudachi/tests/stateful_tokenizer.rs
@@ -17,7 +17,7 @@
 extern crate lazy_static;
 extern crate sudachi;
 
-use sudachi::analysis::node::LatticeNode;
+use std::ops::Deref;
 use sudachi::prelude::Mode;
 
 mod common;
@@ -43,14 +43,14 @@ fn get_word_id() {
     let ms = tok.tokenize("京都");
     assert_eq!(1, ms.len());
     let m0 = ms.get(0);
-    let pos = m0.part_of_speech().expect("failed to get pos");
+    let pos = m0.part_of_speech();
     assert_eq!(&["名詞", "固有名詞", "地名", "一般", "*", "*"], pos);
 
     // we do not have word_id field in Morpheme and skip testing.
     let ms = tok.tokenize("ぴらる");
     assert_eq!(1, ms.len());
     let m0 = ms.get(0);
-    let pos = m0.part_of_speech().expect("failed to get pos");
+    let pos = m0.part_of_speech();
     assert_eq!(&["名詞", "普通名詞", "一般", "*", "*", "*"], pos);
 }
 
@@ -102,11 +102,11 @@ fn tokenize_with_dots() {
     let mut tok = TestTokenizer::new_built(Mode::C);
     let ms = tok.tokenize("京都…");
     assert_eq!(4, ms.len());
-    assert_eq!("…", ms.get(1).surface());
+    assert_eq!("…", ms.get(1).surface().deref());
     assert_eq!(".", ms.get(1).normalized_form());
-    assert_eq!("", ms.get(2).surface());
+    assert_eq!("", ms.get(2).surface().deref());
     assert_eq!(".", ms.get(2).normalized_form());
-    assert_eq!("", ms.get(3).surface());
+    assert_eq!("", ms.get(3).surface().deref());
     assert_eq!(".", ms.get(3).normalized_form());
 }
 
@@ -115,13 +115,13 @@ fn tokenizer_morpheme_split() {
     let mut tok = TestTokenizer::new_built(Mode::C);
     let ms = tok.tokenize("東京都");
     assert_eq!(1, ms.len());
-    assert_eq!("東京都", ms.get(0).surface());
+    assert_eq!("東京都", ms.get(0).surface().deref());
 
     tok.set_mode(Mode::A);
     let ms = tok.tokenize("東京都");
     assert_eq!(2, ms.len());
-    assert_eq!("東京", ms.get(0).surface());
-    assert_eq!("都", ms.get(1).surface());
+    assert_eq!("東京", ms.get(0).surface().deref());
+    assert_eq!("都", ms.get(1).surface().deref());
 }
 
 #[test]
@@ -130,18 +130,19 @@ fn split_middle() {
     let ms = tok.tokenize("京都東京都京都");
     assert_eq!(ms.len(), 3);
     let m = ms.get(1);
-    assert_eq!(m.surface(), "東京都");
+    assert_eq!(m.surface().deref().deref(), "東京都");
 
-    let ms_a = m.split(Mode::A).expect("works");
+    let mut ms_a = ms.empty_clone();
+    assert!(m.split_into(Mode::A, &mut ms_a).expect("works"));
     assert_eq!(ms_a.len(), 2);
-    assert_eq!(ms_a.get(0).surface(), "東京");
-    assert_eq!(ms_a.get_node(0).begin(), 2);
-    assert_eq!(ms_a.get_node(0).end(), 4);
+    assert_eq!(ms_a.get(0).surface().deref(), "東京");
+    assert_eq!(ms_a.get(0).begin_c(), 2);
+    assert_eq!(ms_a.get(0).end_c(), 4);
     assert_eq!(ms_a.get(0).begin(), 6);
     assert_eq!(ms_a.get(0).end(), 12);
-    assert_eq!(ms_a.get(1).surface(), "都");
-    assert_eq!(ms_a.get_node(1).begin(), 4);
-    assert_eq!(ms_a.get_node(1).end(), 5);
+    assert_eq!(ms_a.get(1).surface().deref(), "都");
+    assert_eq!(ms_a.get(1).begin_c(), 4);
+    assert_eq!(ms_a.get(1).end_c(), 5);
     assert_eq!(ms_a.get(1).begin(), 12);
     assert_eq!(ms_a.get(1).end(), 15);
 }

--- a/sudachi/tests/stateless_tokenizer.rs
+++ b/sudachi/tests/stateless_tokenizer.rs
@@ -34,17 +34,19 @@ fn tokenize_small_katakana_only() {
 fn get_word_id() {
     let tok = TestTokenizer::new();
     let ms = tok.tokenize("京都", Mode::C);
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    let pos = ms[0].part_of_speech();
-    assert_eq!(["名詞", "固有名詞", "地名", "一般", "*", "*"], &pos[..]);
+    let m = ms.get(0);
+    let pos = m.part_of_speech();
+    assert_eq!(["名詞", "固有名詞", "地名", "一般", "*", "*"], pos);
 
     // we do not have word_id field in Morpheme and skip testing.
     let ms = tok.tokenize("ぴらる", Mode::C);
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    let pos = ms[0].part_of_speech();
-    assert_eq!(["名詞", "普通名詞", "一般", "*", "*", "*"], &pos[..]);
+    let m = ms.get(0);
+    assert_eq!(
+        ["名詞", "普通名詞", "一般", "*", "*", "*"],
+        m.part_of_speech()
+    );
 }
 
 #[test]
@@ -67,19 +69,16 @@ fn get_dictionary_id() {
 fn get_synonym_group_id() {
     let tok = TestTokenizer::new();
     let ms = tok.tokenize("京都", Mode::C);
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    assert_eq!([1, 5], ms[0].synonym_group_ids());
+    assert_eq!([1, 5], ms.get(0).synonym_group_ids());
 
     let ms = tok.tokenize("ぴらる", Mode::C);
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    assert!(ms[0].synonym_group_ids().is_empty());
+    assert!(ms.get(0).synonym_group_ids().is_empty());
 
     let ms = tok.tokenize("東京府", Mode::C);
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    assert_eq!([1, 3], ms[0].synonym_group_ids());
+    assert_eq!([1, 3], ms.get(0).synonym_group_ids());
 }
 
 #[test]
@@ -94,27 +93,24 @@ fn tokenize_kanji_alphabet_word() {
 fn tokenize_with_dots() {
     let tok = TestTokenizer::new();
     let ms = tok.tokenize("京都…", Mode::C);
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(4, ms.len());
-    assert_eq!("…", ms[1].surface().deref());
-    assert_eq!(".", ms[1].normalized_form());
-    assert_eq!("", ms[2].surface().deref());
-    assert_eq!(".", ms[2].normalized_form());
-    assert_eq!("", ms[3].surface().deref());
-    assert_eq!(".", ms[3].normalized_form());
+    assert_eq!("…", ms.get(1).surface().deref());
+    assert_eq!(".", ms.get(1).normalized_form());
+    assert_eq!("", ms.get(2).surface().deref());
+    assert_eq!(".", ms.get(2).normalized_form());
+    assert_eq!("", ms.get(3).surface().deref());
+    assert_eq!(".", ms.get(3).normalized_form());
 }
 
 #[test]
 fn tokenizer_morpheme_split() {
     let tok = TestTokenizer::new();
     let ms = tok.tokenize("東京都", Mode::C);
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    assert_eq!("東京都", ms[0].surface().deref());
+    assert_eq!("東京都", ms.get(0).surface().deref());
 
     let ms = tok.tokenize("東京都", Mode::A);
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(2, ms.len());
-    assert_eq!("東京", ms[0].surface().deref());
-    assert_eq!("都", ms[1].surface().deref());
+    assert_eq!("東京", ms.get(0).surface().deref());
+    assert_eq!("都", ms.get(1).surface().deref());
 }

--- a/sudachi/tests/stateless_tokenizer.rs
+++ b/sudachi/tests/stateless_tokenizer.rs
@@ -17,6 +17,7 @@
 extern crate lazy_static;
 extern crate sudachi;
 
+use std::ops::Deref;
 use sudachi::prelude::Mode;
 
 mod common;
@@ -35,14 +36,14 @@ fn get_word_id() {
     let ms = tok.tokenize("京都", Mode::C);
     let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    let pos = ms[0].part_of_speech().expect("failed to get pos");
+    let pos = ms[0].part_of_speech();
     assert_eq!(["名詞", "固有名詞", "地名", "一般", "*", "*"], &pos[..]);
 
     // we do not have word_id field in Morpheme and skip testing.
     let ms = tok.tokenize("ぴらる", Mode::C);
     let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    let pos = ms[0].part_of_speech().expect("failed to get pos");
+    let pos = ms[0].part_of_speech();
     assert_eq!(["名詞", "普通名詞", "一般", "*", "*", "*"], &pos[..]);
 }
 
@@ -50,19 +51,16 @@ fn get_word_id() {
 fn get_dictionary_id() {
     let tok = TestTokenizer::new();
     let ms = tok.tokenize("京都", Mode::C);
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    assert_eq!(0, ms[0].dictionary_id());
+    assert_eq!(0, ms.get(0).dictionary_id());
 
     let ms = tok.tokenize("ぴらる", Mode::C);
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    assert_eq!(1, ms[0].dictionary_id());
+    assert_eq!(1, ms.get(0).dictionary_id());
 
     let ms = tok.tokenize("京", Mode::C);
-    let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    assert!(ms[0].dictionary_id() < 0);
+    assert!(ms.get(0).dictionary_id() < 0);
 }
 
 #[test]
@@ -98,11 +96,11 @@ fn tokenize_with_dots() {
     let ms = tok.tokenize("京都…", Mode::C);
     let ms: Vec<_> = ms.iter().collect();
     assert_eq!(4, ms.len());
-    assert_eq!("…", ms[1].surface());
+    assert_eq!("…", ms[1].surface().deref());
     assert_eq!(".", ms[1].normalized_form());
-    assert_eq!("", ms[2].surface());
+    assert_eq!("", ms[2].surface().deref());
     assert_eq!(".", ms[2].normalized_form());
-    assert_eq!("", ms[3].surface());
+    assert_eq!("", ms[3].surface().deref());
     assert_eq!(".", ms[3].normalized_form());
 }
 
@@ -112,11 +110,11 @@ fn tokenizer_morpheme_split() {
     let ms = tok.tokenize("東京都", Mode::C);
     let ms: Vec<_> = ms.iter().collect();
     assert_eq!(1, ms.len());
-    assert_eq!("東京都", ms[0].surface());
+    assert_eq!("東京都", ms[0].surface().deref());
 
     let ms = tok.tokenize("東京都", Mode::A);
     let ms: Vec<_> = ms.iter().collect();
     assert_eq!(2, ms.len());
-    assert_eq!("東京", ms[0].surface());
-    assert_eq!("都", ms[1].surface());
+    assert_eq!("東京", ms[0].surface().deref());
+    assert_eq!("都", ms[1].surface().deref());
 }


### PR DESCRIPTION
Fixes #184 

Implement out parameters for `Tokenizer.tokenize()` and `Morpheme.split()` Python API.

For the memory sharing to be actually useful, I had to refactor internal MorphemeList to allow multiple references to input data, while having distinct list of morphemes. Let's welcome `Arc<RefCell<X>>` in our codebase.
Python `MorphemeListWrapper` has also changed. As a side effect there is no copy in custom pretokenizers (win). Need to document semantics of everything, but will do that as a documentation pass.