### PR TITLE
Let ubuild subcommand require system-dict argument

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -309,18 +309,20 @@ You can build a user dictionary with the subcommand `ubuild`.
 
 ```bash
 $ sudachipy ubuild -h
-usage: sudachipy ubuild [-h] [-d string] [-o file] [-s file] file [file ...]
+usage: sudachipy ubuild [-h] [-o file] [-d string] -s file file [file ...]
 
 Build User Dictionary
 
 positional arguments:
   file        source files with CSV format (one or more)
 
-optional arguments:
+options:
   -h, --help  show this help message and exit
-  -d string   description comment to be embedded on dictionary
   -o file     output file (default: user.dic)
-  -s file     system dictionary path (default: system core dictionary path)
+  -d string   description comment to be embedded on dictionary
+
+required named arguments:
+  -s file     system dictionary path
 ```
 
 About the dictionary file format, please refer to [this document](https://github.com/WorksApplications/Sudachi/blob/develop/docs/user_dict.md) (written in Japanese, English version is not available yet).

--- a/python/py_src/sudachipy/command_line.py
+++ b/python/py_src/sudachipy/command_line.py
@@ -251,12 +251,14 @@ def main():
     # build user-dictionary parser
     parser_ubd = subparsers.add_parser(
         'ubuild', help='see `ubuild -h`', description='Build User Dictionary')
-    parser_ubd.add_argument('-d', dest='description', default='', metavar='string', required=False,
-                            help='description comment to be embedded on dictionary')
     parser_ubd.add_argument('-o', dest='out_file', metavar='file', default='user.dic',
                             help='output file (default: user.dic)')
-    parser_ubd.add_argument('-s', dest='system_dic', metavar='file', required=False,
-                            help='system dictionary path (default: system core dictionary path)')
+    parser_ubd.add_argument('-d', dest='description', default='', metavar='string', required=False,
+                            help='description comment to be embedded on dictionary')
+    required_named_ubd = parser_ubd.add_argument_group(
+        'required named arguments')
+    required_named_ubd.add_argument('-s', dest='system_dic', metavar='file', required=True,
+                            help='system dictionary path')
     parser_ubd.add_argument("in_files", metavar="file", nargs=argparse.ONE_OR_MORE,
                             help='source files with CSV format (one or more)')
     parser_ubd.set_defaults(handler=_command_user_build,


### PR DESCRIPTION
fix #206 , #226 

- Change `-s` argument of `ubuild` subcommand to required.
- Arrange the help text following that of `build`.

The contents of #226 is not visible now (I should have copied the text from slack...), but I think current readme and help text explains the basic usage.