### PR TITLE
Error: TypeError: 'type' object is not subscriptable

### DIFF
--- a/python/py_src/sudachipy/config.py
+++ b/python/py_src/sudachipy/config.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 import dataclasses as _dataclasses
 from json import dumps as _dumps
+from typing import List
 
 
 @_dataclasses.dataclass
@@ -32,7 +33,7 @@ class Config:
     we try to load the dictionary from the SudachiDict_{system} installed package.
     For example, for "core" we will try to load the dictionary from the installed SudachiDict_core package.
     """
-    user: list[str] = None
+    user: List[str] = None
     """
     Paths to user dictionaries, maximum number of user dictionaries is 14
     """


### PR DESCRIPTION
To solve error:

```
  File "/usr/local/lib/python3.8/site-packages/spacy/lang/ja/__init__.py", line 47, in __init__
    self.tokenizer = try_sudachi_import(self.split_mode)
  File "/usr/local/lib/python3.8/site-packages/spacy/lang/ja/__init__.py", line 236, in try_sudachi_import
    from sudachipy import dictionary, tokenizer
  File "/usr/local/lib/python3.8/site-packages/sudachipy/__init__.py", line 10, in <module>
    from .config import Config
  File "/usr/local/lib/python3.8/site-packages/sudachipy/config.py", line 19, in <module>
    class Config:
  File "/usr/local/lib/python3.8/site-packages/sudachipy/config.py", line 35, in Config
    user: list[str] = None
TypeError: 'type' object is not subscriptable
```