### PR TITLE
Add option for embedded config and fallback resources

### DIFF
--- a/sudachi/src/config.rs
+++ b/sudachi/src/config.rs
@@ -29,6 +29,7 @@ use thiserror::Error;
 
 const DEFAULT_RESOURCE_DIR: &str = "resources";
 const DEFAULT_SETTING_FILE: &str = "sudachi.json";
+const DEFAULT_SETTING_BYTES: &[u8] = include_bytes!("../../resources/sudachi.json");
 const DEFAULT_CHAR_DEF_FILE: &str = "char.def";
 
 /// Sudachi Error
@@ -339,6 +340,13 @@ impl Config {
             None => raw_config,
             Some(p) => raw_config.system_dict(p),
         };
+
+        Ok(raw_config.build())
+    }
+
+    pub fn new_embedded() -> Result<Self, ConfigError> {
+        // prioritize arg (cli option) > default
+        let raw_config = ConfigBuilder::from_bytes(DEFAULT_SETTING_BYTES)?;
 
         Ok(raw_config.build())
     }

--- a/sudachi/src/config.rs
+++ b/sudachi/src/config.rs
@@ -345,7 +345,6 @@ impl Config {
     }
 
     pub fn new_embedded() -> Result<Self, ConfigError> {
-        // prioritize arg (cli option) > default
         let raw_config = ConfigBuilder::from_bytes(DEFAULT_SETTING_BYTES)?;
 
         Ok(raw_config.build())

--- a/sudachi/src/dic/character_category.rs
+++ b/sudachi/src/dic/character_category.rs
@@ -85,6 +85,11 @@ impl CharacterCategory {
         Self::from_reader(reader)
     }
 
+    pub fn from_bytes(bytes: &[u8]) -> SudachiResult<CharacterCategory> {
+        let reader = BufReader::new(bytes);
+        Self::from_reader(reader)
+    }
+
     pub fn from_reader<T: BufRead>(data: T) -> SudachiResult<CharacterCategory> {
         let ranges = Self::read_character_definition(data)?;
         Ok(Self::compile(&ranges))

--- a/sudachi/src/dic/dictionary.rs
+++ b/sudachi/src/dic/dictionary.rs
@@ -116,7 +116,7 @@ impl JapaneseDictionary {
     }
 
     /// Creates a dictionary from the default embedded configuration and storage
-    pub fn from_embedded_storage(
+    pub fn from_cfg_storage_with_embedded_chardef(
         cfg: &Config,
         storage: SudachiDicData,
     ) -> SudachiResult<JapaneseDictionary> {

--- a/sudachi/src/dic/dictionary.rs
+++ b/sudachi/src/dic/dictionary.rs
@@ -115,7 +115,7 @@ impl JapaneseDictionary {
         Ok(dic)
     }
 
-    /// Creates a dictionary from the default embedded configuration and storage
+    /// Creates a dictionary from the specified configuration and storage, with embedded character definition
     pub fn from_cfg_storage_with_embedded_chardef(
         cfg: &Config,
         storage: SudachiDicData,

--- a/sudachi/src/dic/dictionary.rs
+++ b/sudachi/src/dic/dictionary.rs
@@ -120,7 +120,9 @@ impl JapaneseDictionary {
         cfg: &Config,
         storage: SudachiDicData,
     ) -> SudachiResult<JapaneseDictionary> {
-        let mut basic_dict = LoadedDictionary::from_system_dictionary_embedded( unsafe { storage.system_static_slice() } )?;
+        let mut basic_dict = LoadedDictionary::from_system_dictionary_embedded(unsafe {
+            storage.system_static_slice()
+        })?;
 
         let plugins = {
             let grammar = &mut basic_dict.grammar;

--- a/sudachi/src/dic/mod.rs
+++ b/sudachi/src/dic/mod.rs
@@ -42,6 +42,7 @@ pub mod storage;
 pub mod subset;
 pub mod word_id;
 
+const DEFAULT_CHAR_DEF_BYTES: &[u8] = include_bytes!("../../../resources/char.def");
 const POS_DEPTH: usize = 6;
 
 /// A dictionary consists of one system_dict and zero or more user_dicts
@@ -77,7 +78,7 @@ impl<'a> LoadedDictionary<'a> {
     ) -> SudachiResult<LoadedDictionary<'a>> {
         let system_dict = DictionaryLoader::read_system_dictionary(dictionary_bytes)?;
 
-        let character_category = CharacterCategory::from_bytes(include_bytes!("../../../resources/char.def"))?;
+        let character_category = CharacterCategory::from_bytes(DEFAULT_CHAR_DEF_BYTES)?;
         let mut grammar = system_dict
             .grammar
             .ok_or(SudachiError::InvalidDictionaryGrammar)?;

--- a/sudachi/src/dic/mod.rs
+++ b/sudachi/src/dic/mod.rs
@@ -71,6 +71,25 @@ impl<'a> LoadedDictionary<'a> {
         })
     }
 
+    /// Creates a system dictionary from bytes, and load embedded default character category
+    pub fn from_system_dictionary_embedded(
+        dictionary_bytes: &'a [u8],
+    ) -> SudachiResult<LoadedDictionary<'a>> {
+        let system_dict = DictionaryLoader::read_system_dictionary(dictionary_bytes)?;
+
+        let character_category = CharacterCategory::from_bytes(include_bytes!("../../../resources/char.def"))?;
+        let mut grammar = system_dict
+            .grammar
+            .ok_or(SudachiError::InvalidDictionaryGrammar)?;
+        grammar.set_character_category(character_category);
+
+        let num_system_pos = grammar.pos_list.len();
+        Ok(LoadedDictionary {
+            grammar,
+            lexicon_set: LexiconSet::new(system_dict.lexicon, num_system_pos),
+        })
+    }
+
     #[cfg(test)]
     pub(crate) fn merge_dictionary(
         mut self,

--- a/sudachi/src/dic/mod.rs
+++ b/sudachi/src/dic/mod.rs
@@ -77,7 +77,10 @@ impl<'a> LoadedDictionary<'a> {
         character_category_file: &Path,
     ) -> SudachiResult<LoadedDictionary<'a>> {
         let character_category = CharacterCategory::from_file(character_category_file)?;
-        Ok(Self::from_system_dictionary_and_chardef(dictionary_bytes, character_category)?)
+        Ok(Self::from_system_dictionary_and_chardef(
+            dictionary_bytes,
+            character_category,
+        )?)
     }
 
     /// Creates a system dictionary from bytes, and load embedded default character category
@@ -85,7 +88,10 @@ impl<'a> LoadedDictionary<'a> {
         dictionary_bytes: &'a [u8],
     ) -> SudachiResult<LoadedDictionary<'a>> {
         let character_category = CharacterCategory::from_bytes(DEFAULT_CHAR_DEF_BYTES)?;
-        Ok(Self::from_system_dictionary_and_chardef(dictionary_bytes, character_category)?)
+        Ok(Self::from_system_dictionary_and_chardef(
+            dictionary_bytes,
+            character_category,
+        )?)
     }
 
     #[cfg(test)]

--- a/sudachi/src/dic/mod.rs
+++ b/sudachi/src/dic/mod.rs
@@ -52,14 +52,13 @@ pub struct LoadedDictionary<'a> {
 }
 
 impl<'a> LoadedDictionary<'a> {
-    /// Creates a system dictionary from bytes, and load a character category from file
-    pub fn from_system_dictionary(
+    /// Creates a system dictionary from bytes, and preloaded character category
+    pub fn from_system_dictionary_and_chardef(
         dictionary_bytes: &'a [u8],
-        character_category_file: &Path,
+        character_category: CharacterCategory,
     ) -> SudachiResult<LoadedDictionary<'a>> {
         let system_dict = DictionaryLoader::read_system_dictionary(dictionary_bytes)?;
 
-        let character_category = CharacterCategory::from_file(character_category_file)?;
         let mut grammar = system_dict
             .grammar
             .ok_or(SudachiError::InvalidDictionaryGrammar)?;
@@ -72,23 +71,21 @@ impl<'a> LoadedDictionary<'a> {
         })
     }
 
+    /// Creates a system dictionary from bytes, and load a character category from file
+    pub fn from_system_dictionary(
+        dictionary_bytes: &'a [u8],
+        character_category_file: &Path,
+    ) -> SudachiResult<LoadedDictionary<'a>> {
+        let character_category = CharacterCategory::from_file(character_category_file)?;
+        Ok(Self::from_system_dictionary_and_chardef(dictionary_bytes, character_category)?)
+    }
+
     /// Creates a system dictionary from bytes, and load embedded default character category
     pub fn from_system_dictionary_embedded(
         dictionary_bytes: &'a [u8],
     ) -> SudachiResult<LoadedDictionary<'a>> {
-        let system_dict = DictionaryLoader::read_system_dictionary(dictionary_bytes)?;
-
         let character_category = CharacterCategory::from_bytes(DEFAULT_CHAR_DEF_BYTES)?;
-        let mut grammar = system_dict
-            .grammar
-            .ok_or(SudachiError::InvalidDictionaryGrammar)?;
-        grammar.set_character_category(character_category);
-
-        let num_system_pos = grammar.pos_list.len();
-        Ok(LoadedDictionary {
-            grammar,
-            lexicon_set: LexiconSet::new(system_dict.lexicon, num_system_pos),
-        })
+        Ok(Self::from_system_dictionary_and_chardef(dictionary_bytes, character_category)?)
     }
 
     #[cfg(test)]

