### PR TITLE
fix char category continuous length calculation

### DIFF
--- a/sudachi/src/dic/character_category.rs
+++ b/sudachi/src/dic/character_category.rs
@@ -319,6 +319,7 @@ mod tests {
 
     const TEST_RESOURCE_DIR: &str = "./tests/resources/";
     const TEST_CHAR_DEF_FILE: &str = "char.def";
+    type CT = CategoryType;
 
     #[test]
     fn get_category_types() {
@@ -326,7 +327,7 @@ mod tests {
         let cat = CharacterCategory::from_file(&path).expect("failed to load char.def for test");
         let cats = cat.get_category_types('熙');
         assert_eq!(1, cats.count());
-        assert!(cats.contains(CategoryType::KANJI));
+        assert!(cats.contains(CT::KANJI));
     }
 
     fn read_categories(data: &str) -> CharacterCategory {
@@ -334,8 +335,6 @@ mod tests {
             .expect("error when parsing character categories");
         CharacterCategory::compile(&ranges)
     }
-
-    type CT = CategoryType;
 
     #[test]
     fn read_cdef_1() {
@@ -515,6 +514,7 @@ mod tests {
         assert_eq!(c.get_category_types('ｂ'), CT::ALPHA);
         assert_eq!(c.get_category_types('C'), CT::ALPHA);
         assert_eq!(c.get_category_types('漢'), CT::KANJI);
+        assert_eq!(c.get_category_types('々'), CT::KANJI | CT::SYMBOL);
         assert_eq!(c.get_category_types('𡈽'), CT::DEFAULT);
         assert_eq!(c.get_category_types('ア'), CT::KATAKANA);
         assert_eq!(c.get_category_types('ｺ'), CT::KATAKANA);

--- a/sudachi/src/input_text/buffer.rs
+++ b/sudachi/src/input_text/buffer.rs
@@ -190,20 +190,28 @@ impl InputBuffer {
         if self.mod_chars.is_empty() {
             return;
         }
-        // single pass algorithm
-        // by default continuity is 1 codepoint
-        // go from the back and set it prev + 1 when chars are compatible
-        self.mod_cat_continuity.resize(self.mod_chars.len(), 1);
-        let mut cat = *self.mod_cat.last().unwrap_or(&CategoryType::all());
-        for i in (0..self.mod_cat.len() - 1).rev() {
-            let cur = self.mod_cat[i];
-            let common = cur & cat;
-            if !common.is_empty() {
-                self.mod_cat_continuity[i] = self.mod_cat_continuity[i + 1] + 1;
-                cat = common;
-            } else {
-                cat = cur;
+        self.mod_cat_continuity.clear();
+        self.mod_cat_continuity.reserve(self.mod_cat.len());
+
+        let mut length = 1;
+        for start in 0..self.mod_cat.len() {
+            // skip intermediate to align with Java implementation
+            if length > 1 {
+                length -= 1;
+                self.mod_cat_continuity.push(length);
+                continue;
             }
+
+            let mut common = self.mod_cat[start];
+            length = 1;
+            while start + length < self.mod_cat.len() {
+                common &= self.mod_cat[start + length];
+                if common.is_empty() {
+                    break;
+                }
+                length += 1;
+            }
+            self.mod_cat_continuity.push(length);
         }
     }
 

--- a/sudachi/src/input_text/buffer/test_ported.rs
+++ b/sudachi/src/input_text/buffer/test_ported.rs
@@ -77,6 +77,18 @@ fn get_char_category_continuous_length() {
 }
 
 #[test]
+fn get_char_category_continuous_length_with_multi_category_char() {
+    let grammar = cat_grammar();
+    // categories are: KANJI / KANJI|SYMBOL / SYMBOL
+    let mut input = InputBuffer::from("漢々！");
+    input.build(&grammar).expect("works");
+    // we expect continuous length to be 2/1/1, not 2/2/1 respecting Java implementation
+    assert_eq!(2, input.cat_continuous_len(0)); // 漢
+    assert_eq!(1, input.cat_continuous_len(1)); // 々
+    assert_eq!(1, input.cat_continuous_len(2)); // ！
+}
+
+#[test]
 fn range_cat() {
     let grammar = cat_grammar();
     let mut input = InputBuffer::from("âｂC1あ234漢字𡈽アｺﾞ");

--- a/sudachi/tests/resources/char.def
+++ b/sudachi/tests/resources/char.def
@@ -12,7 +12,7 @@ ALPHA           1 1 0
 0xFF9E..0xFF9F  KATAKANA
 0x2E80..0x2EF3  KANJI # CJK Raidcals Supplement
 0x2F00..0x2FD5  KANJI
-0x3005          KANJI
+0x3005          KANJI SYMBOL # 々
 0x3007          KANJI
 0x3400..0x4DB5  KANJI # CJK Unified Ideographs Extention
 0x4E00..0x9FA5  KANJI


### PR DESCRIPTION
relates to #317 
this fixes the problem of "「禰々」".

char category continuous length become wrong with the char of multiple categories: (e.g. A / A|B / B).
(Categories for "「禰々」" are symbol / kanji / kanji | symbol / symbol)

Note:
With current implementation, char-category continuous length for (A / A|B / B) becomes 2/1/1, not 2/2/1.
This respects Java implementation.
