### PR TITLE
fix dictionary.__repr__ for no user-dict case

### DIFF
--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -434,10 +434,10 @@ fn config_repr(cfg: &Config) -> Result<String, std::fmt::Error> {
     match cfg.resolved_user_dicts() {
         Ok(dicts) => {
             for (i, dic) in dicts.iter().enumerate() {
-                write!(result, "{}", dic.display())?;
-                if i + 1 != dicts.len() {
+                if i != 0 {
                     write!(result, ", ")?;
                 }
+                write!(result, "{}", dic.display())?;
             }
         }
         Err(e) => {

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -435,9 +435,7 @@ fn config_repr(cfg: &Config) -> Result<String, std::fmt::Error> {
         Ok(dicts) => {
             for (i, dic) in dicts.iter().enumerate() {
                 write!(result, "{}", dic.display())?;
-                if i + 1 == dicts.len() {
-                    write!(result, "]")?;
-                } else {
+                if i + 1 != dicts.len() {
                     write!(result, ", ")?;
                 }
             }
@@ -446,8 +444,7 @@ fn config_repr(cfg: &Config) -> Result<String, std::fmt::Error> {
             write!(result, "<err:{:?}>", e)?;
         }
     }
-
-    write!(result, ")>")?;
+    write!(result, "])>")?;
     Ok(result)
 }
 


### PR DESCRIPTION
current `__repr__` misses close "]" when the user dict list is empty:

```python
dict = sudachipy.Dictionary()
dict.__repr__()
# '<SudachiDictionary(system=/path/to/system.dic, user=[)>'
```

