### PR TITLE
update python-support-version badge to py39

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,7 +1,7 @@
 # SudachiPy
 
 [![PyPi version](https://img.shields.io/pypi/v/sudachipy.svg)](https://pypi.python.org/pypi/sudachipy/)
-[![](https://img.shields.io/badge/python-3.6+-blue.svg)](https://www.python.org/downloads/release/python-360/)
+[![](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/release/python-390/)
 [Documentation](https://worksapplications.github.io/sudachi.rs/python)
 
 SudachiPy is a Python version of [Sudachi](https://github.com/WorksApplications/Sudachi), a Japanese morphological analyzer.


### PR DESCRIPTION
fix #291.

update the badge in `python/README.md` from py3.6+ to py3.9+.

Note that py3.13t is not supported yet.
