### PR TITLE
Make Python Tokenizer concurrent-use errors explicit

### DIFF
--- a/python/src/tokenizer.rs
+++ b/python/src/tokenizer.rs
@@ -136,6 +136,10 @@ impl PyTokenizer {
     /// :param out: tokenization results will be written into this MorphemeList, a new one will be created instead.
     ///    See https://worksapplications.github.io/sudachi.rs/python/topics/out_param.html for details.
     ///
+    /// A Tokenizer instance cannot be used concurrently from multiple threads.
+    /// For parallel tokenization, share a Dictionary and create one Tokenizer
+    /// per worker/thread. Concurrent calls raise sudachipy.errors.SudachiError.
+    ///
     /// :type text: str
     /// :type mode: SplitMode | str | None
     /// :type out: MorphemeList
@@ -145,7 +149,7 @@ impl PyTokenizer {
     )]
     #[allow(unused_variables)]
     fn tokenize<'py>(
-        &'py mut self,
+        self_: &Bound<'py, Self>,
         py: Python<'py>,
         text: &'py str,
         mode: Option<&Bound<'py, PyAny>>,
@@ -157,8 +161,19 @@ impl PyTokenizer {
             None => None,
             Some(m) => Some(extract_mode(m)?),
         };
-        let default_mode = mode.map(|m| self.tokenizer.set_mode(m));
-        let mut tokenizer = scopeguard::guard(&mut self.tokenizer, |t| {
+
+        let mut this = match self_.try_borrow_mut() {
+            Ok(this) => this,
+            Err(_) => {
+                return errors::wrap(Err(
+                    "Tokenizer is already in use. A Tokenizer instance cannot be used concurrently; create a separate Tokenizer per thread or guard calls externally",
+                ))
+            }
+        };
+
+        let projection = this.projection.clone();
+        let default_mode = mode.map(|m| this.tokenizer.set_mode(m));
+        let mut tokenizer = scopeguard::guard(&mut this.tokenizer, |t| {
             default_mode.map(|m| t.set_mode(m));
         });
 
@@ -175,8 +190,7 @@ impl PyTokenizer {
             None => {
                 let dict = tokenizer.dict_clone();
                 let morphemes = MorphemeList::empty(dict);
-                let wrapper =
-                    PyMorphemeListWrapper::from_components(morphemes, self.projection.clone());
+                let wrapper = PyMorphemeListWrapper::from_components(morphemes, projection);
                 Bound::new(py, wrapper)?
             }
             Some(list) => list,

--- a/python/tests/test_tokenizer.py
+++ b/python/tests/test_tokenizer.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import os
+import queue
+import threading
 import unittest
 
 from sudachipy import Dictionary, SplitMode
+from sudachipy.errors import SudachiError
 
 
 class TestTokenizer(unittest.TestCase):
@@ -165,6 +168,77 @@ class TestTokenizer(unittest.TestCase):
         ms2 = self.tokenizer_obj.tokenize('すだち', out=ms1)
         self.assertEqual(id(ms1), id(ms2))
         self.assertEqual(m.surface(), 'すだち')
+
+    def test_concurrent_tokenize_on_same_tokenizer_fails(self):
+        text = '東京都庁に行きました。' * 1000
+        ready = threading.Barrier(8)
+        errors = queue.Queue()
+        unexpected = queue.Queue()
+
+        def worker():
+            try:
+                ready.wait(timeout=10)
+                for _ in range(20):
+                    self.tokenizer_obj.tokenize(text)
+            except SudachiError as err:
+                errors.put(str(err))
+            except Exception as err:
+                unexpected.put(err)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertTrue(unexpected.empty(), list(unexpected.queue))
+
+        messages = list(errors.queue)
+        self.assertTrue(
+            any('Tokenizer is already in use' in message for message in messages),
+            messages,
+        )
+        self.assertFalse(
+            any('Already borrowed' in message for message in messages),
+            messages,
+        )
+
+    def test_separate_tokenizers_work_in_threads(self):
+        errors = queue.Queue()
+
+        def worker():
+            try:
+                tok = self.dict_.create()
+                for _ in range(50):
+                    morphemes = tok.tokenize('東京都庁に行きました。')
+                    self.assertGreater(morphemes.size(), 0)
+            except Exception as err:
+                errors.put(err)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertTrue(errors.empty(), list(errors.queue))
+
+    def test_tokenizer_is_released_after_internal_error(self):
+        with self.assertRaises(SudachiError) as cm:
+            self.tokenizer_obj.tokenize('あ' * 20000)
+
+        self.assertIn('Input is too long', str(cm.exception))
+
+        morphemes = self.tokenizer_obj.tokenize('東京')
+        self.assertGreater(morphemes.size(), 0)
+
+    def test_temporary_mode_is_restored_after_internal_error(self):
+        tok = self.dict_.create(SplitMode.C)
+
+        with self.assertRaises(SudachiError):
+            tok.tokenize('あ' * 20000, SplitMode.A)
+
+        self.assertEqual(SplitMode.C, tok.mode)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #205.

## Summary

This makes concurrent use of a single Python `Tokenizer` fail with an explicit Sudachi error instead of leaking PyO3's generic runtime borrow error.

The intended concurrent usage model is unchanged: share a `Dictionary`, but create one `Tokenizer` per worker/thread.

## Root Cause

`Tokenizer.tokenize()` releases the GIL while Rust performs analysis, which allows another Python thread to enter the binding during an ongoing tokenization.

Before this change, `tokenize()` used `&mut self`, so PyO3 attempted to borrow the `Tokenizer` mutably before the method body was entered. A concurrent call failed at the generated PyO3 wrapper layer with:

```text
RuntimeError: Already borrowed
```

That protected the mutable `StatefulTokenizer`, but the error was generic and did not explain the supported usage model.

## Changes

This change keeps using PyO3's runtime borrow checking as the concurrency guard, but moves the borrow attempt into the method body:

- `tokenize()` now receives `&Bound<Self>` instead of `&mut self`;
- the method validates `mode` before borrowing the tokenizer;
- the method explicitly calls `try_borrow_mut()`;
- concurrent use returns a SudachiError with an actionable message;
- `py.detach(...)` remains around the Rust analysis path, so GIL-free tokenization is preserved.

New error message:

```text
Tokenizer is already in use. A Tokenizer instance cannot be used concurrently; create a separate Tokenizer per thread or guard calls externally
```

## Behavior

Before, with two threads using the same `Tokenizer`:

```text
[('err', 'RuntimeError', 'Already borrowed'), ('ok', 4756)]
```

After:

```text
[('err', 'SudachiError', 'Tokenizer is already in use. A Tokenizer instance cannot be used concurrently; create a separate Tokenizer per thread or guard calls externally'), ('ok', 4756)]
```

Using separate tokenizers from the same dictionary continues to work across threads.

## Concurrency Measurement

Environment:

- macOS 26.4.1 arm64, Mac16,5, 16 CPU cores
- Python 3.14.4
- test dictionary from `python/tests/resources`
- synthetic Japanese corpus, 20,008 UTF-8 bytes per document
- 80 documents per worker, median of 2 runs
- each worker uses its own `Tokenizer`

Reference measurement:

| variant | workers | elapsed, s | MB/s |
|---|---:|---:|---:|
| local no-`py.detach` baseline | 1 | 0.830 | 1.9 |
| local no-`py.detach` baseline | 2 | 1.686 | 1.9 |
| local no-`py.detach` baseline | 4 | 3.331 | 1.9 |
| local no-`py.detach` baseline | 8 | 6.683 | 1.9 |
| current branch, GIL released | 1 | 0.819 | 2.0 |
| current branch, GIL released | 2 | 0.847 | 3.8 |
| current branch, GIL released | 4 | 0.850 | 7.5 |
| current branch, GIL released | 8 | 0.867 | 14.8 |

The current `develop` branch already releases the GIL during analysis; this PR preserves that behavior. The table shows why keeping the analysis path inside `py.detach` matters: with the GIL held, throughput stays flat as threads serialize; with the GIL released, aggregate throughput scales with worker count.

## Tests

Added coverage for:

- concurrent calls on one `Tokenizer` raise the clear SudachiError;
- the generic PyO3 `Already borrowed` message does not leak for concurrent `tokenize()` calls;
- separate tokenizers from one dictionary work across threads;
- tokenizer state is reusable after an internal tokenization error;
- temporary split mode is restored after an internal tokenization error.

Validation run:

```bash
cargo fmt --check
cargo test -p sudachipy --no-run
.env/bin/pip install -q -e .
.env/bin/python -m unittest tests.test_tokenizer.TestTokenizer.test_concurrent_tokenize_on_same_tokenizer_fails tests.test_tokenizer.TestTokenizer.test_separate_tokenizers_work_in_threads tests.test_tokenizer.TestTokenizer.test_tokenizer_is_released_after_internal_error tests.test_tokenizer.TestTokenizer.test_temporary_mode_is_restored_after_internal_error
.env/bin/python -m unittest
```

Full Python suite result:

```text
Ran 78 tests in 3.938s

OK
```
