### PR TITLE
resolve paths in more smart fashion

### DIFF
--- a/python/py_src/sudachipy/resources/sudachi.json
+++ b/python/py_src/sudachipy/resources/sudachi.json
@@ -1,5 +1,5 @@
 {
-    "systemDict" : "",
+    "systemDict" : null,
     "characterDefinitionFile" : "char.def",
     "inputTextPlugin" : [
         { "class" : "com.worksap.nlp.sudachi.DefaultInputTextPlugin" },

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -18,7 +18,7 @@ use std::fmt::Write;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use pyo3::exceptions::{self, PyException, PyIndexError};
+use pyo3::exceptions::{PyException, PyIndexError};
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PyString, PyTuple, PyType};
 

--- a/python/tests/resources/sudachi.json
+++ b/python/tests/resources/sudachi.json
@@ -1,5 +1,5 @@
 {
-    "resourcePath" : "tests/resources/",
+    "path" : "tests/resources/",
     "systemDict" : "system.dic.test",
     "userDict" : [ "user.dic.test" ],
     "characterDefinitionFile" : "char.def",

--- a/python/tests/resources/test_config_template.json
+++ b/python/tests/resources/test_config_template.json
@@ -1,5 +1,5 @@
 {
-  "resourcePath" : "tests/resources/",
+  "path" : "tests/resources/",
   "systemDict" : "$system_dict",
   "userDict" : "$user_dict",
   "characterDefinitionFile" : "char.def",

--- a/python/tests/test_dictionary.py
+++ b/python/tests/test_dictionary.py
@@ -32,6 +32,11 @@ class TestDictionary(unittest.TestCase):
     def test_create(self):
         self.assertEqual(Tokenizer, type(self.dict_.create()))
 
+    def test_repr(self):
+        repr_str = repr(self.dict_)
+        self.assertTrue(repr_str.startswith("<SudachiDictionary(system="))
+        self.assertTrue(repr_str.endswith("user.dic.test])>"))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/sudachi/src/dic/character_category.rs
+++ b/sudachi/src/dic/character_category.rs
@@ -19,7 +19,7 @@ use std::fs;
 use std::io::{BufRead, BufReader};
 use std::iter::FusedIterator;
 use std::ops::Range;
-use std::path::PathBuf;
+use std::path::Path;
 
 use thiserror::Error;
 
@@ -80,7 +80,7 @@ impl Default for CharacterCategory {
 
 impl CharacterCategory {
     /// Creates a character category from file
-    pub fn from_file(path: &PathBuf) -> SudachiResult<CharacterCategory> {
+    pub fn from_file(path: &Path) -> SudachiResult<CharacterCategory> {
         let reader = BufReader::new(fs::File::open(path)?);
         Self::from_reader(reader)
     }
@@ -307,6 +307,7 @@ impl FusedIterator for CharCategoryIter<'_> {}
 mod tests {
     use super::*;
     use claim::assert_matches;
+    use std::path::PathBuf;
 
     const TEST_RESOURCE_DIR: &str = "./tests/resources/";
     const TEST_CHAR_DEF_FILE: &str = "char.def";

--- a/sudachi/src/dic/mod.rs
+++ b/sudachi/src/dic/mod.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::analysis::stateless_tokenizer::DictionaryAccess;
 use character_category::CharacterCategory;
@@ -54,7 +54,7 @@ impl<'a> LoadedDictionary<'a> {
     /// Creates a system dictionary from bytes, and load a character category from file
     pub fn from_system_dictionary(
         dictionary_bytes: &'a [u8],
-        character_category_file: &PathBuf,
+        character_category_file: &Path,
     ) -> SudachiResult<LoadedDictionary<'a>> {
         let system_dict = DictionaryLoader::read_system_dictionary(dictionary_bytes)?;
 

--- a/sudachi/src/plugin/input_text/default_input_text/mod.rs
+++ b/sudachi/src/plugin/input_text/default_input_text/mod.rs
@@ -259,7 +259,7 @@ impl InputTextPlugin for DefaultInputTextPlugin {
             settings
                 .rewriteDef
                 .unwrap_or(PathBuf::from(DEFAULT_REWRITE_DEF_FILE)),
-        );
+        )?;
 
         let reader = BufReader::new(fs::File::open(&rewrite_file_path)?);
         self.read_rewrite_lists(reader)?;

--- a/sudachi/src/plugin/loader.rs
+++ b/sudachi/src/plugin/loader.rs
@@ -134,10 +134,10 @@ impl<'a, T: PluginCategory + ?Sized> PluginLoader<'a, T> {
     }
 
     fn resolve_dso_names(&self, name: &str) -> Vec<String> {
-        let mut resolved = self.cfg.resolve_plugin_paths(name.to_owned());
+        let mut resolved = self.cfg.resolve_paths(name.to_owned());
 
         if let Some(sysname) = system_specific_name(name) {
-            let resolved_sys = self.cfg.resolve_plugin_paths(sysname);
+            let resolved_sys = self.cfg.resolve_paths(sysname);
             resolved.extend(resolved_sys);
         }
 

--- a/sudachi/src/plugin/oov/mecab_oov/mod.rs
+++ b/sudachi/src/plugin/oov/mecab_oov/mod.rs
@@ -250,7 +250,7 @@ impl OovProviderPlugin for MeCabOovPlugin {
             settings
                 .charDef
                 .unwrap_or_else(|| PathBuf::from(DEFAULT_CHAR_DEF_FILE)),
-        );
+        )?;
         let reader = BufReader::new(fs::File::open(&char_def_path)?);
         let categories = MeCabOovPlugin::read_character_property(reader)?;
 
@@ -258,7 +258,7 @@ impl OovProviderPlugin for MeCabOovPlugin {
             settings
                 .unkDef
                 .unwrap_or_else(|| PathBuf::from(DEFAULT_UNK_DEF_FILE)),
-        );
+        )?;
         let reader = BufReader::new(fs::File::open(&unk_def_path)?);
         let oov_list = MeCabOovPlugin::read_oov(reader, &categories, grammar)?;
 

--- a/sudachi/tests/common/mod.rs
+++ b/sudachi/tests/common/mod.rs
@@ -45,8 +45,6 @@ pub fn dictionary_bytes_from_path<P: AsRef<Path>>(dictionary_path: P) -> Sudachi
     Ok(dictionary_bytes)
 }
 
-pub const LEX_CSV: &[u8] = include_bytes!("../resources/lex.csv");
-
 lazy_static! {
     pub static ref TEST_CONFIG: Config = {
         let test_config_path = "tests/resources/sudachi.json";
@@ -57,16 +55,19 @@ lazy_static! {
     };
     static ref DICTIONARY_BYTES: Vec<u8> = {
         let dictionary_path = TEST_CONFIG
-            .system_dict
-            .clone()
-            .expect("No system dictionary set in config");
+            .resolved_system_dict()
+            .expect("system dict failure");
+
         let dictionary_bytes = dictionary_bytes_from_path(dictionary_path)
             .expect("Failed to read dictionary from path");
         dictionary_bytes
     };
     static ref USER_DICTIONARY_BYTES: Vec<Box<[u8]>> = {
         let mut bytes = Vec::with_capacity(TEST_CONFIG.user_dicts.len());
-        for pb in &TEST_CONFIG.user_dicts {
+        for pb in TEST_CONFIG
+            .resolved_user_dicts()
+            .expect("user dicts failure")
+        {
             let storage_buf = dictionary_bytes_from_path(pb)
                 .expect("Failed to get user dictionary bytes from file");
             bytes.push(storage_buf.into_boxed_slice());

--- a/sudachi/tests/resources/sudachi.json
+++ b/sudachi/tests/resources/sudachi.json
@@ -1,5 +1,5 @@
 {
-    "resourcePath" : "tests/resources/",
+    "path" : "tests/resources/",
     "systemDict" : "system.dic.test",
     "userDict" : [ "user.dic.test" ],
     "characterDefinitionFile" : "char.def",

--- a/sudachi/tests/resources/sudachi.oov.json
+++ b/sudachi/tests/resources/sudachi.oov.json
@@ -1,5 +1,5 @@
 {
-    "resourcePath" : "tests/resources/",
+    "path" : "tests/resources/",
     "systemDict" : "system.dic.test",
     "userDict" : [ "user.dic.test" ],
     "characterDefinitionFile" : "char.def",

--- a/sudachi/tests/stateful_tokenizer.rs
+++ b/sudachi/tests/stateful_tokenizer.rs
@@ -21,7 +21,7 @@ use std::ops::Deref;
 use sudachi::prelude::Mode;
 
 mod common;
-use crate::common::{TestStatefulTokenizer as TestTokenizer, LEX_CSV};
+use crate::common::TestStatefulTokenizer as TestTokenizer;
 
 #[test]
 fn empty() {
@@ -145,6 +145,7 @@ fn split_middle() {
 }
 
 const OOV_CFG: &[u8] = include_bytes!("resources/sudachi.oov.json");
+const LEX_CSV: &[u8] = include_bytes!("resources/lex.csv");
 
 #[test]
 fn istanbul_is_not_splitted() {


### PR DESCRIPTION
Fixes https://github.com/WorksApplications/SudachiPy/issues/172

Sudachi.rs now resolves paths of resources in the following order:
1. Absolute paths stay as they are
2. Relative to "path" value of the config file
3. Relative to "resource_dir" parameter of the config object during creation
4. Relative to the location of the configuration file
5. Relative to the current directory


Also adds `__repr__` to Python Dictionary object which tells which exactly dictionary files are being used.