### PR TITLE
Add wheel build for the aarch64 architecture in Github actions

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -38,6 +38,9 @@ jobs:
   build-linux-wheels:
     name: Build Linux Python Wheels (+PGO)
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [none, aarch64]
     steps:
       - uses: actions/checkout@v4
 
@@ -56,6 +59,7 @@ jobs:
 
       - uses: eiennohito/gha-manylinux-build@master
         with:
+          arch: ${{ matrix.arch }}
           script: python/build-wheels-manylinux-pgo.sh
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Add in the `Build Linux Python Wheels (+PGO)` job of the `Python Packages` Github actions workflow, a new `arch` matrix variable to build the wheel on the `aarch64` architecture.

The wheel already builds fine on the `aarch64` architecture in local.

This PR fixes the #220 issue.

I didn't test this new configuration in the Github workflow because I don't know how to test it. 