### PR TITLE
update pyo3 to v0.23

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -15,7 +15,7 @@ name = "sudachipy"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.22", features = ["extension-module"] }
+pyo3 = { version = "0.23", features = ["extension-module"] }
 scopeguard = "1" # Apache 2.0/MIT
 thread_local = "1.1" # Apache 2.0/MIT
 

--- a/python/build-wheels-manylinux-pgo.sh
+++ b/python/build-wheels-manylinux-pgo.sh
@@ -35,8 +35,7 @@ export CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu
 
 # see following link for the list of cpython bin
 # https://github.com/pypa/manylinux?tab=readme-ov-file#image-content
-# TODO: after supporting py313t, "/opt/python/cp{37,38,39,310,311,312,313}-*/bin" would suffice.
-for PYBIN in /opt/python/cp*-cp{37m,38,39,310,311,312,313}/bin; do
+for PYBIN in /opt/python/cp{37,38,39,310,311,312,313}-*/bin; do
     "${PYBIN}/pip" install -U setuptools wheel setuptools-rust
     find . -iname 'sudachipy*.so'
     rm -f build/lib/sudachipy/sudachipy*.so

--- a/python/src/errors.rs
+++ b/python/src/errors.rs
@@ -14,6 +14,7 @@
  *  limitations under the License.
  */
 
+use core::ffi::CStr;
 use std::fmt::{Debug, Display};
 
 use pyo3::exceptions::PyDeprecationWarning;
@@ -37,6 +38,6 @@ pub fn wrap_ctx<T, E: Display, C: Debug + ?Sized>(v: Result<T, E>, ctx: &C) -> P
     }
 }
 
-pub fn warn_deprecation(py: Python<'_>, msg: &str) -> PyResult<()> {
-    PyErr::warn_bound(py, &py.get_type_bound::<PyDeprecationWarning>(), msg, 1)
+pub fn warn_deprecation(py: Python<'_>, msg: &CStr) -> PyResult<()> {
+    PyErr::warn(py, &py.get_type::<PyDeprecationWarning>(), msg, 1)
 }

--- a/python/src/pos_matcher.rs
+++ b/python/src/pos_matcher.rs
@@ -39,23 +39,21 @@ pub struct PyPosMatcher {
 
 impl PyPosMatcher {
     pub(crate) fn create<'py>(
-        py: Python<'py>,
         dic: &'py Arc<PyDicData>,
         data: &Bound<'py, PyAny>,
     ) -> PyResult<PyPosMatcher> {
         if data.is_callable() {
-            Self::create_from_fn(dic, data, py)
+            Self::create_from_fn(dic, data)
         } else {
-            let iter = data.iter()?;
+            let iter = data.try_iter()?;
             Self::create_from_iter(dic, &iter)
         }
     }
 
-    fn create_from_fn(dic: &Arc<PyDicData>, func: &Bound<PyAny>, py: Python) -> PyResult<Self> {
+    fn create_from_fn(dic: &Arc<PyDicData>, func: &Bound<PyAny>) -> PyResult<Self> {
         let mut data = Vec::new();
         for (pos_id, pos) in dic.pos.iter().enumerate() {
-            let args = PyTuple::new_bound(py, [pos]);
-            if func.call1(args)?.downcast::<PyBool>()?.is_true() {
+            if func.call1((pos,))?.downcast::<PyBool>()?.is_true() {
                 data.push(pos_id as u16);
             }
         }

--- a/python/src/projection.rs
+++ b/python/src/projection.rs
@@ -36,7 +36,7 @@ struct Surface {}
 
 impl MorphemeProjection for Surface {
     fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
-        PyString::new_bound(py, m.surface().deref())
+        PyString::new(py, m.surface().deref())
     }
 }
 
@@ -46,7 +46,7 @@ struct Mapped<F: for<'a> Fn(&'a Morpheme<'a, Arc<PyDicData>>) -> &'a str> {
 
 impl<F: for<'a> Fn(&'a Morpheme<'a, Arc<PyDicData>>) -> &'a str> MorphemeProjection for Mapped<F> {
     fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
-        PyString::new_bound(py, (self.func)(m))
+        PyString::new(py, (self.func)(m))
     }
 }
 
@@ -64,9 +64,9 @@ impl DictionaryAndSurface {
 impl MorphemeProjection for DictionaryAndSurface {
     fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
         if self.matcher.matches_id(m.part_of_speech_id()) {
-            PyString::new_bound(py, m.surface().deref())
+            PyString::new(py, m.surface().deref())
         } else {
-            PyString::new_bound(py, m.dictionary_form())
+            PyString::new(py, m.dictionary_form())
         }
     }
 }
@@ -85,9 +85,9 @@ impl NormalizedAndSurface {
 impl MorphemeProjection for NormalizedAndSurface {
     fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
         if self.matcher.matches_id(m.part_of_speech_id()) {
-            PyString::new_bound(py, m.surface().deref())
+            PyString::new(py, m.surface().deref())
         } else {
-            PyString::new_bound(py, m.normalized_form())
+            PyString::new(py, m.normalized_form())
         }
     }
 }
@@ -106,9 +106,9 @@ impl NormalizedNouns {
 impl MorphemeProjection for NormalizedNouns {
     fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
         if self.matcher.matches_id(m.part_of_speech_id()) {
-            PyString::new_bound(py, m.normalized_form())
+            PyString::new(py, m.normalized_form())
         } else {
-            PyString::new_bound(py, m.surface().deref())
+            PyString::new(py, m.surface().deref())
         }
     }
 }


### PR DESCRIPTION
resolve #280.

migration guide: https://pyo3.rs/v0.23.0/migration.html

rewrite deprecated pyo3 methods:
- remove "_bound" suffix
- provide rust tuples directly to methods that can take `IntoPyObject<PyTuple>` obj (e.g. `call1`).
- use `c_str` macro for the warning messages
- use `into_pyobject` instead of `into_py`

todo:
- ~~update release workflow for py3.13t~~
  - separate as #285