### PR TITLE
mv pyprojector to projection mod, organize required_field constructio

### DIFF
--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -26,11 +26,10 @@ use sudachi::prelude::{Morpheme, MorphemeList};
 
 use crate::dictionary::{extract_mode, PyDicData, PyDictionary};
 use crate::errors;
-use crate::projection::MorphemeProjection;
+use crate::projection::{MorphemeProjection, PyProjector};
 use crate::word_info::PyWordInfo;
 
 pub(crate) type PyMorphemeList = MorphemeList<Arc<PyDicData>>;
-pub(crate) type PyProjector = Option<Arc<dyn MorphemeProjection + Send + Sync>>;
 
 /// A list of morphemes.
 ///

--- a/python/src/pretokenizer.rs
+++ b/python/src/pretokenizer.rs
@@ -29,8 +29,8 @@ use sudachi::prelude::Mode;
 
 use crate::dictionary::PyDicData;
 use crate::errors;
-use crate::morpheme::{PyMorphemeList, PyMorphemeListWrapper, PyProjector};
-use crate::projection::MorphemeProjection;
+use crate::morpheme::{PyMorphemeList, PyMorphemeListWrapper};
+use crate::projection::{MorphemeProjection, PyProjector};
 
 /// This struct perform actual tokenization
 /// There should be at most one instance per thread of execution

--- a/python/src/tokenizer.rs
+++ b/python/src/tokenizer.rs
@@ -26,7 +26,8 @@ use sudachi::prelude::*;
 
 use crate::dictionary::{extract_mode, PyDicData};
 use crate::errors;
-use crate::morpheme::{PyMorphemeListWrapper, PyProjector};
+use crate::morpheme::PyMorphemeListWrapper;
+use crate::projection::PyProjector;
 
 /// Unit to split text.
 ///


### PR DESCRIPTION
organize the `projection` code.

- combine projection resolution
  - perform in single if-else branch, removing `resolve_projection`
- required word info fields depends only on the projection
  - calculate and return as a tuple of (proj, fields)
- pyprojector = None is equivalent to the `surface` projection
  - use None for the simplification

also see #259