### PR TITLE
feat: add support for Apple embedded platforms (iOS, tvOS, watchOS, visionOS)

### DIFF
--- a/sudachi/src/plugin/loader.rs
+++ b/sudachi/src/plugin/loader.rs
@@ -67,6 +67,11 @@ fn make_system_specific_name(s: &str) -> String {
     format!("lib{}.dylib", s)
 }
 
+#[cfg(any(target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+fn make_system_specific_name(_s: &str) -> String {
+    String::new()
+}
+
 fn system_specific_name(s: &str) -> Option<String> {
     if s.contains('.') {
         None

--- a/sudachi/src/plugin/loader.rs
+++ b/sudachi/src/plugin/loader.rs
@@ -68,6 +68,10 @@ fn make_system_specific_name(s: &str) -> String {
 }
 
 #[cfg(any(target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+// Apple embedded platforms do not support dynamic library loading (DSO plugins)
+// due to platform security restrictions. Returning an empty string here
+// effectively disables loading plugins from DSOs, while still allowing
+// plugins bundled with the application/binary to work as expected.
 fn make_system_specific_name(_s: &str) -> String {
     String::new()
 }

--- a/sudachi/src/plugin/loader.rs
+++ b/sudachi/src/plugin/loader.rs
@@ -53,27 +53,27 @@ struct PluginLoader<'a, 'b, T: PluginCategory + ?Sized> {
 }
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-fn make_system_specific_name(s: &str) -> String {
-    format!("lib{}.so", s)
+fn make_system_specific_name(s: &str) -> Option<String> {
+    Some(format!("lib{}.so", s))
 }
 
 #[cfg(target_os = "windows")]
-fn make_system_specific_name(s: &str) -> String {
-    format!("{}.dll", s)
+fn make_system_specific_name(s: &str) -> Option<String> {
+    Some(format!("{}.dll", s))
 }
 
 #[cfg(target_os = "macos")]
-fn make_system_specific_name(s: &str) -> String {
-    format!("lib{}.dylib", s)
+fn make_system_specific_name(s: &str) -> Option<String> {
+    Some(format!("lib{}.dylib", s))
 }
 
 #[cfg(any(target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 // Apple embedded platforms do not support dynamic library loading (DSO plugins)
-// due to platform security restrictions. Returning an empty string here
+// due to platform security restrictions. Returning None here
 // effectively disables loading plugins from DSOs, while still allowing
 // plugins bundled with the application/binary to work as expected.
-fn make_system_specific_name(_s: &str) -> String {
-    String::new()
+fn make_system_specific_name(_s: &str) -> Option<String> {
+    None
 }
 
 fn system_specific_name(s: &str) -> Option<String> {
@@ -84,7 +84,7 @@ fn system_specific_name(s: &str) -> Option<String> {
         let fname = p
             .file_name()
             .and_then(|np| np.to_str())
-            .map(make_system_specific_name);
+            .and_then(make_system_specific_name);
         let parent = p.parent().and_then(|np| np.to_str());
         match (parent, fname) {
             (Some(p), Some(c)) => Some(format!("{}/{}", p, c)),

--- a/sudachi/src/plugin/loader.rs
+++ b/sudachi/src/plugin/loader.rs
@@ -67,7 +67,12 @@ fn make_system_specific_name(s: &str) -> Option<String> {
     Some(format!("lib{}.dylib", s))
 }
 
-#[cfg(any(target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+#[cfg(any(
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos",
+    target_os = "visionos"
+))]
 // Apple embedded platforms do not support dynamic library loading (DSO plugins)
 // due to platform security restrictions. Returning None here
 // effectively disables loading plugins from DSOs, while still allowing


### PR DESCRIPTION
## Summary

Add support for compiling sudachi on Apple embedded platforms (iOS, tvOS, watchOS, visionOS).

## Changes

Apple embedded platforms do not support dynamic library loading due to security restrictions. This adds a `#[cfg]` attribute to return an empty string for `make_system_specific_name()` on these platforms, which prevents DSO plugin loading while still allowing bundled plugins (`com.worksap.nlp.sudachi.*`) to work normally.

## Motivation

Enable sudachi.rs to be used in iOS/tvOS/watchOS/visionOS applications via Swift bindings (UniFFI).

## Testing

- [x] `cargo build -p sudachi --target aarch64-apple-ios` compiles successfully
- [x] `cargo build -p sudachi --target aarch64-apple-ios-sim` compiles successfully
- [x] Tested in iOS app with real dictionary tokenization