### PR TITLE
use Quansight-Labs/setup-python@v5 for py313t support

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -69,12 +69,12 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macOS-latest]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t" ]
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: Quansight-Labs/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-upload-test.yml
+++ b/.github/workflows/python-upload-test.yml
@@ -80,12 +80,12 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macOS-latest]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t" ]
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: Quansight-Labs/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -149,13 +149,13 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t" ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: Quansight-Labs/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
resolve #285.

use https://github.com/Quansight-Labs/setup-python to support py3.13t in the workflow.

This should be a temporary workaround and we will switch back to https://github.com/actions/setup-python.
see https://github.com/actions/setup-python/pull/973#issuecomment-2495900996.

