### PR TITLE
Allow string literals as segmentation modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ README*.html
 python/dist/
 __pycache__/
 .env
+.venv
 *.egg-info
 *.so
 python/py_src/sudachipy/*.pyd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,6 +932,7 @@ name = "sudachipy"
 version = "0.6.9-a1"
 dependencies = [
  "pyo3",
+ "scopeguard",
  "sudachi",
  "thread_local",
 ]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.20", features = ["extension-module"] }
 thread_local = "1.1" # Apache 2.0/MIT
+scopeguard = "1" # Apache 2.0/MIT
 
 [dependencies.sudachi]
 path = "../sudachi"

--- a/python/py_src/sudachipy/sudachipy.pyi
+++ b/python/py_src/sudachipy/sudachipy.pyi
@@ -1,5 +1,5 @@
 from typing import ClassVar, Iterator, List, Tuple, Union, Callable, Iterable, Optional, Literal, Set
-from sudachipy.config import Config
+from .config import Config
 
 POS = Tuple[str, str, str, str, str, str]
 # POS element
@@ -32,7 +32,12 @@ class SplitMode:
     B: ClassVar[SplitMode] = ...
     C: ClassVar[SplitMode] = ...
     @classmethod
-    def __init__(cls) -> None: ...
+    def __init__(cls, mode: str = "C") -> None:
+        """
+        Creates a split mode from a string value
+        :param mode: string representation of the split mode
+        """
+        ...
 
 
 class Dictionary:
@@ -65,7 +70,7 @@ class Dictionary:
         ...
 
     def create(self,
-               mode: SplitMode = SplitMode.C,
+               mode: Union[SplitMode, Literal["A"], Literal["B"], Literal["C"]] = SplitMode.C,
                fields: FieldSet = None,
                *,
                projection: str = None) -> Tokenizer:
@@ -191,7 +196,7 @@ class Morpheme:
         """
         ...
 
-    def split(self, mode: SplitMode, out: Optional[MorphemeList] = None, add_single: bool = True) -> MorphemeList:
+    def split(self, mode: Union[SplitMode, Literal["A", "B", "C"]], out: Optional[MorphemeList] = None, add_single: bool = True) -> MorphemeList:
         """
         Returns sub-morphemes in the provided split mode.
 
@@ -278,7 +283,7 @@ class Tokenizer:
     def __init__(cls) -> None: ...
 
     def tokenize(self, text: str,
-                 mode: SplitMode = ...,
+                 mode: Union[SplitMode, Literal["A", "B", "C"]] = ...,
                  out: Optional[MorphemeList] = None) -> MorphemeList:
         """
         Break text into morphemes.
@@ -292,6 +297,14 @@ class Tokenizer:
             If you need multi-level splitting, prefer using :py:meth:`Morpheme.split` method instead.
         :param out: tokenization results will be written into this MorphemeList, a new one will be created instead.
             See https://worksapplications.github.io/sudachi.rs/python/topics/out_param.html for details.
+        """
+        ...
+
+    @property
+    def mode(self) -> SplitMode:
+        """
+        Get the current analysis mode
+        :return: current analysis mode
         """
         ...
 

--- a/python/py_src/sudachipy/sudachipy.pyi
+++ b/python/py_src/sudachipy/sudachipy.pyi
@@ -70,7 +70,7 @@ class Dictionary:
         ...
 
     def create(self,
-               mode: Union[SplitMode, Literal["A"], Literal["B"], Literal["C"]] = SplitMode.C,
+               mode: Union[SplitMode, Literal["A", "B", "C"]] = SplitMode.C,
                fields: FieldSet = None,
                *,
                projection: str = None) -> Tokenizer:
@@ -101,7 +101,7 @@ class Dictionary:
         ...
 
     def pre_tokenizer(self,
-                      mode: SplitMode = SplitMode.C,
+                      mode: Union[SplitMode, Literal["A", "B", "C"]] = "C",
                       fields: FieldSet = None,
                       handler: Optional[Callable[[int, object, MorphemeList], list]] = None,
                       *,

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -289,12 +289,15 @@ impl PyDictionary {
     fn pre_tokenizer<'p>(
         &'p self,
         py: Python<'p>,
-        mode: Option<PySplitMode>,
+        mode: Option<&PyAny>,
         fields: Option<&PySet>,
         handler: Option<Py<PyAny>>,
         projection: Option<&PyString>,
     ) -> PyResult<&'p PyAny> {
-        let mode = mode.unwrap_or(PySplitMode::C).into();
+        let mode = match mode {
+            Some(m) => extract_mode(py, m)?,
+            None => Mode::C,
+        };
         let subset = parse_field_subset(fields)?;
         if let Some(h) = handler.as_ref() {
             if !h.as_ref(py).is_callable() {

--- a/python/src/tokenizer.rs
+++ b/python/src/tokenizer.rs
@@ -26,8 +26,8 @@ use sudachi::dic::subset::InfoSubset;
 use sudachi::prelude::*;
 
 use crate::dictionary::{extract_mode, PyDicData};
+use crate::errors::SudachiError as SudachiPyErr;
 use crate::morpheme::{PyMorphemeListWrapper, PyProjector};
-use crate::errors::{SudachiError as SudachiPyErr};
 
 /// Unit to split text
 ///
@@ -72,16 +72,15 @@ impl PySplitMode {
     fn new(mode: Option<&str>) -> PyResult<PySplitMode> {
         let mode = match mode {
             Some(m) => m,
-            None => return Ok(PySplitMode::C)
+            None => return Ok(PySplitMode::C),
         };
 
         match Mode::from_str(mode) {
             Ok(m) => Ok(m.into()),
-            Err(e) => Err(SudachiPyErr::new_err(e.to_string()))
+            Err(e) => Err(SudachiPyErr::new_err(e.to_string())),
         }
     }
 }
-
 
 /// Sudachi Tokenizer, Python version
 #[pyclass(module = "sudachipy.tokenizer", name = "Tokenizer")]
@@ -141,11 +140,10 @@ impl PyTokenizer {
         logger: Option<PyObject>,
         out: Option<&'py PyCell<PyMorphemeListWrapper>>,
     ) -> PyResult<&'py PyCell<PyMorphemeListWrapper>> {
-
         // restore default mode on scope exit
         let mode = match mode {
             None => None,
-            Some(m) => Some(extract_mode(py, m)?)
+            Some(m) => Some(extract_mode(py, m)?),
         };
         let default_mode = mode.map(|m| self.tokenizer.set_mode(m.into()));
         let mut tokenizer = scopeguard::guard(&mut self.tokenizer, |t| {

--- a/python/src/tokenizer.rs
+++ b/python/src/tokenizer.rs
@@ -150,13 +150,11 @@ impl PyTokenizer {
             default_mode.map(|m| t.set_mode(m));
         });
 
-        // this needs to be in GIL as it references Python memory
-        tokenizer.reset().push_str(text);
         // analysis can be done without GIL
-        let err = {
-            let tokenizer = tokenizer.deref_mut();
-            py.allow_threads(|| tokenizer.do_tokenize())
-        };
+        let err = py.allow_threads(|| {
+            tokenizer.reset().push_str(text);
+            tokenizer.do_tokenize()
+        });
 
         err.map_err(|e| SudachiPyErr::new_err(format!("Tokenization error: {}", e.to_string())))?;
 

--- a/python/tests/test_pretokenizers.py
+++ b/python/tests/test_pretokenizers.py
@@ -58,6 +58,21 @@ class PretokenizerTestCase(unittest.TestCase):
         res = tok.encode("外国人参政権")
         self.assertEqual(res.ids, [1, 5, 2, 3])
 
+    def test_works_with_different_split_mode_str(self):
+        pretok = self.dict.pre_tokenizer(mode='A')
+        vocab = {
+            "[UNK]": 0,
+            "外国": 1,
+            "参政": 2,
+            "権": 3,
+            "人": 5,
+            "外国人参政権": 4
+        }
+        tok = tokenizers.Tokenizer(WordLevel(vocab, unk_token="[UNK]"))
+        tok.pre_tokenizer = pretok
+        res = tok.encode("外国人参政権")
+        self.assertEqual(res.ids, [1, 5, 2, 3])
+
     def test_with_handler(self):
         def _handler(index, sentence: tokenizers.NormalizedString, ml: MorphemeList):
             return [tokenizers.NormalizedString(ml[0].part_of_speech()[0]), tokenizers.NormalizedString(str(len(ml)))]

--- a/python/tests/test_tokenizer.py
+++ b/python/tests/test_tokenizer.py
@@ -27,8 +27,25 @@ class TestTokenizer(unittest.TestCase):
             resource_dir, 'sudachi.json'), resource_dir)
         self.tokenizer_obj = self.dict_.create()
 
-    def test_nothing(self):
-        pass
+    def test_split_mode_default(self):
+        mode_c = SplitMode()
+        self.assertEqual(mode_c, SplitMode.C)
+
+    def test_split_mode_from_string_a(self):
+        mode = SplitMode("A")
+        self.assertEqual(mode, SplitMode.A)
+
+    def test_split_mode_from_string_b(self):
+        mode = SplitMode("B")
+        self.assertEqual(mode, SplitMode.B)
+
+    def test_split_mode_from_string_c(self):
+        mode = SplitMode("C")
+        self.assertEqual(mode, SplitMode.C)
+
+    def test_tokenizer_with_split_mode_str(self):
+        tok_a = self.dict_.create("A")
+        self.assertEqual(tok_a.mode, SplitMode.A)
 
     def test_tokenize_small_katanana_only(self):
         ms = self.tokenizer_obj.tokenize('ァ')
@@ -106,6 +123,16 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(ms[0].surface(), '東京都')
 
         ms_a = ms[0].split(SplitMode.A)
+        self.assertEqual(2, ms_a.size())
+        self.assertEqual(ms_a[0].surface(), '東京')
+        self.assertEqual(ms_a[1].surface(), '都')
+
+    def test_tokenizer_morpheme_split_strings(self):
+        ms = self.tokenizer_obj.tokenize('東京都', 'C')
+        self.assertEqual(1, ms.size())
+        self.assertEqual(ms[0].surface(), '東京都')
+
+        ms_a = ms[0].split('A')
         self.assertEqual(2, ms_a.size())
         self.assertEqual(ms_a[0].surface(), '東京')
         self.assertEqual(ms_a[1].surface(), '都')

--- a/sudachi/src/analysis/stateful_tokenizer.rs
+++ b/sudachi/src/analysis/stateful_tokenizer.rs
@@ -86,6 +86,11 @@ impl<D: DictionaryAccess> StatefulTokenizer<D> {
         std::mem::replace(&mut self.mode, mode)
     }
 
+    /// Return current analysis mode
+    pub fn mode(&self) -> Mode {
+        return self.mode
+    }
+
     /// Analyzer will read only following [`WordInfo`] field subset
     pub fn set_subset(&mut self, subset: InfoSubset) -> InfoSubset {
         let mode_subset = match self.mode {

--- a/sudachi/src/analysis/stateful_tokenizer.rs
+++ b/sudachi/src/analysis/stateful_tokenizer.rs
@@ -88,7 +88,7 @@ impl<D: DictionaryAccess> StatefulTokenizer<D> {
 
     /// Return current analysis mode
     pub fn mode(&self) -> Mode {
-        return self.mode
+        return self.mode;
     }
 
     /// Analyzer will read only following [`WordInfo`] field subset


### PR DESCRIPTION
Fixes #243 

In addition to `SplitMode` objects SudachiPy will now accept A, B, C string literals as well (in all places).
Split mode also gets a constructor that accepts string literal in addition to class members

Bonus fix: tokenization now releases GIL