### PR TITLE
Fix post-#263 clippy warnings in sudachi crate

### DIFF
--- a/sudachi/src/analysis/mlist.rs
+++ b/sudachi/src/analysis/mlist.rs
@@ -135,16 +135,16 @@ impl<T: DictionaryAccess> MorphemeList<T> {
         self.nodes.data.is_empty()
     }
 
-    pub fn get(&self, idx: usize) -> Morpheme<T> {
-        return Morpheme::for_list(self, idx);
+    pub fn get(&self, idx: usize) -> Morpheme<'_, T> {
+        Morpheme::for_list(self, idx)
     }
 
-    pub fn surface(&self) -> Ref<str> {
+    pub fn surface(&self) -> Ref<'_, str> {
         let inp = self.input();
         Ref::map(inp, |i| i.original())
     }
 
-    pub fn iter(&self) -> MorphemeIter<T> {
+    pub fn iter(&self) -> MorphemeIter<'_, T> {
         MorphemeIter {
             index: 0,
             list: self,
@@ -171,7 +171,7 @@ impl<T: DictionaryAccess> MorphemeList<T> {
         &self.dict
     }
 
-    pub(crate) fn input(&self) -> Ref<InputBuffer> {
+    pub(crate) fn input(&self) -> Ref<'_, InputBuffer> {
         Ref::map(self.input.deref().borrow(), |x| &x.input)
     }
 

--- a/sudachi/src/analysis/morpheme.rs
+++ b/sudachi/src/analysis/morpheme.rs
@@ -78,7 +78,7 @@ impl<'a, T: DictionaryAccess> Morpheme<'a, T> {
     }
 
     /// Returns a substring of the original text which corresponds to the morpheme
-    pub fn surface(&self) -> Ref<str> {
+    pub fn surface(&self) -> Ref<'_, str> {
         let inp = self.list.input();
         Ref::map(inp, |i| i.orig_slice(self.node().bytes_range()))
     }
@@ -152,7 +152,7 @@ impl<'a, T: DictionaryAccess> Morpheme<'a, T> {
 
     /// Returns total cost from the beginning of the path
     pub fn total_cost(&self) -> i32 {
-        return self.node().total_cost();
+        self.node().total_cost()
     }
 }
 

--- a/sudachi/src/analysis/stateless_tokenizer.rs
+++ b/sudachi/src/analysis/stateless_tokenizer.rs
@@ -85,7 +85,7 @@ where
     <T as Deref>::Target: DictionaryAccess,
 {
     pub fn as_dict(&self) -> &<T as Deref>::Target {
-        return Deref::deref(&self.dict);
+        Deref::deref(&self.dict)
     }
 }
 

--- a/sudachi/src/config.rs
+++ b/sudachi/src/config.rs
@@ -72,7 +72,7 @@ impl PathResolver {
 
     fn contains<P: AsRef<Path>>(&self, path: P) -> bool {
         let query = path.as_ref();
-        return self.roots.iter().any(|p| p.as_path() == query);
+        self.roots.iter().any(|p| p.as_path() == query)
     }
 
     pub fn first_existing<P: AsRef<Path> + Clone>(&self, path: P) -> Option<PathBuf> {

--- a/sudachi/src/dic/build/index.rs
+++ b/sudachi/src/dic/build/index.rs
@@ -84,7 +84,7 @@ impl<'a> IndexBuilder<'a> {
             trie_entries.push((k, v.offset as u32));
         }
         self.data.shrink_to_fit();
-        trie_entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+        trie_entries.sort_by_key(|(a, _)| *a);
 
         let trie = yada::builder::DoubleArrayBuilder::build(&trie_entries);
         match trie {

--- a/sudachi/src/dic/build/parse.rs
+++ b/sudachi/src/dic/build/parse.rs
@@ -174,7 +174,7 @@ fn check_str_len(data: &str) -> DicWriteResult<()> {
 }
 
 #[inline]
-pub(crate) fn unescape_cow(data: &str) -> DicWriteResult<Cow<str>> {
+pub(crate) fn unescape_cow(data: &str) -> DicWriteResult<Cow<'_, str>> {
     check_str_len(data)?;
     if !UNICODE_LITERAL.is_match(data) {
         Ok(Cow::Borrowed(data))

--- a/sudachi/src/dic/character_category.rs
+++ b/sudachi/src/dic/character_category.rs
@@ -262,7 +262,7 @@ impl CharacterCategory {
         }
     }
 
-    pub fn iter(&self) -> CharCategoryIter {
+    pub fn iter(&self) -> CharCategoryIter<'_> {
         CharCategoryIter {
             categories: self,
             current: 0,

--- a/sudachi/src/dic/grammar.rs
+++ b/sudachi/src/dic/grammar.rs
@@ -55,7 +55,7 @@ impl<'a> Grammar<'a> {
     ///
     /// buf: reference to the dictionary bytes
     /// offset: offset to the grammar section in the buf
-    pub fn parse(buf: &[u8], offset: usize) -> SudachiResult<Grammar> {
+    pub fn parse(buf: &[u8], offset: usize) -> SudachiResult<Grammar<'_>> {
         let (rest, (pos_list, left_id_size, right_id_size)) = grammar_parser(buf, offset)
             .map_err(|e| SudachiError::InvalidDictionaryGrammar.with_context(e.to_string()))?;
 
@@ -89,7 +89,7 @@ impl<'a> Grammar<'a> {
     }
 
     #[inline]
-    pub fn conn_matrix(&self) -> &ConnectionMatrix {
+    pub fn conn_matrix(&self) -> &ConnectionMatrix<'_> {
         &self.connection
     }
 

--- a/sudachi/src/dic/lexicon/mod.rs
+++ b/sudachi/src/dic/lexicon/mod.rs
@@ -74,7 +74,7 @@ impl<'a> Lexicon<'a> {
         buf: &[u8],
         original_offset: usize,
         has_synonym_group_ids: bool,
-    ) -> SudachiResult<Lexicon> {
+    ) -> SudachiResult<Lexicon<'_>> {
         let mut offset = original_offset;
 
         let (_rest, trie_size) = u32_parser_offset(buf, offset)?;

--- a/sudachi/src/dic/mod.rs
+++ b/sudachi/src/dic/mod.rs
@@ -138,7 +138,9 @@ impl<'a> DictionaryLoader<'a> {
     ///
     /// # Safety
     /// This function is marked unsafe because it does not perform header validation
-    pub unsafe fn read_any_dictionary(dictionary_bytes: &[u8]) -> SudachiResult<DictionaryLoader> {
+    pub unsafe fn read_any_dictionary(
+        dictionary_bytes: &[u8],
+    ) -> SudachiResult<DictionaryLoader<'_>> {
         let header = Header::parse(&dictionary_bytes[..Header::STORAGE_SIZE])?;
         let mut offset = Header::STORAGE_SIZE;
 
@@ -162,7 +164,7 @@ impl<'a> DictionaryLoader<'a> {
     /// Creates a system binary dictionary from bytes
     ///
     /// Returns Err if header version is not match
-    pub fn read_system_dictionary(dictionary_bytes: &[u8]) -> SudachiResult<DictionaryLoader> {
+    pub fn read_system_dictionary(dictionary_bytes: &[u8]) -> SudachiResult<DictionaryLoader<'_>> {
         let dict = unsafe { Self::read_any_dictionary(dictionary_bytes) }?;
         match dict.header.version {
             header::HeaderVersion::SystemDict(_) => Ok(dict),
@@ -175,7 +177,7 @@ impl<'a> DictionaryLoader<'a> {
     /// Creates a user binary dictionary from bytes
     ///
     /// Returns Err if header version is not match
-    pub fn read_user_dictionary(dictionary_bytes: &[u8]) -> SudachiResult<DictionaryLoader> {
+    pub fn read_user_dictionary(dictionary_bytes: &[u8]) -> SudachiResult<DictionaryLoader<'_>> {
         let dict = unsafe { Self::read_any_dictionary(dictionary_bytes) }?;
         match dict.header.version {
             header::HeaderVersion::UserDict(_) => Ok(dict),

--- a/sudachi/src/input_text/buffer/mod.rs
+++ b/sudachi/src/input_text/buffer/mod.rs
@@ -252,7 +252,7 @@ impl InputBuffer {
         // the buffer object itself will be accessible as RO
         let replaces: &'a mut Vec<edit::ReplaceOp<'a>> =
             unsafe { std::mem::transmute(&mut self.replaces) };
-        return InputEditor::new(replaces);
+        InputEditor::new(replaces)
     }
 
     /// Execute a function which can modify the contents of the current buffer

--- a/sudachi/src/plugin/connect_cost/inhibit_connection.rs
+++ b/sudachi/src/plugin/connect_cost/inhibit_connection.rs
@@ -104,7 +104,7 @@ mod tests {
         buf
     }
 
-    fn build_mock_grammar(bytes: &[u8]) -> Grammar {
+    fn build_mock_grammar(bytes: &[u8]) -> Grammar<'_> {
         Grammar::parse(bytes, 0).expect("Failed to create grammar")
     }
 }

--- a/sudachi/src/plugin/input_text/prolonged_sound_mark/tests.rs
+++ b/sudachi/src/plugin/input_text/prolonged_sound_mark/tests.rs
@@ -53,7 +53,7 @@ fn combined_continuous_prolonged_sound_marks_at_end() {
     assert_eq!(original, text.original());
     assert_eq!(normalized, text.current());
 
-    assert_eq!(12, text.current().as_bytes().len());
+    assert_eq!(12, text.current().len());
     let expected = b"\xe3\x82\xb9\xe3\x83\xbc\xe3\x83\x91\xe3\x83\xbc";
     assert_eq!(expected, text.current().as_bytes());
 
@@ -75,7 +75,7 @@ fn combine_continuous_prolonged_sound_marks_multi_times() {
     assert_eq!(original, text.original());
     assert_eq!(normalized, text.current());
 
-    assert_eq!(18, text.current().as_bytes().len());
+    assert_eq!(18, text.current().len());
     let expected = b"\xe3\x82\xa8\xe3\x83\xbc\xe3\x83\x93\xe3\x83\xbc\xe3\x82\xb7\xe3\x83\xbc";
     assert_eq!(expected, text.current().as_bytes());
 
@@ -99,7 +99,7 @@ fn combine_continuous_prolonged_sound_marks_multi_symbol_types() {
     assert_eq!(original, text.original());
     assert_eq!(normalized, text.current());
 
-    assert_eq!(18, text.current().as_bytes().len());
+    assert_eq!(18, text.current().len());
     let expected = b"\xe3\x82\xa8\xe3\x83\xbc\xe3\x83\x93\xe3\x83\xbc\xe3\x82\xb7\xe3\x83\xbc";
     assert_eq!(expected, text.current().as_bytes());
 
@@ -124,7 +124,7 @@ fn combine_continuous_prolonged_sound_marks_multi_mixed_symbol_types() {
     assert_eq!(original, text.original());
     assert_eq!(normalized, text.current());
 
-    assert_eq!(18, text.current().as_bytes().len());
+    assert_eq!(18, text.current().len());
     let expected = b"\xe3\x82\xa8\xe3\x83\xbc\xe3\x83\x93\xe3\x83\xbc\xe3\x82\xb7\xe3\x83\xbc";
     assert_eq!(expected, text.current().as_bytes());
 

--- a/sudachi/src/plugin/oov/regex_oov/mod.rs
+++ b/sudachi/src/plugin/oov/regex_oov/mod.rs
@@ -128,7 +128,7 @@ impl OovProviderPlugin for RegexOovProvider {
         let regex = self
             .regex
             .as_ref()
-            .ok_or_else(|| SudachiError::InvalidDictionaryGrammar)?;
+            .ok_or(SudachiError::InvalidDictionaryGrammar)?;
 
         let end = input_text
             .current_chars()

--- a/sudachi/src/sentence_detector.rs
+++ b/sudachi/src/sentence_detector.rs
@@ -34,7 +34,6 @@ impl<'a> NonBreakChecker<'a> {
 
 impl NonBreakChecker<'_> {
     /// Returns whether there is a word that crosses the boundary
-
     fn has_non_break_word(&self, input: &str, length: usize) -> bool {
         // assume that SentenceDetector::get_eos called with self.input[self.bos..]
         let eos_byte = self.bos + length;

--- a/sudachi/src/util/cow_array.rs
+++ b/sudachi/src/util/cow_array.rs
@@ -109,7 +109,7 @@ impl<'a, T: ReadLE + Clone> CowArray<'a, T> {
             self.storage = Some(self.slice.to_vec());
             //refresh slice
             let slice: &[T] = self.storage.as_ref().unwrap().as_slice();
-            self.slice = unsafe { std::mem::transmute(slice) };
+            self.slice = unsafe { std::mem::transmute::<&[T], &'a [T]>(slice) };
         }
         if let Some(s) = self.storage.as_mut() {
             s[offset] = value;

--- a/sudachi/src/util/testing.rs
+++ b/sudachi/src/util/testing.rs
@@ -54,7 +54,7 @@ pub fn build_mock_bytes() -> Vec<u8> {
     buf
 }
 
-pub fn build_mock_grammar(bytes: &[u8]) -> Grammar {
+pub fn build_mock_grammar(bytes: &[u8]) -> Grammar<'_> {
     let mut grammar = Grammar::parse(bytes, 0).expect("Failed to create grammar");
     grammar.set_character_category(char_cats());
     grammar

--- a/sudachi/src/util/user_pos.rs
+++ b/sudachi/src/util/user_pos.rs
@@ -36,7 +36,7 @@ pub trait UserPosSupport {
     ) -> SudachiResult<u16>;
 }
 
-impl<'a> UserPosSupport for &'a mut Grammar<'_> {
+impl UserPosSupport for &mut Grammar<'_> {
     fn handle_user_pos<S: AsRef<str> + ToString + Display>(
         &mut self,
         pos: &[S],

--- a/sudachi/tests/common/mod.rs
+++ b/sudachi/tests/common/mod.rs
@@ -214,7 +214,7 @@ impl TestStatefulTokenizer {
         }
     }
 
-    pub fn builder(system: &[u8]) -> TestTokenizerBuilder {
+    pub fn builder(system: &[u8]) -> TestTokenizerBuilder<'_> {
         TestTokenizerBuilder {
             system,
             user: Vec::new(),


### PR DESCRIPTION
Partial fix for #40.

This fixes default-level clippy/rustc warnings introduced after #263 in the `sudachi` crate only.
No API or behavior changes are intended.

Fixed:
- `mismatched_lifetime_syntaxes`: make elided lifetimes explicit on return types
- `needless_as_bytes`
- `needless_return`
- `unnecessary_lazy_evaluations`
- `unnecessary_sort_by`
- `missing_transmute_annotations`
- `needless_lifetimes`
- `empty_line_after_doc_comments`

Intentionally left out:
- `result_large_err`
- dead-code warnings
- `&Vec` / `&String` signature changes
- `StringNumber::to_string` rename
- `sudachi-fuzz` `unexpected_cfgs(fuzzing)`
- `python/` transmute annotations

Tested:
- `cargo fmt -- --check --files-with-diff`
- `cargo test --verbose`