--- a/sudachi/src/plugin/input_text/default_input_text/mod.rs
+++ b/sudachi/src/plugin/input_text/default_input_text/mod.rs
@@ -37,6 +37,7 @@ use crate::prelude::*;
 mod tests;
 
 const DEFAULT_REWRITE_DEF_FILE: &str = "rewrite.def";
+const DEFAULT_REWRITE_DEF_BYTES: &[u8] = include_bytes!("../../../../../resources/rewrite.def");
 
 /// Provides basic normalization of the input text
 #[derive(Default)]
@@ -262,10 +263,15 @@ impl InputTextPlugin for DefaultInputTextPlugin {
             settings
                 .rewriteDef
                 .unwrap_or_else(|| DEFAULT_REWRITE_DEF_FILE.into()),
-        )?;
+        );
 
-        let reader = BufReader::new(fs::File::open(&rewrite_file_path)?);
-        self.read_rewrite_lists(reader)?;
+        if rewrite_file_path.is_ok() {
+            let reader = BufReader::new(fs::File::open(&rewrite_file_path?)?);
+            self.read_rewrite_lists(reader)?;
+        } else {
+            let reader = BufReader::new(DEFAULT_REWRITE_DEF_BYTES);
+            self.read_rewrite_lists(reader)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Partial fix for #218

Allows static binaries to function properly in rust by falling back on default config and resources. Missing support for user defined embedded files but I think sudachi.rs should have at least basic support for static binaries.

Basic example code creating a tokenizer using embedded defaults (dictionary must still be added separately):

```rust
let embedded_dictionary = include_bytes!("./system_full.dic");
let sudachi_dic_data = SudachiDicData::new(Storage::Borrowed(embedded_dictionary));
let config = Config::new_embedded().unwrap();
let japanese_dictionary = JapaneseDictionary::from_cfg_storage_with_embedded_chardef(&config, sudachi_dic_data).unwrap();

let tokenizer = StatelessTokenizer::new(&japanese_dictionary);
```