### PR TITLE
Unify three arrays in Lattice for locality of reference

### DIFF
--- a/sudachi/src/analysis/lattice.rs
+++ b/sudachi/src/analysis/lattice.rs
@@ -89,8 +89,7 @@ impl PackedNode {
 }
 
 /// Lattice which is constructed for performing the Viterbi search.
-/// Contain several parallel arrays.
-/// First level of parallel arrays is indexed by end word boundary.
+/// First level of an array is indexed by end word boundary.
 /// Word boundaries are always aligned to codepoint boundaries, not to byte boundaries.
 ///
 /// During the successive analysis, we do not drop inner vectors, so

--- a/sudachi/src/analysis/lattice.rs
+++ b/sudachi/src/analysis/lattice.rs
@@ -79,9 +79,10 @@ impl PackedNode {
 
     #[inline]
     fn from_vnode(vnode: VNode) -> Self {
+        // node and node_idx are dummy.
         Self {
             vnode,
-            node: Node::new(0, 0, 0, 0, 0, WordId::INVALID),
+            node: Node::new(u16::MAX, u16::MAX, 0, 0, 0, WordId::INVALID),
             node_idx: NodeIdx::empty(),
         }
     }


### PR DESCRIPTION
This PR suggests to unify three arrays `ends`, `ends_full`, and `indices` in `Lattice` for locality of reference.

In this modification, I added a new struct `PackedNode` packing three structs `VNode`, `Node`, and `NodeIdx`, and implemented the three arrays as one array of `PackedNode`.

The three arrays are often accessed simultaneously with the same index value, and the modification can improve cache efficiency in tokenization.

My microbenchmark results (with Intel i7, 16G RAM) showed that the modification shortened a tokenization time by 10%.
(My microbenchmark code can be found [here](https://github.com/kampersanda/sudachi.rs/tree/timeperf)).
