### PR TITLE
Stop calling setup.py for build/install

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools setuptools-rust
+          python -m pip install --upgrade setuptools setuptools-rust build
 
-      - name: Build
+      - name: Build sdist
         working-directory: ./python
         run: bash build-sdist.sh
 
@@ -89,15 +89,15 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools setuptools_rust wheel
+          python -m pip install -U setuptools setuptools_rust build
 
       - name: Add aarch64 target for Rust
         run: rustup target add aarch64-apple-darwin
         if: startsWith(matrix.os, 'macOS')
 
-      - name: build wheel
-        run: |
-          cd python && python setup.py bdist_wheel
+      - name: Build wheel
+        working-directory: ./python
+        run: python -m build --wheel
         env:
           ARCHFLAGS: -arch x86_64 -arch arm64
           MACOSX_DEPLOYMENT_TARGET: 10.12

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build python binding
         working-directory: ./python
-        run: python3 setup.py develop
+        run: python3 -m pip install .
 
       - name: Build pyhton document
         working-directory: ./python/docs

--- a/.github/workflows/python-upload-test.yml
+++ b/.github/workflows/python-upload-test.yml
@@ -19,12 +19,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools setuptools-rust
+          python -m pip install --upgrade setuptools setuptools-rust build
 
       - name: Make .devXX version
         run: python ./python/latest_dev_version.py
 
-      - name: Build
+      - name: Build sdist
         working-directory: ./python
         run: bash build-sdist.sh
 
@@ -97,11 +97,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools setuptools_rust wheel
+          python -m pip install -U setuptools setuptools_rust build
 
-      - name: build wheel
-        run: |
-          cd python && python setup.py bdist_wheel
+      - name: Build wheel
+        working-directory: ./python
+        run: python -m build --wheel
         env:
           ARCHFLAGS: -arch x86_64 -arch arm64
           MACOSX_DEPLOYMENT_TARGET: 10.12

--- a/python/README.md
+++ b/python/README.md
@@ -379,8 +379,7 @@ $ sudachipy -r path/to/sudachi.json
 #### Install develop build
 
 1. Install python module `setuptools` and `setuptools-rust`.
-2. Run `python3 setup.py develop`.
-    - `develop` will create a debug build, while `install` will create a release build.
+2. Run `python3 -m pip install -e .` to install sudachipy (editable install).
 3. Now you can import the module by `import sudachipy`.
 
 ref: [setuptools-rust](https://github.com/PyO3/setuptools-rust)

--- a/python/build-sdist.sh
+++ b/python/build-sdist.sh
@@ -8,7 +8,7 @@ sed -i 's/\.\.\/sudachi/\.\/sudachi-lib/' Cargo.toml
 
 
 # Build the source distribution
-python setup.py sdist
+python -m build --sdist
 
 
 # clean up changes


### PR DESCRIPTION
resolve #242.

Followed recommendations in:
https://packaging.python.org/en/latest/discussions/setup-py-deprecated/
