### PR TITLE
Fix usage of NOOOVBOW char category

### DIFF
--- a/python/py_src/sudachipy/resources/char.def
+++ b/python/py_src/sudachipy/resources/char.def
@@ -174,6 +174,6 @@ CYRILLIC        1 1 0
 0x1F3FB..0x1F3FE ALL NOOOVBOW # emoji skin tone modifiers https://codepoints.net/U+1F3FF
 
 # Combination marks
-0x200C..0x200D ALL NOOOVBOW2 # Zero Width Non-Joiner/Joiner
+0x200C..0x200D ALL NOOOVBOW NOOOVEOW # Zero Width Non-Joiner/Joiner
 
 # END OF TABLE

--- a/resources/char.def
+++ b/resources/char.def
@@ -174,6 +174,6 @@ CYRILLIC        1 1 0
 0x1F3FB..0x1F3FE ALL NOOOVBOW # emoji skin tone modifiers https://codepoints.net/U+1F3FF
 
 # Combination marks
-0x200C..0x200D ALL NOOOVBOW2 # Zero Width Non-Joiner/Joiner
+0x200C..0x200D ALL NOOOVBOW NOOOVEOW # Zero Width Non-Joiner/Joiner
 
 # END OF TABLE

--- a/sudachi/src/analysis/stateful_tokenizer.rs
+++ b/sudachi/src/analysis/stateful_tokenizer.rs
@@ -20,7 +20,6 @@ use crate::analysis::lattice::Lattice;
 use crate::analysis::node::{LatticeNode, ResultNode};
 use crate::analysis::stateless_tokenizer::{dump_path, split_path};
 use crate::analysis::Mode;
-use crate::dic::category_type::CategoryType;
 use crate::dic::connect::ConnectionMatrix;
 use crate::dic::lexicon_set::LexiconSet;
 use crate::dic::subset::InfoSubset;
@@ -28,7 +27,6 @@ use crate::dic::word_info::WordInfo;
 use crate::dic::DictionaryAccess;
 use crate::error::{SudachiError, SudachiResult};
 use crate::input_text::InputBuffer;
-use crate::input_text::InputTextIndex;
 use crate::plugin::oov::OovProviderPlugin;
 use crate::prelude::MorphemeList;
 
@@ -293,11 +291,7 @@ impl<'a> LatticeBuilder<'a> {
             }
 
             // OOV
-            if !self
-                .input
-                .cat_at_char(ch_off)
-                .intersects(CategoryType::NOOOVBOW | CategoryType::NOOOVBOW2)
-            {
+            if self.input.can_oov_bow(ch_off) {
                 for provider in self.oov_providers {
                     created = self.provide_oovs(ch_off, created, provider.as_ref())?;
                 }

--- a/sudachi/src/dic/category_type.rs
+++ b/sudachi/src/dic/category_type.rs
@@ -58,10 +58,10 @@ bitflags! {
         const USER4 = (1 << 14);
         /** This character cannot be the beginning of an OOV word */
         const NOOOVBOW = (1 << 30);
-        /** This and next characters cannot be the beginning of an OOV word */
-        const NOOOVBOW2 = (1 << 31);
+        /** This character cannot be the end of an OOV word */
+        const NOOOVEOW = (1 << 31);
 
-        /** All categories at once except NOOOVBOW/2 */
+        /** All categories at once except NOOOVBOW/EOW */
         const ALL = 0b00111111_11111111_11111111_11111111;
     }
 }

--- a/sudachi/src/input_text/buffer.rs
+++ b/sudachi/src/input_text/buffer.rs
@@ -135,11 +135,11 @@ impl InputBuffer {
         let mut last_offset = 0;
         let mut last_chidx = 0;
 
-        // Special cases for BOW logic
+        // Match the Java implementation: only continuation bytes and
+        // same-script alphabetic runs suppress BOW.
         let non_starting = CategoryType::ALPHA | CategoryType::GREEK | CategoryType::CYRILLIC;
         let mut prev_cat = CategoryType::empty();
         self.mod_bow.resize(self.modified.len(), false);
-        let mut next_bow = true;
 
         for (chidx, (bidx, ch)) in self.modified.char_indices().enumerate() {
             self.mod_chars.push(ch);
@@ -151,19 +151,7 @@ impl InputBuffer {
             last_offset = bidx;
             last_chidx = chidx;
 
-            let can_bow = if !next_bow {
-                // this char was forbidden by the previous one
-                next_bow = true;
-                false
-            } else if cat.intersects(CategoryType::NOOOVBOW2) {
-                // this rule is stronger than the next one and must come before
-                // this and next are forbidden
-                next_bow = false;
-                false
-            } else if cat.intersects(CategoryType::NOOOVBOW) {
-                // this char is forbidden
-                false
-            } else if cat.intersects(non_starting) {
+            let can_bow = if cat.intersects(non_starting) {
                 // the previous char is compatible
                 !cat.intersects(prev_cat)
             } else {
@@ -380,6 +368,15 @@ impl InputBuffer {
     pub fn can_bow(&self, offset: usize) -> bool {
         debug_assert_eq!(self.state, BufferState::RO);
         self.mod_bow[offset]
+    }
+
+    /// Whether the character can start a new OOV word.
+    #[inline]
+    pub fn can_oov_bow(&self, offset: usize) -> bool {
+        debug_assert_eq!(self.state, BufferState::RO);
+        let cat = self.mod_cat[offset];
+        !cat.contains(CategoryType::NOOOVBOW)
+            && (offset == 0 || !self.mod_cat[offset - 1].contains(CategoryType::NOOOVEOW))
     }
 
     /// Returns char length to the next can_bow point

--- a/sudachi/tests/resources/char.def
+++ b/sudachi/tests/resources/char.def
@@ -33,4 +33,4 @@ ALPHA           1 1 0
 0x1F3FB..0x1F3FE ALL NOOOVBOW # emoji skin tone modifiers https://codepoints.net/U+1F3FF
 
 # Combination marks
-0x200C..0x200D ALL NOOOVBOW2 # Zero Width Non-Joiner/Joiner
+0x200C..0x200D ALL NOOOVBOW NOOOVEOW # Zero Width Non-Joiner/Joiner


### PR DESCRIPTION
relates to #317.

This will fix the problem of "大自然ー空や海、湖、森" (「大自然」will be a single morpheme).

- NOOOVBOW should be used only for OOV: stop using it for `input_buffer.can_bow`, and use it in `build_lattice`.
- Introduce NOOOVEOW category, and change NOOOVBOW2 to (NOOOVBOW + NOOOVEOW)

Latter (and char.def update) should be ported to Java.