### PR TITLE
improve __str__ and __repr__

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `sudachipy.Tokenizer` will ignore the provided logger.
   - Ref: [#76]
 - `Morpheme.part_of_speech` method now returns Tuple of POS components instead of a list.
+- `Morpheme`/`MorphemeList` now have readable `__repr__` and `__str__`
+  - https://github.com/WorksApplications/sudachi.rs/pull/187
 
 ## [0.6.0] - 2021/10/11
 

--- a/python/src/pos_matcher.rs
+++ b/python/src/pos_matcher.rs
@@ -121,7 +121,7 @@ impl PyPosMatcher {
     }
 
     pub fn __str__(&self) -> String {
-        format!("PosMatcher<{} pos>", self.matcher.num_entries())
+        format!("<PosMatcher:{} pos>", self.matcher.num_entries())
     }
 
     pub fn __iter__(&self) -> PyPosIter {

--- a/python/tests/test_morpheme.py
+++ b/python/tests/test_morpheme.py
@@ -148,6 +148,16 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(ms_a[0].surface(), '東京')
         self.assertEqual(ms_a[1].surface(), '都')
 
+    def test_morpheme_str_repr(self):
+        ms = self.tokenizer_obj.tokenize('東京都', SplitMode.A)
+        self.assertEqual(2, ms.size())
+        self.assertEqual(str(ms), '東京 都')
+        self.assertEqual(repr(ms), '<MorphemeList[\n  <Morpheme(東京, 0:2, (0, 5))>,\n  <Morpheme(都, 2:3, (0, 9))>,\n]>')
+        self.assertEqual(str(ms[0]), '東京')
+        self.assertEqual(str(ms[1]), '都')
+        self.assertEqual(repr(ms[0]), '<Morpheme(東京, 0:2, (0, 5))>')
+        self.assertEqual(repr(ms[1]), '<Morpheme(都, 2:3, (0, 9))>')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Based on https://github.com/WorksApplications/SudachiPy/pull/166
Fixes #122 

Closes [#SudachiPy/166](https://github.com/WorksApplications/SudachiPy/pull/166)

There is a slight difference in the proposed format caused by WordId formatting, the implemented version uses `(dic_id, word_id)`

```
>>> d = sudachipy.Dictionary()
>>> tok = d.create(sudachipy.SplitMode.A)
>>> mrs = tok.tokenize("外国人参政権")
>>> mrs
<MorphemeList[
  <Morpheme(外国, 0:2, (0, 375175))>,
  <Morpheme(人, 2:3, (0, 284079))>,
  <Morpheme(参政, 3:5, (0, 331513))>,
  <Morpheme(権, 5:6, (0, 522170))>,
]>
>>> str(mrs)
'外国 人 参政 権'
>>> mrs[0]
<Morpheme(外国, 0:2, (0, 375175))>
>>> str(mrs[0])
'外国'
```

Remaining question:
Should strings be naked as they are now or should we put them into quotes? (`<Morpheme('外国', 0:2, (0, 375175))>`)