### PR TITLE
fix build-sdist script

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -3,3 +3,4 @@ include pyproject.toml
 include ../LICENSE
 recursive-include src *
 recursive-include sudachi-lib *
+recursive-include resources *

--- a/python/build-sdist.sh
+++ b/python/build-sdist.sh
@@ -1,9 +1,22 @@
 #!/bin/bash
 set -ex
 
-## Create a symlink for sudachi.rs
+## Create a symlink for sudachi.rs and resource to embed
 ln -sf ../sudachi sudachi-lib
-## Modify cargo.toml to include this symlink
+ln -sf ../resources resources
+
+## Resolve workspace.package value in Cargo.toml
+pip install tomlkit
+
+mv Cargo.toml Cargo.sudachipy.toml
+python modify_cargotoml_for_sdist.py \
+    ../Cargo.toml Cargo.sudachipy.toml --out Cargo.toml
+
+mv sudachi-lib/Cargo.toml Cargo.sudachilib.toml
+python modify_cargotoml_for_sdist.py \
+    ../Cargo.toml Cargo.sudachilib.toml --out sudachi-lib/Cargo.toml
+
+## Modify to include the symlink
 sed -i 's/\.\.\/sudachi/\.\/sudachi-lib/' Cargo.toml
 
 
@@ -12,9 +25,10 @@ python -m build --sdist
 
 
 # clean up changes
-## Modify cargo.toml
-sed -i 's/\.\/sudachi-lib/\.\.\/sudachi/' Cargo.toml
+## Revert cargo.toml
+rm Cargo.toml sudachi-lib/Cargo.toml
+mv Cargo.sudachipy.toml Cargo.toml
+mv Cargo.sudachilib.toml sudachi-lib/Cargo.toml
 
 ## rm files
-rm LICENSE sudachi-lib
-rm resources/ -rf
+rm LICENSE sudachi-lib resources

--- a/python/modify_cargotoml_for_sdist.py
+++ b/python/modify_cargotoml_for_sdist.py
@@ -1,0 +1,52 @@
+#   Copyright (c) 2025 Works Applications Co., Ltd.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# This script resolves workspace.package variables.
+# Keep original Cargo.toml file to revert changes.
+# see https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table
+
+import argparse
+from pathlib import Path
+import tomlkit
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("base", type=Path,
+                        help="Cargo.toml with workspace.package")
+    parser.add_argument("target", type=Path, help="Cargo.toml to modify")
+    parser.add_argument("--out", type=Path, default=None,
+                        help="output file")
+    args = parser.parse_args()
+    return args
+
+
+args = parse_args()
+
+# load Cargo.toml
+with args.base.open() as fi:
+    ws_toml = tomlkit.parse(fi.read())
+with args.target.open() as fi:
+    tgt_toml = tomlkit.parse(fi.read())
+
+# edit workspace.package variables
+keys = [k for k, v in tgt_toml["package"].items()
+        if v == {"workspace": True}]
+for key in keys:
+    tgt_toml["package"][key] = ws_toml["workspace"]["package"][key]
+
+# save (overwrite)
+outfile = args.out if args.out is not None else args.target
+with outfile.open("w") as fo:
+    tomlkit.dump(tgt_toml, fo)


### PR DESCRIPTION
resolve #290.

source distribution (sdist) is broken in v0.6.9 due to following changes:

- Cargo.toml uses [workspace package table](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table) and misses the root toml in sdist.
- resource file to embed is not packaged.

This PR should fix those problems.
