### PR TITLE
[codex] Add morpheme form entry accessors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +592,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +657,12 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -913,6 +934,7 @@ dependencies = [
  "join_katakana_oov",
  "join_numeric",
  "lazy_static",
+ "libc",
  "libloading",
  "memmap2",
  "nom",
@@ -932,8 +954,10 @@ version = "0.6.11-a1"
 dependencies = [
  "cfg-if",
  "clap",
+ "csv",
  "memmap2",
  "sudachi",
+ "time",
 ]
 
 [[package]]
@@ -1013,6 +1037,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/python/src/build.rs
+++ b/python/src/build.rs
@@ -24,7 +24,7 @@ use pyo3::types::{PyBytes, PyList, PyString, PyType};
 use sudachi::config::Config;
 use sudachi::dic::build::{DataSource, DictBuilder};
 use sudachi::dic::dictionary::JapaneseDictionary;
-use sudachi::dic::DictionaryAccess;
+use sudachi::dic::{DictionaryAccess, ReferenceIdAccess};
 
 use crate::dictionary::get_default_resource_dir;
 use crate::errors;
@@ -35,7 +35,10 @@ pub fn register_functions(m: &Bound<PyModule>) -> PyResult<()> {
     Ok(())
 }
 
-fn to_stats<T: DictionaryAccess>(py: Python, builder: DictBuilder<T>) -> PyResult<Bound<PyList>> {
+fn to_stats<T: DictionaryAccess + ReferenceIdAccess>(
+    py: Python,
+    builder: DictBuilder<T>,
+) -> PyResult<Bound<PyList>> {
     let stats = PyList::empty(py);
 
     for p in builder.report() {

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -280,13 +280,20 @@ impl PyMorpheme {
         )
     }
 
+    fn self_equivalent(&self, py: Python<'_>) -> PyMorpheme {
+        PyMorpheme {
+            list: self.list.clone_ref(py),
+            index: self.index,
+        }
+    }
+
     fn form_morpheme<'py, F>(
         &'py self,
         py: Python<'py>,
         subset: InfoSubset,
         form_word_id: F,
         context: &str,
-    ) -> PyResult<Option<PyMorpheme>>
+    ) -> PyResult<PyMorpheme>
     where
         F: FnOnce(&WordInfoData) -> WordId,
     {
@@ -296,7 +303,7 @@ impl PyMorpheme {
             let word_id = internal.get(self.index).word_id();
 
             if word_id.is_oov() || word_id.is_special() {
-                return Ok(None);
+                return Ok(self.self_equivalent(py));
             }
 
             let word_info = errors::wrap_ctx(
@@ -307,8 +314,12 @@ impl PyMorpheme {
                 context,
             )?;
             let form_word_id = form_word_id(word_info.borrow_data());
-            if form_word_id.is_oov() || form_word_id.is_special() {
-                return Ok(None);
+            if form_word_id == WordId::INVALID
+                || form_word_id == word_id
+                || form_word_id.is_oov()
+                || form_word_id.is_special()
+            {
+                return Ok(self.self_equivalent(py));
             }
 
             (
@@ -328,10 +339,10 @@ impl PyMorpheme {
             py,
             PyMorphemeListWrapper::from_components(form_list, projection),
         )?;
-        Ok(Some(PyMorpheme {
+        Ok(PyMorpheme {
             list: py_list,
             index: 0,
-        }))
+        })
     }
 }
 
@@ -398,9 +409,9 @@ impl PyMorpheme {
 
     /// Returns the morpheme corresponding to this morpheme's dictionary form.
     ///
-    /// If this morpheme is out-of-vocabulary, returns ``None``.
-    #[pyo3(text_signature = "(self, /) -> Morpheme | None")]
-    fn dictionary_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<Option<PyMorpheme>> {
+    /// If this morpheme is out-of-vocabulary, returns a morpheme equivalent to ``self``.
+    #[pyo3(text_signature = "(self, /) -> Morpheme")]
+    fn dictionary_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<PyMorpheme> {
         self.form_morpheme(
             py,
             InfoSubset::DICTIONARY_FORM,
@@ -417,9 +428,9 @@ impl PyMorpheme {
 
     /// Returns the morpheme corresponding to this morpheme's normalized form.
     ///
-    /// If this morpheme is out-of-vocabulary, returns ``None``.
-    #[pyo3(text_signature = "(self, /) -> Morpheme | None")]
-    fn normalized_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<Option<PyMorpheme>> {
+    /// If this morpheme is out-of-vocabulary, returns a morpheme equivalent to ``self``.
+    #[pyo3(text_signature = "(self, /) -> Morpheme")]
+    fn normalized_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<PyMorpheme> {
         self.form_morpheme(
             py,
             InfoSubset::NORMALIZED_FORM,

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -23,6 +23,10 @@ use pyo3::ffi::c_str;
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PyString, PyTuple, PyType};
 
+use sudachi::dic::subset::InfoSubset;
+use sudachi::dic::word_id::WordId;
+use sudachi::dic::word_info::WordInfoData;
+use sudachi::dic::LexiconAccess;
 use sudachi::prelude::{Morpheme, MorphemeList};
 
 use crate::dictionary::{extract_mode, PyDicData, PyDictionary};
@@ -275,6 +279,60 @@ impl PyMorpheme {
             mrp.word_id()
         )
     }
+
+    fn form_morpheme<'py, F>(
+        &'py self,
+        py: Python<'py>,
+        subset: InfoSubset,
+        form_word_id: F,
+        context: &str,
+    ) -> PyResult<Option<PyMorpheme>>
+    where
+        F: FnOnce(&WordInfoData) -> WordId,
+    {
+        let (dict, projection, form_word_id) = {
+            let list = self.list(py);
+            let internal = list.internal(py);
+            let word_id = internal.get(self.index).word_id();
+
+            if word_id.is_oov() || word_id.is_special() {
+                return Ok(None);
+            }
+
+            let word_info = errors::wrap_ctx(
+                internal
+                    .dict()
+                    .lexicon()
+                    .get_word_info_subset(word_id, subset),
+                context,
+            )?;
+            let form_word_id = form_word_id(word_info.borrow_data());
+            if form_word_id.is_oov() || form_word_id.is_special() {
+                return Ok(None);
+            }
+
+            (
+                internal.dict().clone(),
+                list.projection.clone(),
+                form_word_id,
+            )
+        };
+
+        let mut form_list = MorphemeList::empty(dict);
+        errors::wrap_ctx(
+            form_list.lookup_word_id(form_word_id, InfoSubset::all()),
+            context,
+        )?;
+
+        let py_list = Py::new(
+            py,
+            PyMorphemeListWrapper::from_components(form_list, projection),
+        )?;
+        Ok(Some(PyMorpheme {
+            list: py_list,
+            index: 0,
+        }))
+    }
 }
 
 #[pymethods]
@@ -338,10 +396,36 @@ impl PyMorpheme {
         Ok(self.morph(py).dictionary_form().into_pyobject(py)?)
     }
 
+    /// Returns the morpheme corresponding to this morpheme's dictionary form.
+    ///
+    /// If this morpheme is out-of-vocabulary, returns ``None``.
+    #[pyo3(text_signature = "(self, /) -> Morpheme | None")]
+    fn dictionary_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<Option<PyMorpheme>> {
+        self.form_morpheme(
+            py,
+            InfoSubset::DICTIONARY_FORM,
+            WordInfoData::dictionary_form_word_id,
+            "Failed to load dictionary form morpheme",
+        )
+    }
+
     /// Returns the normalized form.
     #[pyo3(text_signature = "(self, /) -> str")]
     fn normalized_form<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyString>> {
         Ok(self.morph(py).normalized_form().into_pyobject(py)?)
+    }
+
+    /// Returns the morpheme corresponding to this morpheme's normalized form.
+    ///
+    /// If this morpheme is out-of-vocabulary, returns ``None``.
+    #[pyo3(text_signature = "(self, /) -> Morpheme | None")]
+    fn normalized_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<Option<PyMorpheme>> {
+        self.form_morpheme(
+            py,
+            InfoSubset::NORMALIZED_FORM,
+            WordInfoData::normalized_form_word_id,
+            "Failed to load normalized form morpheme",
+        )
     }
 
     /// Returns the reading form.

--- a/python/tests/test_morpheme.py
+++ b/python/tests/test_morpheme.py
@@ -81,6 +81,68 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(m.normalized_form(), 'ぴらる')
         self.assertEqual(m.reading_form(), 'ピラル')
 
+    def test_dictionary_form_morpheme(self):
+        m = self.tokenizer_obj.tokenize('行っ')[0]
+        df = m.dictionary_form_morpheme()
+
+        self.assertIsNotNone(df)
+        self.assertEqual(df.surface(), '行く')
+        self.assertEqual(df.raw_surface(), '行く')
+        self.assertEqual(df.dictionary_form(), '行く')
+        self.assertEqual(df.reading_form(), 'イク')
+
+    def test_normalized_form_morpheme(self):
+        m = self.tokenizer_obj.tokenize('いっ')[0]
+        nf = m.normalized_form_morpheme()
+
+        self.assertIsNotNone(nf)
+        self.assertEqual(nf.surface(), '行く')
+        self.assertEqual(nf.raw_surface(), '行く')
+        self.assertEqual(nf.normalized_form(), '行く')
+        self.assertEqual(nf.reading_form(), 'イク')
+
+    def test_form_morpheme_for_same_entry(self):
+        m = self.tokenizer_obj.tokenize('東京')[0]
+        df = m.dictionary_form_morpheme()
+        nf = m.normalized_form_morpheme()
+
+        self.assertIsNotNone(df)
+        self.assertIsNotNone(nf)
+        self.assertEqual(df.word_id(), m.word_id())
+        self.assertEqual(nf.word_id(), m.word_id())
+        self.assertEqual(df.surface(), '東京')
+        self.assertEqual(nf.surface(), '東京')
+
+    def test_form_morpheme_for_normalized_input_same_entry(self):
+        m = self.tokenizer_obj.tokenize('特Ａ東京')[0]
+        nf = m.normalized_form_morpheme()
+
+        self.assertIsNotNone(nf)
+        self.assertEqual(m.surface(), '特Ａ')
+        self.assertEqual(m.normalized_form(), '特A')
+        self.assertEqual(nf.word_id(), m.word_id())
+        self.assertEqual(nf.raw_surface(), '特A')
+
+    def test_form_morpheme_with_field_subset(self):
+        tokenizer = self.dict_.create(fields={'surface'})
+        m = tokenizer.tokenize('行っ')[0]
+        df = m.dictionary_form_morpheme()
+        nf = m.normalized_form_morpheme()
+
+        self.assertIsNotNone(df)
+        self.assertIsNotNone(nf)
+        self.assertEqual(df.surface(), '行く')
+        self.assertEqual(nf.surface(), '行く')
+        self.assertEqual(df.reading_form(), 'イク')
+        self.assertEqual(nf.reading_form(), 'イク')
+
+    def test_form_morpheme_oov_returns_none(self):
+        m = self.tokenizer_obj.tokenize('京')[0]
+
+        self.assertTrue(m.is_oov())
+        self.assertIsNone(m.dictionary_form_morpheme())
+        self.assertIsNone(m.normalized_form_morpheme())
+
     def test_morpheme_dictionary_id(self):
         m = self.tokenizer_obj.tokenize('京都')[0]
         self.assertEqual(m.dictionary_id(), 0)

--- a/python/tests/test_morpheme.py
+++ b/python/tests/test_morpheme.py
@@ -85,43 +85,47 @@ class TestTokenizer(unittest.TestCase):
         m = self.tokenizer_obj.tokenize('行っ')[0]
         df = m.dictionary_form_morpheme()
 
-        self.assertIsNotNone(df)
         self.assertEqual(df.surface(), '行く')
         self.assertEqual(df.raw_surface(), '行く')
         self.assertEqual(df.dictionary_form(), '行く')
         self.assertEqual(df.reading_form(), 'イク')
+        self.assertEqual(df.begin(), 0)
+        self.assertEqual(df.end(), len(df.surface()))
 
     def test_normalized_form_morpheme(self):
         m = self.tokenizer_obj.tokenize('いっ')[0]
         nf = m.normalized_form_morpheme()
 
-        self.assertIsNotNone(nf)
         self.assertEqual(nf.surface(), '行く')
         self.assertEqual(nf.raw_surface(), '行く')
         self.assertEqual(nf.normalized_form(), '行く')
         self.assertEqual(nf.reading_form(), 'イク')
+        self.assertEqual(nf.begin(), 0)
+        self.assertEqual(nf.end(), len(nf.surface()))
 
     def test_form_morpheme_for_same_entry(self):
         m = self.tokenizer_obj.tokenize('東京')[0]
         df = m.dictionary_form_morpheme()
         nf = m.normalized_form_morpheme()
 
-        self.assertIsNotNone(df)
-        self.assertIsNotNone(nf)
         self.assertEqual(df.word_id(), m.word_id())
         self.assertEqual(nf.word_id(), m.word_id())
         self.assertEqual(df.surface(), '東京')
         self.assertEqual(nf.surface(), '東京')
+        self.assertEqual(df.begin(), m.begin())
+        self.assertEqual(df.end(), m.end())
+        self.assertEqual(nf.begin(), m.begin())
+        self.assertEqual(nf.end(), m.end())
 
     def test_form_morpheme_for_normalized_input_same_entry(self):
         m = self.tokenizer_obj.tokenize('特Ａ東京')[0]
         nf = m.normalized_form_morpheme()
 
-        self.assertIsNotNone(nf)
         self.assertEqual(m.surface(), '特Ａ')
         self.assertEqual(m.normalized_form(), '特A')
         self.assertEqual(nf.word_id(), m.word_id())
-        self.assertEqual(nf.raw_surface(), '特A')
+        self.assertEqual(nf.raw_surface(), m.raw_surface())
+        self.assertEqual(nf.surface(), m.surface())
 
     def test_form_morpheme_with_field_subset(self):
         tokenizer = self.dict_.create(fields={'surface'})
@@ -129,19 +133,25 @@ class TestTokenizer(unittest.TestCase):
         df = m.dictionary_form_morpheme()
         nf = m.normalized_form_morpheme()
 
-        self.assertIsNotNone(df)
-        self.assertIsNotNone(nf)
         self.assertEqual(df.surface(), '行く')
         self.assertEqual(nf.surface(), '行く')
         self.assertEqual(df.reading_form(), 'イク')
         self.assertEqual(nf.reading_form(), 'イク')
 
-    def test_form_morpheme_oov_returns_none(self):
+    def test_form_morpheme_oov_returns_self_equivalent(self):
         m = self.tokenizer_obj.tokenize('京')[0]
+        df = m.dictionary_form_morpheme()
+        nf = m.normalized_form_morpheme()
 
         self.assertTrue(m.is_oov())
-        self.assertIsNone(m.dictionary_form_morpheme())
-        self.assertIsNone(m.normalized_form_morpheme())
+        self.assertTrue(df.is_oov())
+        self.assertTrue(nf.is_oov())
+        self.assertEqual(df.surface(), m.surface())
+        self.assertEqual(nf.surface(), m.surface())
+        self.assertEqual(df.begin(), m.begin())
+        self.assertEqual(df.end(), m.end())
+        self.assertEqual(nf.begin(), m.begin())
+        self.assertEqual(nf.end(), m.end())
 
     def test_morpheme_dictionary_id(self):
         m = self.tokenizer_obj.tokenize('京都')[0]

--- a/sudachi/src/analysis/mlist.rs
+++ b/sudachi/src/analysis/mlist.rs
@@ -24,6 +24,7 @@ use crate::analysis::node::{PathCost, ResultNode};
 use crate::analysis::stateful_tokenizer::StatefulTokenizer;
 use crate::analysis::{Mode, Node};
 use crate::dic::subset::InfoSubset;
+use crate::dic::word_id::WordId;
 use crate::dic::DictionaryAccess;
 use crate::error::{SudachiError, SudachiResult};
 use crate::input_text::InputBuffer;
@@ -217,6 +218,38 @@ impl<D: DictionaryAccess> MorphemeList<D> {
             result += 1;
         }
         Ok(result)
+    }
+
+    /// Resets this list to a single dictionary entry for the given word ID.
+    #[allow(clippy::result_large_err)]
+    pub fn lookup_word_id(&mut self, word_id: WordId, subset: InfoSubset) -> SudachiResult<()> {
+        let lex = self.dict.lexicon();
+        let info = lex.get_word_info_subset(word_id, subset)?;
+        let headword = info.headword(lex).to_owned();
+        let (left_id, right_id, cost) = lex.get_word_param(word_id);
+        let end_bytes = headword.len();
+
+        let end_chars = {
+            let input = &mut self.input.borrow_mut().input;
+            input.reset().push_str(&headword);
+            input.start_build()?;
+            input.build(self.dict.grammar())?;
+            input.ch_idx(end_bytes)
+        };
+
+        self.clear();
+        let node = Node::new(
+            0,
+            end_chars as u16,
+            left_id as u16,
+            right_id as u16,
+            cost,
+            word_id,
+        );
+        self.nodes
+            .data
+            .push(ResultNode::new(node, 0, 0, end_bytes as u16, info));
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
- add `Morpheme.dictionary_form_morpheme()` and `Morpheme.normalized_form_morpheme()` returning `Morpheme`, matching the Java API from WorksApplications/Sudachi#359
- return a self-equivalent morpheme for OOV morphemes, invalid/self references, and same-entry normalized/dictionary forms
- materialize distinct form entries by exact `WordId` instead of re-tokenizing or string lookup, preserving the referenced dictionary entry across homographs
- cover distinct forms, same-entry forms, normalized input, OOV, and field-subset tokenizers

Fixes #322.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p sudachipy`
- `cargo test -p sudachipy`
- `cargo test -p sudachi`
- `python/.env/bin/python -m unittest tests.test_morpheme -v`
- `cd python && bash build_and_test.sh`

Note: `cargo clippy -p sudachipy -- -D warnings` currently fails on existing `sudachi`-wide lint debt with this toolchain (`result_large_err`, `needless_return`, etc.).
