### PR TITLE
Update workflow actions (node 16 to 20)

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macOS-latest]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -14,10 +14,10 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -30,20 +30,21 @@ jobs:
         working-directory: ./python
         run: bash build-sdist.sh
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-sdist
           path: python/dist/*
 
   build-linux-wheels:
     name: Build Linux Python Wheels (+PGO)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download dictionary
         run: bash fetch_dictionary.sh "20220519" "core"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -57,8 +58,9 @@ jobs:
         with:
           script: python/build-wheels-manylinux-pgo.sh
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-manylinux
           path: python/dist/*manylinux*
 
   build-non-linux-wheels:
@@ -70,13 +72,13 @@ jobs:
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -102,8 +104,9 @@ jobs:
           ARCHFLAGS: -arch x86_64 -arch arm64
           MACOSX_DEPLOYMENT_TARGET: 10.12
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-${{ matrix.os }}-${{ matrix.python-version }}
           path: python/dist/*.whl
 
   upload-to-pypi: # run only if all have succeeded
@@ -112,10 +115,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') # only for tags
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact # default artifact name
+          pattern: artifact-*
           path: dist/
+          merge-multiple: true
 
       - name: List files to upload
         run: ls -R dist/

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build rust document
         # build document of lib only for now to avoid name collision.
@@ -19,7 +19,7 @@ jobs:
         run: mv ./target/doc ./docs/rust
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install dependencies
@@ -36,7 +36,7 @@ jobs:
         run: mv ./python/docs/build/html ./docs/python
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs

--- a/.github/workflows/python-upload-test.yml
+++ b/.github/workflows/python-upload-test.yml
@@ -9,10 +9,10 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -28,20 +28,21 @@ jobs:
         working-directory: ./python
         run: bash build-sdist.sh
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-sdist
           path: python/dist/*
 
   build-linux-wheels:
     name: Build Linux Python Wheels (+PGO)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download dictionary
         run: bash fetch_dictionary.sh "20220519" "core"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -58,8 +59,9 @@ jobs:
         with:
           script: python/build-wheels-manylinux-pgo.sh
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-manylinux
           path: python/dist/*manylinux*
 
   build-non-linux-wheels:
@@ -71,13 +73,13 @@ jobs:
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -106,18 +108,20 @@ jobs:
           ARCHFLAGS: -arch x86_64 -arch arm64
           MACOSX_DEPLOYMENT_TARGET: 10.12
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-${{ matrix.os }}-${{ matrix.python-version }}
           path: python/dist/*.whl
 
   upload-to-testpypi: # run only if all have succeeded
     needs: [ build-sdist, build-non-linux-wheels, build-linux-wheels ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact # default artifact name
+          pattern: artifact-*
           path: dist/
+          merge-multiple: true
 
       - name: List files to upload
         run: ls -R dist/
@@ -140,8 +144,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-upload-test.yml
+++ b/.github/workflows/python-upload-test.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macOS-latest]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
       - uses: actions/checkout@v4
@@ -139,7 +139,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download dictionary
         run: bash fetch_dictionary.sh "20220519" "core"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install dependencies

--- a/.github/workflows/rust-lint-fmt.yml
+++ b/.github/workflows/rust-lint-fmt.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Rustfmt
         run: cargo fmt -- --check --files-with-diff

--- a/.github/workflows/rust-noncached.yml
+++ b/.github/workflows/rust-noncached.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download dictionary
         run: bash fetch_dictionary.sh "20220519" "core"
       - name: Run tests (Debug)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Download dictionary
       run: bash fetch_dictionary.sh "20220519" "core"
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/


### PR DESCRIPTION
Fix #244.

Updated versions of each actions.
For `upload-artifact` and `download-artifact`, followed their [migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md).

Also removed 3.7 from build matrix as it has reached its end of life (https://devguide.python.org/versions/)