### PR TITLE
Add morpheme form entry accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Also check [python changelog](python/CHANGELOG.md).
 
 ## [Unreleased]
 
+### Added
+
+- Add Rust-side morpheme form accessors and standalone morpheme materialization.
+
+### Fixed
+
+- Reject invalid, OOV, and special word IDs in exact-entry morpheme materialization instead of panicking.
+
 ## [0.6.10](https://github.com/WorksApplications/sudachi.rs/releases/tag/v0.6.10) (2025-01-10)
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Also check [python changelog](python/CHANGELOG.md).
 
 ## [Unreleased]
 
+### Added
+
+- Add `MorphemeList::reset_with_word_id()` for materializing an exact dictionary entry.
+
 ## [0.6.10](https://github.com/WorksApplications/sudachi.rs/releases/tag/v0.6.10) (2025-01-10)
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ Also check [python changelog](python/CHANGELOG.md).
 
 ## [Unreleased]
 
-### Added
-
-- Add `MorphemeList::reset_with_word_id()` for materializing an exact dictionary entry.
-
 ## [0.6.10](https://github.com/WorksApplications/sudachi.rs/releases/tag/v0.6.10) (2025-01-10)
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,15 +302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,12 +583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,12 +642,6 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -934,7 +913,6 @@ dependencies = [
  "join_katakana_oov",
  "join_numeric",
  "lazy_static",
- "libc",
  "libloading",
  "memmap2",
  "nom",
@@ -954,10 +932,8 @@ version = "0.6.11-a1"
 dependencies = [
  "cfg-if",
  "clap",
- "csv",
  "memmap2",
  "sudachi",
- "time",
 ]
 
 [[package]]
@@ -1037,37 +1013,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +592,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +657,12 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -913,6 +934,7 @@ dependencies = [
  "join_katakana_oov",
  "join_numeric",
  "lazy_static",
+ "libc",
  "libloading",
  "memmap2",
  "nom",
@@ -932,8 +954,10 @@ version = "0.6.11-a1"
 dependencies = [
  "cfg-if",
  "clap",
+ "csv",
  "memmap2",
  "sudachi",
+ "time",
 ]
 
 [[package]]
@@ -1013,6 +1037,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,14 @@ Also check [rust changelog](../CHANGELOG.md).
 
 ## [Unreleased]
 
+### Added
+
+- Add `Morpheme.dictionary_form_morpheme()` and `Morpheme.normalized_form_morpheme()`.
+
+### Fixed
+
+- Preserve standalone form-morpheme split behavior when Python wraps Rust form entries.
+
 ## [0.6.10](https://github.com/WorksApplications/sudachi.rs/releases/tag/v0.6.10) (2025-01-10)
 
 - Add support for py3.13t (free thread) (#293, #295)

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,10 @@ Also check [rust changelog](../CHANGELOG.md).
 
 ## [Unreleased]
 
+### Added
+
+- Add `Morpheme.dictionary_form_morpheme()` and `Morpheme.normalized_form_morpheme()`.
+
 ## [0.6.10](https://github.com/WorksApplications/sudachi.rs/releases/tag/v0.6.10) (2025-01-10)
 
 - Add support for py3.13t (free thread) (#293, #295)

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,10 +6,6 @@ Also check [rust changelog](../CHANGELOG.md).
 
 ## [Unreleased]
 
-### Added
-
-- Add `Morpheme.dictionary_form_morpheme()` and `Morpheme.normalized_form_morpheme()`.
-
 ## [0.6.10](https://github.com/WorksApplications/sudachi.rs/releases/tag/v0.6.10) (2025-01-10)
 
 - Add support for py3.13t (free thread) (#293, #295)

--- a/python/py_src/sudachipy/sudachipy.pyi
+++ b/python/py_src/sudachipy/sudachipy.pyi
@@ -192,6 +192,12 @@ class Morpheme:
         """
         ...
 
+    def dictionary_form_morpheme(self) -> Morpheme:
+        """
+        Returns the morpheme corresponding to this morpheme's dictionary form.
+        """
+        ...
+
     def dictionary_id(self) -> int:
         """
         Returns the dictionary id which this word belongs.
@@ -213,6 +219,12 @@ class Morpheme:
     def normalized_form(self) -> str:
         """
         Returns the normalized form.
+        """
+        ...
+
+    def normalized_form_morpheme(self) -> Morpheme:
+        """
+        Returns the morpheme corresponding to this morpheme's normalized form.
         """
         ...
 

--- a/python/src/build.rs
+++ b/python/src/build.rs
@@ -24,7 +24,7 @@ use pyo3::types::{PyBytes, PyList, PyString, PyType};
 use sudachi::config::Config;
 use sudachi::dic::build::{DataSource, DictBuilder};
 use sudachi::dic::dictionary::JapaneseDictionary;
-use sudachi::dic::DictionaryAccess;
+use sudachi::dic::{DictionaryAccess, ReferenceIdAccess};
 
 use crate::dictionary::get_default_resource_dir;
 use crate::errors;
@@ -35,7 +35,10 @@ pub fn register_functions(m: &Bound<PyModule>) -> PyResult<()> {
     Ok(())
 }
 
-fn to_stats<T: DictionaryAccess>(py: Python, builder: DictBuilder<T>) -> PyResult<Bound<PyList>> {
+fn to_stats<T: DictionaryAccess + ReferenceIdAccess>(
+    py: Python,
+    builder: DictBuilder<T>,
+) -> PyResult<Bound<PyList>> {
     let stats = PyList::empty(py);
 
     for p in builder.report() {

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -407,10 +407,12 @@ impl PyDictionary {
             }
         };
 
+        let dict = self.dictionary.clone().unwrap();
+        let projection = dict.projection.clone();
         // this needs to be a variable
         let mut borrow = l.try_borrow_mut();
         let out_list = match borrow {
-            Ok(ref mut ms) => ms.internal_mut(py),
+            Ok(ref mut ms) => ms.replace_with_empty_list(dict, projection)?,
             Err(_) => return errors::wrap(Err("out was used twice at the same time")),
         };
 

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -331,7 +331,7 @@ impl PyMorpheme {
 
         let mut form_list = MorphemeList::empty(dict);
         errors::wrap_ctx(
-            form_list.lookup_word_id(form_word_id, InfoSubset::all()),
+            form_list.reset_with_word_id(form_word_id, InfoSubset::all()),
             context,
         )?;
 
@@ -409,7 +409,10 @@ impl PyMorpheme {
 
     /// Returns the morpheme corresponding to this morpheme's dictionary form.
     ///
-    /// If this morpheme is out-of-vocabulary, returns a morpheme equivalent to ``self``.
+    /// For out-of-vocabulary morphemes, invalid references, and references to
+    /// the same dictionary entry, returns a morpheme equivalent to ``self``.
+    /// For a distinct referenced entry, returns a standalone morpheme whose
+    /// begin/end offsets are ``0..len(surface)``.
     #[pyo3(text_signature = "(self, /) -> Morpheme")]
     fn dictionary_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<PyMorpheme> {
         self.form_morpheme(
@@ -428,7 +431,10 @@ impl PyMorpheme {
 
     /// Returns the morpheme corresponding to this morpheme's normalized form.
     ///
-    /// If this morpheme is out-of-vocabulary, returns a morpheme equivalent to ``self``.
+    /// For out-of-vocabulary morphemes, invalid references, and references to
+    /// the same dictionary entry, returns a morpheme equivalent to ``self``.
+    /// For a distinct referenced entry, returns a standalone morpheme whose
+    /// begin/end offsets are ``0..len(surface)``.
     #[pyo3(text_signature = "(self, /) -> Morpheme")]
     fn normalized_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<PyMorpheme> {
         self.form_morpheme(

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -318,7 +318,9 @@ impl PyMorpheme {
                     list.projection.clone(),
                     morpheme.word_id(),
                 ),
-                _ => unreachable!("unhandled Rust morpheme reference variant"),
+                _ => {
+                    return errors::wrap(Err("unsupported Rust morpheme reference variant"));
+                }
             }
         };
 

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -280,13 +280,20 @@ impl PyMorpheme {
         )
     }
 
+    fn self_equivalent(&self, py: Python<'_>) -> PyMorpheme {
+        PyMorpheme {
+            list: self.list.clone_ref(py),
+            index: self.index,
+        }
+    }
+
     fn form_morpheme<'py, F>(
         &'py self,
         py: Python<'py>,
         subset: InfoSubset,
         form_word_id: F,
         context: &str,
-    ) -> PyResult<Option<PyMorpheme>>
+    ) -> PyResult<PyMorpheme>
     where
         F: FnOnce(&WordInfoData) -> WordId,
     {
@@ -296,7 +303,7 @@ impl PyMorpheme {
             let word_id = internal.get(self.index).word_id();
 
             if word_id.is_oov() || word_id.is_special() {
-                return Ok(None);
+                return Ok(self.self_equivalent(py));
             }
 
             let word_info = errors::wrap_ctx(
@@ -307,8 +314,12 @@ impl PyMorpheme {
                 context,
             )?;
             let form_word_id = form_word_id(word_info.borrow_data());
-            if form_word_id.is_oov() || form_word_id.is_special() {
-                return Ok(None);
+            if form_word_id == WordId::INVALID
+                || form_word_id == word_id
+                || form_word_id.is_oov()
+                || form_word_id.is_special()
+            {
+                return Ok(self.self_equivalent(py));
             }
 
             (
@@ -328,10 +339,10 @@ impl PyMorpheme {
             py,
             PyMorphemeListWrapper::from_components(form_list, projection),
         )?;
-        Ok(Some(PyMorpheme {
+        Ok(PyMorpheme {
             list: py_list,
             index: 0,
-        }))
+        })
     }
 }
 
@@ -398,9 +409,9 @@ impl PyMorpheme {
 
     /// Returns the morpheme corresponding to this morpheme's dictionary form.
     ///
-    /// If this morpheme is out-of-vocabulary, returns ``None``.
-    #[pyo3(text_signature = "(self, /) -> Morpheme | None")]
-    fn dictionary_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<Option<PyMorpheme>> {
+    /// If this morpheme is out-of-vocabulary, returns a morpheme equivalent to ``self``.
+    #[pyo3(text_signature = "(self, /) -> Morpheme")]
+    fn dictionary_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<PyMorpheme> {
         self.form_morpheme(
             py,
             InfoSubset::DICTIONARY_FORM,
@@ -417,9 +428,9 @@ impl PyMorpheme {
 
     /// Returns the morpheme corresponding to this morpheme's normalized form.
     ///
-    /// If this morpheme is out-of-vocabulary, returns ``None``.
-    #[pyo3(text_signature = "(self, /) -> Morpheme | None")]
-    fn normalized_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<Option<PyMorpheme>> {
+    /// If this morpheme is out-of-vocabulary, returns a morpheme equivalent to ``self``.
+    #[pyo3(text_signature = "(self, /) -> Morpheme")]
+    fn normalized_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<PyMorpheme> {
         self.form_morpheme(
             py,
             InfoSubset::NORMALIZED_FORM,

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -24,10 +24,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyList, PyString, PyTuple, PyType};
 
 use sudachi::dic::subset::InfoSubset;
-use sudachi::dic::word_id::WordId;
-use sudachi::dic::word_info::WordInfoData;
-use sudachi::dic::LexiconAccess;
-use sudachi::prelude::{Morpheme, MorphemeList};
+use sudachi::prelude::{MorphemeList, MorphemeListItem, MorphemeRef as RustMorphemeRef};
 
 use crate::dictionary::{extract_mode, PyDicData, PyDictionary};
 use crate::errors;
@@ -233,14 +230,14 @@ impl PyMorphemeIter {
 
 /// It is a syntax sugar for accessing Morpheme reference
 /// Without it binding implementations become much less readable
-struct MorphemeRef<'py> {
+struct MorphemeListItemRef<'py> {
     #[allow(unused)] // need to keep this around for correct reference count
     list: PyRef<'py, PyMorphemeListWrapper>,
-    morph: Morpheme<'py, Arc<PyDicData>>,
+    morph: MorphemeListItem<'py, Arc<PyDicData>>,
 }
 
-impl<'py> Deref for MorphemeRef<'py> {
-    type Target = Morpheme<'py, Arc<PyDicData>>;
+impl<'py> Deref for MorphemeListItemRef<'py> {
+    type Target = MorphemeListItem<'py, Arc<PyDicData>>;
 
     fn deref(&self) -> &Self::Target {
         &self.morph
@@ -254,16 +251,22 @@ pub struct PyMorpheme {
     index: usize,
 }
 
+#[derive(Clone, Copy)]
+enum FormMorphemeKind {
+    Dictionary,
+    Normalized,
+}
+
 impl PyMorpheme {
     fn list<'py>(&'py self, py: Python<'py>) -> PyRef<'py, PyMorphemeListWrapper> {
         self.list.borrow(py)
     }
 
-    fn morph<'py>(&'py self, py: Python<'py>) -> MorphemeRef<'py> {
+    fn morph<'py>(&'py self, py: Python<'py>) -> MorphemeListItemRef<'py> {
         let list = self.list(py);
         // workaround for self-referential structs
         let morph = unsafe { std::mem::transmute(list.internal(py).get(self.index)) };
-        MorphemeRef { list, morph }
+        MorphemeListItemRef { list, morph }
     }
 
     fn write_repr<'py, W: Write>(&'py self, py: Python<'py>, out: &mut W) -> std::fmt::Result {
@@ -287,46 +290,29 @@ impl PyMorpheme {
         }
     }
 
-    fn form_morpheme<'py, F>(
+    fn form_morpheme<'py>(
         &'py self,
         py: Python<'py>,
-        subset: InfoSubset,
-        form_word_id: F,
+        kind: FormMorphemeKind,
         context: &str,
-    ) -> PyResult<PyMorpheme>
-    where
-        F: FnOnce(&WordInfoData) -> WordId,
-    {
+    ) -> PyResult<PyMorpheme> {
         let (dict, projection, form_word_id) = {
             let list = self.list(py);
             let internal = list.internal(py);
-            let word_id = internal.get(self.index).word_id();
+            let morph = internal.get(self.index);
+            let form_morpheme = match kind {
+                FormMorphemeKind::Dictionary => morph.dictionary_form_morpheme(),
+                FormMorphemeKind::Normalized => morph.normalized_form_morpheme(),
+            };
 
-            if word_id.is_oov() || word_id.is_special() {
-                return Ok(self.self_equivalent(py));
+            match errors::wrap_ctx(form_morpheme, context)? {
+                RustMorphemeRef::ListItem(_) => return Ok(self.self_equivalent(py)),
+                RustMorphemeRef::Single(morpheme) => (
+                    internal.dict().clone(),
+                    list.projection.clone(),
+                    morpheme.word_id(),
+                ),
             }
-
-            let word_info = errors::wrap_ctx(
-                internal
-                    .dict()
-                    .lexicon()
-                    .get_word_info_subset(word_id, subset),
-                context,
-            )?;
-            let form_word_id = form_word_id(word_info.borrow_data());
-            if form_word_id == WordId::INVALID
-                || form_word_id == word_id
-                || form_word_id.is_oov()
-                || form_word_id.is_special()
-            {
-                return Ok(self.self_equivalent(py));
-            }
-
-            (
-                internal.dict().clone(),
-                list.projection.clone(),
-                form_word_id,
-            )
         };
 
         let mut form_list = MorphemeList::empty(dict);
@@ -417,8 +403,7 @@ impl PyMorpheme {
     fn dictionary_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<PyMorpheme> {
         self.form_morpheme(
             py,
-            InfoSubset::DICTIONARY_FORM,
-            WordInfoData::dictionary_form_word_id,
+            FormMorphemeKind::Dictionary,
             "Failed to load dictionary form morpheme",
         )
     }
@@ -439,8 +424,7 @@ impl PyMorpheme {
     fn normalized_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<PyMorpheme> {
         self.form_morpheme(
             py,
-            InfoSubset::NORMALIZED_FORM,
-            WordInfoData::normalized_form_word_id,
+            FormMorphemeKind::Normalized,
             "Failed to load normalized form morpheme",
         )
     }

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -24,7 +24,8 @@ use pyo3::prelude::*;
 use pyo3::types::{PyList, PyString, PyTuple, PyType};
 
 use sudachi::dic::subset::InfoSubset;
-use sudachi::prelude::{MorphemeList, MorphemeListItem, MorphemeRef as RustMorphemeRef};
+use sudachi::dic::word_id::WordId;
+use sudachi::prelude::{Morpheme, MorphemeList, MorphemeRef as RustMorphemeRef, SingleMorpheme};
 
 use crate::dictionary::{extract_mode, PyDicData, PyDictionary};
 use crate::errors;
@@ -152,6 +153,7 @@ impl PyMorphemeListWrapper {
         Ok(PyMorpheme {
             list: py_list,
             index: idx as usize,
+            standalone_word_id: None,
         })
     }
 
@@ -180,6 +182,7 @@ impl PyMorphemeListWrapper {
             let pymorph = PyMorpheme {
                 list: slf.clone_ref(py),
                 index: i,
+                standalone_word_id: None,
             };
             errors::wrap_ctx(pymorph.write_repr(py, &mut result), "format failed")?;
             result.push_str(",\n");
@@ -221,6 +224,7 @@ impl PyMorphemeIter {
         let morpheme = PyMorpheme {
             list: self.list.clone_ref(py),
             index: self.index,
+            standalone_word_id: None,
         };
 
         self.index += 1;
@@ -230,14 +234,14 @@ impl PyMorphemeIter {
 
 /// It is a syntax sugar for accessing Morpheme reference
 /// Without it binding implementations become much less readable
-struct MorphemeListItemRef<'py> {
+struct MorphemeBorrow<'py> {
     #[allow(unused)] // need to keep this around for correct reference count
     list: PyRef<'py, PyMorphemeListWrapper>,
-    morph: MorphemeListItem<'py, Arc<PyDicData>>,
+    morph: Morpheme<'py, Arc<PyDicData>>,
 }
 
-impl<'py> Deref for MorphemeListItemRef<'py> {
-    type Target = MorphemeListItem<'py, Arc<PyDicData>>;
+impl<'py> Deref for MorphemeBorrow<'py> {
+    type Target = Morpheme<'py, Arc<PyDicData>>;
 
     fn deref(&self) -> &Self::Target {
         &self.morph
@@ -249,6 +253,7 @@ impl<'py> Deref for MorphemeListItemRef<'py> {
 pub struct PyMorpheme {
     list: Py<PyMorphemeListWrapper>,
     index: usize,
+    standalone_word_id: Option<WordId>,
 }
 
 #[derive(Clone, Copy)]
@@ -262,11 +267,11 @@ impl PyMorpheme {
         self.list.borrow(py)
     }
 
-    fn morph<'py>(&'py self, py: Python<'py>) -> MorphemeListItemRef<'py> {
+    fn morph<'py>(&'py self, py: Python<'py>) -> MorphemeBorrow<'py> {
         let list = self.list(py);
         // workaround for self-referential structs
         let morph = unsafe { std::mem::transmute(list.internal(py).get(self.index)) };
-        MorphemeListItemRef { list, morph }
+        MorphemeBorrow { list, morph }
     }
 
     fn write_repr<'py, W: Write>(&'py self, py: Python<'py>, out: &mut W) -> std::fmt::Result {
@@ -287,6 +292,7 @@ impl PyMorpheme {
         PyMorpheme {
             list: self.list.clone_ref(py),
             index: self.index,
+            standalone_word_id: self.standalone_word_id,
         }
     }
 
@@ -312,6 +318,7 @@ impl PyMorpheme {
                     list.projection.clone(),
                     morpheme.word_id(),
                 ),
+                _ => unreachable!("unhandled Rust morpheme reference variant"),
             }
         };
 
@@ -328,7 +335,59 @@ impl PyMorpheme {
         Ok(PyMorpheme {
             list: py_list,
             index: 0,
+            standalone_word_id: Some(form_word_id),
         })
+    }
+
+    fn split_standalone<'py>(
+        &'py self,
+        py: Python<'py>,
+        mode: &Bound<'py, PyAny>,
+        out: Option<Bound<'py, PyMorphemeListWrapper>>,
+        add_single: Option<bool>,
+    ) -> PyResult<Bound<'py, PyMorphemeListWrapper>> {
+        let word_id = self
+            .standalone_word_id
+            .expect("split_standalone called for list-backed morpheme");
+        let mode = extract_mode(mode)?;
+        let (dict, projection, split_word_ids) = {
+            let list = self.list(py);
+            let dict = list.internal(py).dict().clone();
+            let projection = list.projection.clone();
+            let morpheme = errors::wrap_ctx(
+                SingleMorpheme::from_word_id(&dict, word_id, InfoSubset::all()),
+                "Error while splitting morpheme",
+            )?;
+            let splits = errors::wrap_ctx(morpheme.split(mode), "Error while splitting morpheme")?;
+            let no_split = splits.len() == 1 && splits[0].word_id() == word_id;
+            let split_word_ids = if add_single.unwrap_or(true) || !no_split {
+                splits.into_iter().map(|m| m.word_id()).collect()
+            } else {
+                Vec::new()
+            };
+            (dict, projection, split_word_ids)
+        };
+
+        let out_cell = match out {
+            None => Bound::new(
+                py,
+                PyMorphemeListWrapper::from_components(MorphemeList::empty(dict), projection),
+            )?,
+            Some(r) => r,
+        };
+
+        let mut borrow = out_cell.try_borrow_mut();
+        let out_ref = match borrow {
+            Ok(ref mut v) => v.internal_mut(py),
+            Err(_) => return errors::wrap(Err("out was used twice at the same time")),
+        };
+
+        errors::wrap_ctx(
+            out_ref.reset_with_word_ids(split_word_ids, InfoSubset::all()),
+            "Error while splitting morpheme",
+        )?;
+
+        Ok(out_cell)
     }
 }
 
@@ -459,6 +518,10 @@ impl PyMorpheme {
         out: Option<Bound<'py, PyMorphemeListWrapper>>,
         add_single: Option<bool>,
     ) -> PyResult<Bound<'py, PyMorphemeListWrapper>> {
+        if self.standalone_word_id.is_some() {
+            return self.split_standalone(py, mode, out, add_single);
+        }
+
         let list = self.list(py);
 
         let mode = extract_mode(mode)?;

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -23,6 +23,10 @@ use pyo3::ffi::c_str;
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PyString, PyTuple, PyType};
 
+use sudachi::dic::subset::InfoSubset;
+use sudachi::dic::word_id::WordId;
+use sudachi::dic::word_info::WordInfoData;
+use sudachi::dic::LexiconAccess;
 use sudachi::prelude::{Morpheme, MorphemeList};
 
 use crate::dictionary::{extract_mode, PyDicData, PyDictionary};
@@ -275,6 +279,60 @@ impl PyMorpheme {
             mrp.word_id()
         )
     }
+
+    fn form_morpheme<'py, F>(
+        &'py self,
+        py: Python<'py>,
+        subset: InfoSubset,
+        form_word_id: F,
+        context: &str,
+    ) -> PyResult<Option<PyMorpheme>>
+    where
+        F: FnOnce(&WordInfoData) -> WordId,
+    {
+        let (dict, projection, form_word_id) = {
+            let list = self.list(py);
+            let internal = list.internal(py);
+            let word_id = internal.get(self.index).word_id();
+
+            if word_id.is_oov() || word_id.is_special() {
+                return Ok(None);
+            }
+
+            let word_info = errors::wrap_ctx(
+                internal
+                    .dict()
+                    .lexicon()
+                    .get_word_info_subset(word_id, subset),
+                context,
+            )?;
+            let form_word_id = form_word_id(word_info.borrow_data());
+            if form_word_id.is_oov() || form_word_id.is_special() {
+                return Ok(None);
+            }
+
+            (
+                internal.dict().clone(),
+                list.projection.clone(),
+                form_word_id,
+            )
+        };
+
+        let mut form_list = MorphemeList::empty(dict);
+        errors::wrap_ctx(
+            form_list.lookup_word_id(form_word_id, InfoSubset::all()),
+            context,
+        )?;
+
+        let py_list = Py::new(
+            py,
+            PyMorphemeListWrapper::from_components(form_list, projection),
+        )?;
+        Ok(Some(PyMorpheme {
+            list: py_list,
+            index: 0,
+        }))
+    }
 }
 
 #[pymethods]
@@ -338,10 +396,36 @@ impl PyMorpheme {
         Ok(self.morph(py).dictionary_form().into_pyobject(py)?)
     }
 
+    /// Returns the morpheme corresponding to this morpheme's dictionary form.
+    ///
+    /// If this morpheme is out-of-vocabulary, returns ``None``.
+    #[pyo3(text_signature = "(self, /) -> Morpheme | None")]
+    fn dictionary_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<Option<PyMorpheme>> {
+        self.form_morpheme(
+            py,
+            InfoSubset::DICTIONARY_FORM,
+            WordInfoData::dictionary_form_word_id,
+            "Failed to load dictionary form morpheme",
+        )
+    }
+
     /// Returns the normalized form.
     #[pyo3(text_signature = "(self, /) -> str")]
     fn normalized_form<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyString>> {
         Ok(self.morph(py).normalized_form().into_pyobject(py)?)
+    }
+
+    /// Returns the morpheme corresponding to this morpheme's normalized form.
+    ///
+    /// If this morpheme is out-of-vocabulary, returns ``None``.
+    #[pyo3(text_signature = "(self, /) -> Morpheme | None")]
+    fn normalized_form_morpheme<'py>(&'py self, py: Python<'py>) -> PyResult<Option<PyMorpheme>> {
+        self.form_morpheme(
+            py,
+            InfoSubset::NORMALIZED_FORM,
+            WordInfoData::normalized_form_word_id,
+            "Failed to load normalized form morpheme",
+        )
     }
 
     /// Returns the reading form.

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -511,7 +511,13 @@ impl PyMorpheme {
         match out {
             None => Bound::new(py, PyMorphemeListWrapper::from_singles(splits, projection)),
             Some(cell) => {
-                cell.borrow_mut().replace_with_singles(splits, projection);
+                {
+                    let mut wrapper = match cell.try_borrow_mut() {
+                        Ok(wrapper) => wrapper,
+                        Err(_) => return errors::wrap(Err("out was used twice at the same time")),
+                    };
+                    wrapper.replace_with_singles(splits, projection);
+                }
                 Ok(cell)
             }
         }

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -23,9 +23,9 @@ use pyo3::ffi::c_str;
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PyString, PyTuple, PyType};
 
-use sudachi::dic::subset::InfoSubset;
-use sudachi::dic::word_id::WordId;
-use sudachi::prelude::{Morpheme, MorphemeList, MorphemeRef as RustMorphemeRef, SingleMorpheme};
+use sudachi::prelude::{
+    Morpheme, MorphemeList, MorphemeRef as RustMorphemeRef, MorphemeView, SingleMorpheme,
+};
 
 use crate::dictionary::{extract_mode, PyDicData, PyDictionary};
 use crate::errors;
@@ -33,14 +33,18 @@ use crate::projection::{MorphemeProjection, PyProjector};
 
 pub(crate) type PyMorphemeList = MorphemeList<Arc<PyDicData>>;
 
+enum PyMorphemeListBacking {
+    List(PyMorphemeList),
+    Singles(Vec<SingleMorpheme<Arc<PyDicData>>>),
+}
+
 /// A list of morphemes.
 ///
 /// An object can not be instantiated manually.
 /// Use Tokenizer.tokenize("") to create an empty morpheme list.
 #[pyclass(module = "sudachipy.morphemelist", name = "MorphemeList")]
 pub struct PyMorphemeListWrapper {
-    /// use `internal()` function instead
-    inner: PyMorphemeList,
+    inner: PyMorphemeListBacking,
     projection: PyProjector,
 }
 
@@ -53,14 +57,24 @@ impl PyMorphemeListWrapper {
     pub(crate) fn new(dict: Arc<PyDicData>) -> Self {
         let proj = dict.projection.clone();
         Self {
-            inner: PyMorphemeList::empty(dict),
+            inner: PyMorphemeListBacking::List(PyMorphemeList::empty(dict)),
             projection: proj,
         }
     }
 
     pub(crate) fn from_components(list: PyMorphemeList, projection: PyProjector) -> Self {
         Self {
-            inner: list,
+            inner: PyMorphemeListBacking::List(list),
+            projection,
+        }
+    }
+
+    pub(crate) fn from_singles(
+        singles: Vec<SingleMorpheme<Arc<PyDicData>>>,
+        projection: PyProjector,
+    ) -> Self {
+        Self {
+            inner: PyMorphemeListBacking::Singles(singles),
             projection,
         }
     }
@@ -72,23 +86,49 @@ impl PyMorphemeListWrapper {
         }
     }
 
-    /// Borrow internals mutable. GIL token proves access.
-    pub(crate) fn internal_mut(&mut self, _py: Python) -> &mut PyMorphemeList {
-        &mut self.inner
-    }
-
-    /// Borrow internals immutable. GIL token proves access.
-    #[inline]
-    pub(crate) fn internal(&self, _py: Python) -> &PyMorphemeList {
-        &self.inner
-    }
-
-    /// Create a copy with empty list of Nodes. GIL token proves access.
-    pub(crate) fn empty_clone(&self, _py: Python) -> Self {
-        Self {
-            inner: self.inner.empty_clone(),
-            projection: self.projection.clone(),
+    pub(crate) fn as_list(&self) -> PyResult<&PyMorphemeList> {
+        match &self.inner {
+            PyMorphemeListBacking::List(list) => Ok(list),
+            PyMorphemeListBacking::Singles(_) => errors::wrap(Err::<&PyMorphemeList, _>(
+                "expected analyzed MorphemeList, got standalone morphemes",
+            )),
         }
+    }
+
+    pub(crate) fn replace_with_empty_list(
+        &mut self,
+        dict: Arc<PyDicData>,
+        projection: PyProjector,
+    ) -> PyResult<&mut PyMorphemeList> {
+        self.projection = projection;
+        self.inner = PyMorphemeListBacking::List(PyMorphemeList::empty(dict));
+
+        match &mut self.inner {
+            PyMorphemeListBacking::List(list) => Ok(list),
+            PyMorphemeListBacking::Singles(_) => errors::wrap(Err::<&mut PyMorphemeList, _>(
+                "failed to install analyzed MorphemeList backing",
+            )),
+        }
+    }
+
+    pub(crate) fn replace_with_singles(
+        &mut self,
+        singles: Vec<SingleMorpheme<Arc<PyDicData>>>,
+        projection: PyProjector,
+    ) {
+        self.projection = projection;
+        self.inner = PyMorphemeListBacking::Singles(singles);
+    }
+
+    fn len_internal(&self) -> usize {
+        match &self.inner {
+            PyMorphemeListBacking::List(list) => list.len(),
+            PyMorphemeListBacking::Singles(items) => items.len(),
+        }
+    }
+
+    fn is_empty_internal(&self) -> bool {
+        self.len_internal() == 0
     }
 }
 
@@ -109,21 +149,26 @@ impl PyMorphemeListWrapper {
         let cloned = dict.dictionary.as_ref().unwrap().clone();
         let proj = cloned.projection.clone();
         Ok(Self {
-            inner: PyMorphemeList::empty(cloned),
+            inner: PyMorphemeListBacking::List(PyMorphemeList::empty(cloned)),
             projection: proj,
         })
     }
 
     /// Returns the total cost of the path.
     #[pyo3(text_signature = "(self, /) -> int")]
-    fn get_internal_cost(&self, py: Python) -> i32 {
-        self.internal(py).get_internal_cost()
+    fn get_internal_cost(&self, _py: Python) -> PyResult<i32> {
+        match &self.inner {
+            PyMorphemeListBacking::List(list) => Ok(list.get_internal_cost()),
+            PyMorphemeListBacking::Singles(_) => errors::wrap(Err(
+                "standalone morpheme lists do not have a lattice path cost",
+            )),
+        }
     }
 
     /// Returns the number of morpheme in this list.
     #[pyo3(text_signature = "(self, /) -> int")]
-    fn size(&self, py: Python) -> usize {
-        self.internal(py).len()
+    fn size(&self, _py: Python) -> usize {
+        self.len_internal()
     }
 
     fn __len__(&self, py: Python) -> usize {
@@ -131,41 +176,60 @@ impl PyMorphemeListWrapper {
     }
 
     fn __getitem__(slf: Bound<PyMorphemeListWrapper>, mut idx: isize) -> PyResult<PyMorpheme> {
-        let list = slf.borrow();
-        let py = slf.py();
-        let len = list.size(py) as isize;
-
-        if idx < 0 {
-            // negative indexing
-            idx += len;
+        enum Item {
+            List(usize),
+            Single(SingleMorpheme<Arc<PyDicData>>, PyProjector),
         }
 
-        if idx < 0 || len <= idx {
-            return Err(PyIndexError::new_err(format!(
-                "MorphemeList index out of range: the len is {} but the index is {}",
-                list.size(py),
-                idx
-            )));
+        let item = {
+            let list = slf.borrow();
+            let len = list.len_internal() as isize;
+
+            if idx < 0 {
+                // negative indexing
+                idx += len;
+            }
+
+            if idx < 0 || len <= idx {
+                return Err(PyIndexError::new_err(format!(
+                    "MorphemeList index out of range: the len is {} but the index is {}",
+                    len, idx
+                )));
+            }
+
+            let idx = idx as usize;
+            match &list.inner {
+                PyMorphemeListBacking::List(_) => Item::List(idx),
+                PyMorphemeListBacking::Singles(items) => {
+                    Item::Single(items[idx].clone(), list.projection.clone())
+                }
+            }
+        };
+
+        match item {
+            Item::List(idx) => {
+                let py_list: Py<PyMorphemeListWrapper> = slf.into();
+                Ok(PyMorpheme::list_backed(py_list, idx))
+            }
+            Item::Single(morpheme, projection) => {
+                Ok(PyMorpheme::single_backed(morpheme, projection))
+            }
         }
-
-        let py_list: Py<PyMorphemeListWrapper> = slf.into();
-
-        Ok(PyMorpheme {
-            list: py_list,
-            index: idx as usize,
-            standalone_word_id: None,
-        })
     }
 
     fn __str__<'py>(&'py self, py: Python<'py>) -> Bound<'py, PyString> {
-        // do a simple tokenization __str__
-        let list = self.internal(py);
-        let mut result = String::with_capacity(list.surface().len() * 2);
-        let nmorphs = list.len();
-        for (i, m) in list.iter().enumerate() {
-            result.push_str(m.surface().deref());
-            if i + 1 != nmorphs {
+        let mut result = String::new();
+        for i in 0..self.len_internal() {
+            if i > 0 {
                 result.push(' ');
+            }
+            match &self.inner {
+                PyMorphemeListBacking::List(list) => {
+                    result.push_str(list.get(i).surface().deref());
+                }
+                PyMorphemeListBacking::Singles(items) => {
+                    result.push_str(items[i].surface());
+                }
             }
         }
         PyString::new(py, result.as_str())
@@ -173,18 +237,18 @@ impl PyMorphemeListWrapper {
 
     fn __repr__(slf: Py<PyMorphemeListWrapper>, py: Python) -> PyResult<Bound<PyString>> {
         let self_ref = slf.borrow(py);
-        let list = self_ref.internal(py);
-        let mut result = String::with_capacity(list.surface().len() * 10);
+        let mut result = String::new();
         result.push_str("<MorphemeList[\n");
-        let nmorphs = list.len();
+        let nmorphs = self_ref.len_internal();
         for i in 0..nmorphs {
             result.push_str("  ");
-            let pymorph = PyMorpheme {
-                list: slf.clone_ref(py),
-                index: i,
-                standalone_word_id: None,
+            let pymorph = match &self_ref.inner {
+                PyMorphemeListBacking::List(_) => PyMorpheme::list_backed(slf.clone_ref(py), i),
+                PyMorphemeListBacking::Singles(items) => {
+                    PyMorpheme::single_backed(items[i].clone(), self_ref.projection.clone())
+                }
             };
-            errors::wrap_ctx(pymorph.write_repr(py, &mut result), "format failed")?;
+            pymorph.write_repr(py, &mut result)?;
             result.push_str(",\n");
         }
         result.push_str("]>");
@@ -198,8 +262,8 @@ impl PyMorphemeListWrapper {
         }
     }
 
-    fn __bool__(&self, py: Python) -> bool {
-        !self.internal(py).is_empty()
+    fn __bool__(&self, _py: Python) -> bool {
+        !self.is_empty_internal()
     }
 }
 
@@ -217,18 +281,32 @@ impl PyMorphemeIter {
     }
 
     fn __next__(&mut self, py: Python) -> Option<PyMorpheme> {
-        if self.index >= self.list.borrow(py).size(py) {
-            return None;
+        enum Item {
+            List(usize),
+            Single(SingleMorpheme<Arc<PyDicData>>, PyProjector),
         }
 
-        let morpheme = PyMorpheme {
-            list: self.list.clone_ref(py),
-            index: self.index,
-            standalone_word_id: None,
+        let item = {
+            let list = self.list.borrow(py);
+            if self.index >= list.len_internal() {
+                return None;
+            }
+
+            match &list.inner {
+                PyMorphemeListBacking::List(_) => Item::List(self.index),
+                PyMorphemeListBacking::Singles(items) => {
+                    Item::Single(items[self.index].clone(), list.projection.clone())
+                }
+            }
         };
 
         self.index += 1;
-        Some(morpheme)
+        match item {
+            Item::List(index) => Some(PyMorpheme::list_backed(self.list.clone_ref(py), index)),
+            Item::Single(morpheme, projection) => {
+                Some(PyMorpheme::single_backed(morpheme, projection))
+            }
+        }
     }
 }
 
@@ -248,12 +326,21 @@ impl<'py> Deref for MorphemeBorrow<'py> {
     }
 }
 
+enum PyMorphemeBacking {
+    List {
+        list: Py<PyMorphemeListWrapper>,
+        index: usize,
+    },
+    Single {
+        morpheme: SingleMorpheme<Arc<PyDicData>>,
+        projection: PyProjector,
+    },
+}
+
 /// A morpheme (basic semantic unit of language).
 #[pyclass(module = "sudachipy.morpheme", name = "Morpheme", frozen)]
 pub struct PyMorpheme {
-    list: Py<PyMorphemeListWrapper>,
-    index: usize,
-    standalone_word_id: Option<WordId>,
+    backing: PyMorphemeBacking,
 }
 
 #[derive(Clone, Copy)]
@@ -263,36 +350,87 @@ enum FormMorphemeKind {
 }
 
 impl PyMorpheme {
-    fn list<'py>(&'py self, py: Python<'py>) -> PyRef<'py, PyMorphemeListWrapper> {
-        self.list.borrow(py)
+    fn list_backed(list: Py<PyMorphemeListWrapper>, index: usize) -> Self {
+        Self {
+            backing: PyMorphemeBacking::List { list, index },
+        }
     }
 
-    fn morph<'py>(&'py self, py: Python<'py>) -> MorphemeBorrow<'py> {
-        let list = self.list(py);
+    fn single_backed(morpheme: SingleMorpheme<Arc<PyDicData>>, projection: PyProjector) -> Self {
+        Self {
+            backing: PyMorphemeBacking::Single {
+                morpheme,
+                projection,
+            },
+        }
+    }
+
+    fn borrow_morpheme<'py>(
+        list: &'py Py<PyMorphemeListWrapper>,
+        py: Python<'py>,
+        index: usize,
+    ) -> PyResult<MorphemeBorrow<'py>> {
+        let list = list.borrow(py);
         // workaround for self-referential structs
-        let morph = unsafe { std::mem::transmute(list.internal(py).get(self.index)) };
-        MorphemeBorrow { list, morph }
+        let morph = unsafe { std::mem::transmute(list.as_list()?.get(index)) };
+        Ok(MorphemeBorrow { list, morph })
     }
 
-    fn write_repr<'py, W: Write>(&'py self, py: Python<'py>, out: &mut W) -> std::fmt::Result {
+    fn write_repr<'py, W: Write>(&'py self, py: Python<'py>, out: &mut W) -> PyResult<()> {
         // per https://github.com/WorksApplications/SudachiPy/pull/166#issuecomment-932043063
-        let mrp = self.morph(py);
-        let surf = mrp.surface();
-        write!(
-            out,
-            "<Morpheme({}, {}:{}, {})>",
-            surf.deref(),
-            mrp.begin_c(),
-            mrp.end_c(),
-            mrp.word_id()
-        )
+        match &self.backing {
+            PyMorphemeBacking::List { list, index } => {
+                let mrp = Self::borrow_morpheme(list, py, *index)?;
+                let surf = mrp.surface();
+                errors::wrap_ctx(
+                    write!(
+                        out,
+                        "<Morpheme({}, {}:{}, {})>",
+                        surf.deref(),
+                        mrp.begin_c(),
+                        mrp.end_c(),
+                        mrp.word_id()
+                    ),
+                    "format failed",
+                )
+            }
+            PyMorphemeBacking::Single { morpheme, .. } => errors::wrap_ctx(
+                write!(
+                    out,
+                    "<Morpheme({}, {}:{}, {})>",
+                    morpheme.surface(),
+                    morpheme.begin_c(),
+                    morpheme.end_c(),
+                    morpheme.word_id()
+                ),
+                "format failed",
+            ),
+        }
     }
 
     fn self_equivalent(&self, py: Python<'_>) -> PyMorpheme {
-        PyMorpheme {
-            list: self.list.clone_ref(py),
-            index: self.index,
-            standalone_word_id: self.standalone_word_id,
+        match &self.backing {
+            PyMorphemeBacking::List { list, index } => {
+                PyMorpheme::list_backed(list.clone_ref(py), *index)
+            }
+            PyMorphemeBacking::Single {
+                morpheme,
+                projection,
+            } => PyMorpheme::single_backed(morpheme.clone(), projection.clone()),
+        }
+    }
+
+    fn with_morpheme<'py, R>(
+        &'py self,
+        py: Python<'py>,
+        f: impl for<'m> FnOnce(&'m dyn MorphemeView<Dictionary = Arc<PyDicData>>) -> R,
+    ) -> PyResult<R> {
+        match &self.backing {
+            PyMorphemeBacking::List { list, index } => {
+                let mrp = Self::borrow_morpheme(list, py, *index)?;
+                Ok(f(mrp.deref()))
+            }
+            PyMorphemeBacking::Single { morpheme, .. } => Ok(f(morpheme)),
         }
     }
 
@@ -302,94 +440,143 @@ impl PyMorpheme {
         kind: FormMorphemeKind,
         context: &str,
     ) -> PyResult<PyMorpheme> {
-        let (dict, projection, form_word_id) = {
-            let list = self.list(py);
-            let internal = list.internal(py);
-            let morph = internal.get(self.index);
-            let form_morpheme = match kind {
-                FormMorphemeKind::Dictionary => morph.dictionary_form_morpheme(),
-                FormMorphemeKind::Normalized => morph.normalized_form_morpheme(),
-            };
+        match &self.backing {
+            PyMorphemeBacking::List { list, index } => {
+                let morph = Self::borrow_morpheme(list, py, *index)?;
+                let form_morpheme = match kind {
+                    FormMorphemeKind::Dictionary => morph.dictionary_form_morpheme(),
+                    FormMorphemeKind::Normalized => morph.normalized_form_morpheme(),
+                };
 
-            match errors::wrap_ctx(form_morpheme, context)? {
-                RustMorphemeRef::ListItem(_) => return Ok(self.self_equivalent(py)),
-                RustMorphemeRef::Single(morpheme) => (
-                    internal.dict().clone(),
-                    list.projection.clone(),
-                    morpheme.word_id(),
-                ),
-                _ => {
-                    return errors::wrap(Err("unsupported Rust morpheme reference variant"));
+                match errors::wrap_ctx(form_morpheme, context)? {
+                    RustMorphemeRef::ListItem(_) => Ok(self.self_equivalent(py)),
+                    RustMorphemeRef::Single(morpheme) => Ok(PyMorpheme::single_backed(
+                        *morpheme,
+                        morph.list.projection.clone(),
+                    )),
+                    _ => errors::wrap(Err("unsupported Rust morpheme reference variant; \
+                         sudachipy bindings are out of sync with sudachi core")),
                 }
             }
-        };
+            PyMorphemeBacking::Single {
+                morpheme,
+                projection,
+            } => {
+                let form_morpheme = match kind {
+                    FormMorphemeKind::Dictionary => morpheme.dictionary_form_morpheme(),
+                    FormMorphemeKind::Normalized => morpheme.normalized_form_morpheme(),
+                };
 
-        let mut form_list = MorphemeList::empty(dict);
-        errors::wrap_ctx(
-            form_list.reset_with_word_id(form_word_id, InfoSubset::all()),
-            context,
-        )?;
-
-        let py_list = Py::new(
-            py,
-            PyMorphemeListWrapper::from_components(form_list, projection),
-        )?;
-        Ok(PyMorpheme {
-            list: py_list,
-            index: 0,
-            standalone_word_id: Some(form_word_id),
-        })
+                match errors::wrap_ctx(form_morpheme, context)? {
+                    RustMorphemeRef::Single(morpheme) => {
+                        Ok(PyMorpheme::single_backed(*morpheme, projection.clone()))
+                    }
+                    RustMorphemeRef::ListItem(_) => Ok(self.self_equivalent(py)),
+                    _ => errors::wrap(Err("unsupported Rust morpheme reference variant; \
+                         sudachipy bindings are out of sync with sudachi core")),
+                }
+            }
+        }
     }
 
-    fn split_standalone<'py>(
+    fn split_single_backed<'py>(
         &'py self,
         py: Python<'py>,
         mode: &Bound<'py, PyAny>,
         out: Option<Bound<'py, PyMorphemeListWrapper>>,
         add_single: Option<bool>,
     ) -> PyResult<Bound<'py, PyMorphemeListWrapper>> {
-        let word_id = self
-            .standalone_word_id
-            .expect("split_standalone called for list-backed morpheme");
         let mode = extract_mode(mode)?;
-        let (dict, projection, split_word_ids) = {
-            let list = self.list(py);
-            let dict = list.internal(py).dict().clone();
-            let projection = list.projection.clone();
-            let morpheme = errors::wrap_ctx(
-                SingleMorpheme::from_word_id(&dict, word_id, InfoSubset::all()),
-                "Error while splitting morpheme",
-            )?;
-            let splits = errors::wrap_ctx(morpheme.split(mode), "Error while splitting morpheme")?;
-            let no_split = splits.len() == 1 && splits[0].word_id() == word_id;
-            let split_word_ids = if add_single.unwrap_or(true) || !no_split {
-                splits.into_iter().map(|m| m.word_id()).collect()
-            } else {
-                Vec::new()
-            };
-            (dict, projection, split_word_ids)
+
+        let (splits, projection) = match &self.backing {
+            PyMorphemeBacking::Single {
+                morpheme,
+                projection,
+            } => {
+                let splits =
+                    errors::wrap_ctx(morpheme.split(mode), "Error while splitting morpheme")?;
+                let no_split = splits.len() == 1 && splits[0].word_id() == morpheme.word_id();
+                let splits = if add_single.unwrap_or(true) || !no_split {
+                    splits
+                } else {
+                    Vec::new()
+                };
+                (splits, projection.clone())
+            }
+            PyMorphemeBacking::List { .. } => {
+                return errors::wrap(Err("split_single_backed called for list-backed morpheme"));
+            }
         };
+
+        match out {
+            None => Bound::new(py, PyMorphemeListWrapper::from_singles(splits, projection)),
+            Some(cell) => {
+                cell.borrow_mut().replace_with_singles(splits, projection);
+                Ok(cell)
+            }
+        }
+    }
+
+    fn split_list_backed<'py>(
+        &'py self,
+        py: Python<'py>,
+        mode: &Bound<'py, PyAny>,
+        out: Option<Bound<'py, PyMorphemeListWrapper>>,
+        add_single: Option<bool>,
+    ) -> PyResult<Bound<'py, PyMorphemeListWrapper>> {
+        let mode = extract_mode(mode)?;
+        let (list_py, index) = match &self.backing {
+            PyMorphemeBacking::List { list, index } => (list.clone_ref(py), *index),
+            PyMorphemeBacking::Single { .. } => {
+                return errors::wrap(Err("split_list_backed called for single-backed morpheme"));
+            }
+        };
+
+        let list_ref = list_py.borrow(py);
+        let source_list = list_ref.as_list()?;
+        let dict = source_list.dict().clone();
+        let projection = list_ref.projection.clone();
 
         let out_cell = match out {
             None => Bound::new(
                 py,
-                PyMorphemeListWrapper::from_components(MorphemeList::empty(dict), projection),
+                PyMorphemeListWrapper::from_components(
+                    MorphemeList::empty(dict.clone()),
+                    projection.clone(),
+                ),
             )?,
-            Some(r) => r,
+            Some(cell) => cell,
         };
 
         let mut borrow = out_cell.try_borrow_mut();
         let out_ref = match borrow {
-            Ok(ref mut v) => v.internal_mut(py),
+            Ok(ref mut v) => v.replace_with_empty_list(dict, projection)?,
             Err(_) => return errors::wrap(Err("out was used twice at the same time")),
         };
 
-        errors::wrap_ctx(
-            out_ref.reset_with_word_ids(split_word_ids, InfoSubset::all()),
+        out_ref.clear();
+        let splitted = errors::wrap_ctx(
+            source_list.split_into(mode, index, out_ref),
             "Error while splitting morpheme",
         )?;
 
+        if add_single.unwrap_or(true) && !splitted {
+            source_list.copy_slice(index, index + 1, out_ref);
+        }
+
         Ok(out_cell)
+    }
+
+    fn dict_pos<'py>(&'py self, py: Python<'py>, pos_id: u16) -> PyResult<Py<PyTuple>> {
+        match &self.backing {
+            PyMorphemeBacking::List { list, .. } => {
+                let list = list.borrow(py);
+                Ok(list.as_list()?.dict().pos_of(pos_id).clone_ref(py))
+            }
+            PyMorphemeBacking::Single { morpheme, .. } => {
+                Ok(MorphemeView::dict(morpheme).pos_of(pos_id).clone_ref(py))
+            }
+        }
     }
 }
 
@@ -397,28 +584,42 @@ impl PyMorpheme {
 impl PyMorpheme {
     /// Returns the begin index of this in the input text.
     #[pyo3(text_signature = "(self, /) -> int")]
-    fn begin(&self, py: Python) -> usize {
+    fn begin(&self, py: Python) -> PyResult<usize> {
         // call codepoint version
-        self.morph(py).begin_c()
+        self.with_morpheme(py, |m| m.begin_c())
     }
 
     /// Returns the end index of this in the input text.
     #[pyo3(text_signature = "(self, /) -> int")]
-    fn end(&self, py: Python) -> usize {
+    fn end(&self, py: Python) -> PyResult<usize> {
         // call codepoint version
-        self.morph(py).end_c()
+        self.with_morpheme(py, |m| m.end_c())
     }
 
     /// Returns the substring of input text corresponding to the morpheme, or a projection if one is configured.
     ///
     /// See `Config.projection`.
     #[pyo3(text_signature = "(self, /) -> str")]
-    fn surface<'py>(&'py self, py: Python<'py>) -> Bound<'py, PyString> {
-        let list = self.list(py);
-        let morph = self.morph(py);
-        match list.projection() {
-            None => PyString::new(py, morph.surface().deref()),
-            Some(proj) => proj.project(morph.deref(), py),
+    fn surface<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyString>> {
+        match &self.backing {
+            PyMorphemeBacking::List { list, index } => {
+                let morph = Self::borrow_morpheme(list, py, *index)?;
+                match morph.list.projection() {
+                    None => {
+                        let surface = morph.surface();
+                        let result = PyString::new(py, surface.deref());
+                        Ok(result)
+                    }
+                    Some(proj) => Ok(proj.project(morph.deref(), py)),
+                }
+            }
+            PyMorphemeBacking::Single {
+                morpheme,
+                projection,
+            } => match projection {
+                None => Ok(PyString::new(py, morpheme.surface())),
+                Some(proj) => Ok(proj.project(morpheme, py)),
+            },
         }
     }
 
@@ -426,32 +627,36 @@ impl PyMorpheme {
     ///
     /// See `Config.projection`.
     #[pyo3(text_signature = "(self, /) -> str")]
-    fn raw_surface<'py>(&'py self, py: Python<'py>) -> Bound<'py, PyString> {
-        PyString::new(py, self.morph(py).surface().deref())
+    fn raw_surface<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyString>> {
+        match &self.backing {
+            PyMorphemeBacking::List { list, index } => {
+                let morph = Self::borrow_morpheme(list, py, *index)?;
+                let surface = morph.surface();
+                let result = PyString::new(py, surface.deref());
+                Ok(result)
+            }
+            PyMorphemeBacking::Single { morpheme, .. } => Ok(PyString::new(py, morpheme.surface())),
+        }
     }
 
     /// Returns the part of speech as a six-element tuple.
     /// Tuple elements are four POS levels, conjugation type and conjugation form.
     #[pyo3(text_signature = "(self, /) -> tuple[str, str, str, str, str, str]")]
-    fn part_of_speech<'py>(&'py self, py: Python<'py>) -> Py<PyTuple> {
-        let pos_id = self.part_of_speech_id(py);
-        self.list(py)
-            .internal(py)
-            .dict()
-            .pos_of(pos_id)
-            .clone_ref(py)
+    fn part_of_speech<'py>(&'py self, py: Python<'py>) -> PyResult<Py<PyTuple>> {
+        let pos_id = self.part_of_speech_id(py)?;
+        self.dict_pos(py, pos_id)
     }
 
     /// Returns the id of the part of speech in the dictionary.
     #[pyo3(text_signature = "(self, /) -> int")]
-    pub fn part_of_speech_id(&self, py: Python) -> u16 {
-        self.morph(py).part_of_speech_id()
+    pub fn part_of_speech_id(&self, py: Python) -> PyResult<u16> {
+        self.with_morpheme(py, |m| m.part_of_speech_id())
     }
 
     /// Returns the dictionary form.
     #[pyo3(text_signature = "(self, /) -> str")]
     fn dictionary_form<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyString>> {
-        Ok(self.morph(py).dictionary_form().into_pyobject(py)?)
+        self.with_morpheme(py, |m| PyString::new(py, m.dictionary_form()))
     }
 
     /// Returns the morpheme corresponding to this morpheme's dictionary form.
@@ -472,7 +677,7 @@ impl PyMorpheme {
     /// Returns the normalized form.
     #[pyo3(text_signature = "(self, /) -> str")]
     fn normalized_form<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyString>> {
-        Ok(self.morph(py).normalized_form().into_pyobject(py)?)
+        self.with_morpheme(py, |m| PyString::new(py, m.normalized_form()))
     }
 
     /// Returns the morpheme corresponding to this morpheme's normalized form.
@@ -493,7 +698,7 @@ impl PyMorpheme {
     /// Returns the reading form.
     #[pyo3(text_signature = "(self, /) -> str")]
     fn reading_form<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyString>> {
-        Ok(self.morph(py).reading_form().into_pyobject(py)?)
+        self.with_morpheme(py, |m| PyString::new(py, m.reading_form()))
     }
 
     /// Returns sub-morphemes in the provided split mode.
@@ -520,86 +725,56 @@ impl PyMorpheme {
         out: Option<Bound<'py, PyMorphemeListWrapper>>,
         add_single: Option<bool>,
     ) -> PyResult<Bound<'py, PyMorphemeListWrapper>> {
-        if self.standalone_word_id.is_some() {
-            return self.split_standalone(py, mode, out, add_single);
+        match &self.backing {
+            PyMorphemeBacking::List { .. } => self.split_list_backed(py, mode, out, add_single),
+            PyMorphemeBacking::Single { .. } => self.split_single_backed(py, mode, out, add_single),
         }
-
-        let list = self.list(py);
-
-        let mode = extract_mode(mode)?;
-
-        let out_cell = match out {
-            None => {
-                let list = list.empty_clone(py);
-                Bound::new(py, list)?
-            }
-            Some(r) => r,
-        };
-
-        let mut borrow = out_cell.try_borrow_mut();
-        let out_ref = match borrow {
-            Ok(ref mut v) => v.internal_mut(py),
-            Err(_) => return errors::wrap(Err("out was used twice at the same time")),
-        };
-
-        out_ref.clear();
-        let splitted = errors::wrap_ctx(
-            list.internal(py).split_into(mode, self.index, out_ref),
-            "Error while splitting morpheme",
-        )?;
-
-        if add_single.unwrap_or(true) && !splitted {
-            list.internal(py)
-                .copy_slice(self.index, self.index + 1, out_ref);
-        }
-
-        Ok(out_cell)
     }
 
     /// Returns whether if this is out of vocabulary word.
     #[pyo3(text_signature = "(self, /) -> bool")]
-    fn is_oov(&self, py: Python) -> bool {
-        self.morph(py).is_oov()
+    fn is_oov(&self, py: Python) -> PyResult<bool> {
+        self.with_morpheme(py, |m| m.is_oov())
     }
 
     /// Returns word id of this word in the dictionary.
     #[pyo3(text_signature = "(self, /) -> int")]
-    fn word_id(&self, py: Python) -> u32 {
-        self.morph(py).word_id().as_raw()
+    fn word_id(&self, py: Python) -> PyResult<u32> {
+        self.with_morpheme(py, |m| m.word_id().as_raw())
     }
 
     /// Returns the dictionary id which this word belongs.
     #[pyo3(text_signature = "(self, /) -> int")]
-    fn dictionary_id(&self, py: Python) -> i32 {
-        let word_id = self.morph(py).word_id();
-        if word_id.is_oov() {
-            -1
-        } else {
-            word_id.dict().as_raw() as i32
-        }
+    fn dictionary_id(&self, py: Python) -> PyResult<i32> {
+        self.with_morpheme(py, |m| m.dictionary_id())
     }
 
     /// Returns the list of synonym group ids.
     #[pyo3(text_signature = "(self, /) -> List[int]")]
     fn synonym_group_ids<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
-        let mref = self.morph(py);
-        let ids = mref.get_word_info().synonym_group_ids();
-        PyList::new(py, ids)
+        match &self.backing {
+            PyMorphemeBacking::List { list, index } => {
+                let mref = Self::borrow_morpheme(list, py, *index)?;
+                PyList::new(py, mref.get_word_info().synonym_group_ids())
+            }
+            PyMorphemeBacking::Single { morpheme, .. } => {
+                PyList::new(py, morpheme.get_word_info().synonym_group_ids())
+            }
+        }
     }
 
     /// Returns morpheme length in codepoints.
-    pub fn __len__(&self, py: Python) -> usize {
-        let m = self.morph(py);
-        m.end_c() - m.begin_c()
+    pub fn __len__(&self, py: Python) -> PyResult<usize> {
+        self.with_morpheme(py, |m| m.end_c() - m.begin_c())
     }
 
-    pub fn __str__<'py>(&'py self, py: Python<'py>) -> Bound<'py, PyString> {
+    pub fn __str__<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyString>> {
         self.surface(py)
     }
 
     pub fn __repr__<'py>(&'py self, py: Python<'py>) -> PyResult<String> {
         let mut result = String::new();
-        errors::wrap_ctx(self.write_repr(py, &mut result), "failed to format repr")?;
+        self.write_repr(py, &mut result)?;
         Ok(result)
     }
 }

--- a/python/src/pos_matcher.rs
+++ b/python/src/pos_matcher.rs
@@ -132,9 +132,9 @@ impl PyPosMatcher {
     /// :return: if morpheme has matching POS.
     ///
     /// :type m: Morpheme
-    pub fn __call__<'py>(&'py self, py: Python<'py>, m: &'py PyMorpheme) -> bool {
-        let pos_id = m.part_of_speech_id(py);
-        self.matcher.matches_id(pos_id)
+    pub fn __call__<'py>(&'py self, py: Python<'py>, m: &'py PyMorpheme) -> PyResult<bool> {
+        let pos_id = m.part_of_speech_id(py)?;
+        Ok(self.matcher.matches_id(pos_id))
     }
 
     pub fn __str__(&self) -> String {

--- a/python/src/pretokenizer.rs
+++ b/python/src/pretokenizer.rs
@@ -66,10 +66,13 @@ impl PerThreadPreTokenizer {
             }
             Some(ms) => ms.borrow_mut(py),
         };
-        mlist
-            .internal_mut(py)
-            .collect_results(&mut self.tokenizer)
-            .unwrap();
+        let dict = self.tokenizer.dict_clone();
+        let projection = dict.projection.clone();
+        errors::wrap(
+            mlist
+                .replace_with_empty_list(dict, projection)?
+                .collect_results(&mut self.tokenizer),
+        )?;
         Ok(())
     }
 
@@ -146,7 +149,7 @@ impl PyPretokenizer {
         match self.handler.as_ref() {
             None => {
                 let py_ref = morphs.borrow(py);
-                let morphs = py_ref.internal(py);
+                let morphs = py_ref.as_list()?;
                 match self.projection.as_deref() {
                     None => make_result_for_surface(py, morphs, string).map(|bl| bl.into_any()),
                     Some(p) => make_result_for_projection(py, morphs, p).map(|bl| bl.into_any()),

--- a/python/src/projection.rs
+++ b/python/src/projection.rs
@@ -24,28 +24,42 @@ use pyo3::Python;
 use sudachi::config::SurfaceProjection;
 use sudachi::dic::DictionaryAccess;
 use sudachi::pos::PosMatcher;
-use sudachi::prelude::Morpheme;
+use sudachi::prelude::MorphemeListItem;
 
 use crate::dictionary::PyDicData;
 
 pub(crate) trait MorphemeProjection {
-    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString>;
+    fn project<'py>(
+        &self,
+        m: &MorphemeListItem<Arc<PyDicData>>,
+        py: Python<'py>,
+    ) -> Bound<'py, PyString>;
 }
 
 struct Surface {}
 
 impl MorphemeProjection for Surface {
-    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
+    fn project<'py>(
+        &self,
+        m: &MorphemeListItem<Arc<PyDicData>>,
+        py: Python<'py>,
+    ) -> Bound<'py, PyString> {
         PyString::new(py, m.surface().deref())
     }
 }
 
-struct Mapped<F: for<'a> Fn(&'a Morpheme<'a, Arc<PyDicData>>) -> &'a str> {
+struct Mapped<F: for<'a> Fn(&'a MorphemeListItem<'a, Arc<PyDicData>>) -> &'a str> {
     func: F,
 }
 
-impl<F: for<'a> Fn(&'a Morpheme<'a, Arc<PyDicData>>) -> &'a str> MorphemeProjection for Mapped<F> {
-    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
+impl<F: for<'a> Fn(&'a MorphemeListItem<'a, Arc<PyDicData>>) -> &'a str> MorphemeProjection
+    for Mapped<F>
+{
+    fn project<'py>(
+        &self,
+        m: &MorphemeListItem<Arc<PyDicData>>,
+        py: Python<'py>,
+    ) -> Bound<'py, PyString> {
         PyString::new(py, (self.func)(m))
     }
 }
@@ -62,7 +76,11 @@ impl DictionaryAndSurface {
 }
 
 impl MorphemeProjection for DictionaryAndSurface {
-    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
+    fn project<'py>(
+        &self,
+        m: &MorphemeListItem<Arc<PyDicData>>,
+        py: Python<'py>,
+    ) -> Bound<'py, PyString> {
         if self.matcher.matches_id(m.part_of_speech_id()) {
             PyString::new(py, m.surface().deref())
         } else {
@@ -83,7 +101,11 @@ impl NormalizedAndSurface {
 }
 
 impl MorphemeProjection for NormalizedAndSurface {
-    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
+    fn project<'py>(
+        &self,
+        m: &MorphemeListItem<Arc<PyDicData>>,
+        py: Python<'py>,
+    ) -> Bound<'py, PyString> {
         if self.matcher.matches_id(m.part_of_speech_id()) {
             PyString::new(py, m.surface().deref())
         } else {
@@ -104,7 +126,11 @@ impl NormalizedNouns {
 }
 
 impl MorphemeProjection for NormalizedNouns {
-    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
+    fn project<'py>(
+        &self,
+        m: &MorphemeListItem<Arc<PyDicData>>,
+        py: Python<'py>,
+    ) -> Bound<'py, PyString> {
         if self.matcher.matches_id(m.part_of_speech_id()) {
             PyString::new(py, m.normalized_form())
         } else {

--- a/python/src/projection.rs
+++ b/python/src/projection.rs
@@ -14,7 +14,6 @@
  *  limitations under the License.
  */
 
-use std::ops::Deref;
 use std::sync::Arc;
 
 use pyo3::prelude::*;
@@ -24,29 +23,52 @@ use pyo3::Python;
 use sudachi::config::SurfaceProjection;
 use sudachi::dic::DictionaryAccess;
 use sudachi::pos::PosMatcher;
-use sudachi::prelude::Morpheme;
+use sudachi::prelude::MorphemeView;
 
 use crate::dictionary::PyDicData;
 
 pub(crate) trait MorphemeProjection {
-    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString>;
+    fn project<'py>(
+        &self,
+        m: &(dyn MorphemeView<Dictionary = Arc<PyDicData>> + '_),
+        py: Python<'py>,
+    ) -> Bound<'py, PyString>;
 }
 
 struct Surface {}
 
 impl MorphemeProjection for Surface {
-    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
-        PyString::new(py, m.surface().deref())
+    fn project<'py>(
+        &self,
+        m: &(dyn MorphemeView<Dictionary = Arc<PyDicData>> + '_),
+        py: Python<'py>,
+    ) -> Bound<'py, PyString> {
+        PyString::new(py, m.surface().as_ref())
     }
 }
 
-struct Mapped<F: for<'a> Fn(&'a Morpheme<'a, Arc<PyDicData>>) -> &'a str> {
-    func: F,
+enum MappedField {
+    Normalized,
+    Reading,
+    Dictionary,
 }
 
-impl<F: for<'a> Fn(&'a Morpheme<'a, Arc<PyDicData>>) -> &'a str> MorphemeProjection for Mapped<F> {
-    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
-        PyString::new(py, (self.func)(m))
+struct Mapped {
+    field: MappedField,
+}
+
+impl MorphemeProjection for Mapped {
+    fn project<'py>(
+        &self,
+        m: &(dyn MorphemeView<Dictionary = Arc<PyDicData>> + '_),
+        py: Python<'py>,
+    ) -> Bound<'py, PyString> {
+        let s = match self.field {
+            MappedField::Normalized => m.normalized_form(),
+            MappedField::Reading => m.reading_form(),
+            MappedField::Dictionary => m.dictionary_form(),
+        };
+        PyString::new(py, s)
     }
 }
 
@@ -62,9 +84,13 @@ impl DictionaryAndSurface {
 }
 
 impl MorphemeProjection for DictionaryAndSurface {
-    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
+    fn project<'py>(
+        &self,
+        m: &(dyn MorphemeView<Dictionary = Arc<PyDicData>> + '_),
+        py: Python<'py>,
+    ) -> Bound<'py, PyString> {
         if self.matcher.matches_id(m.part_of_speech_id()) {
-            PyString::new(py, m.surface().deref())
+            PyString::new(py, m.surface().as_ref())
         } else {
             PyString::new(py, m.dictionary_form())
         }
@@ -83,9 +109,13 @@ impl NormalizedAndSurface {
 }
 
 impl MorphemeProjection for NormalizedAndSurface {
-    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
+    fn project<'py>(
+        &self,
+        m: &(dyn MorphemeView<Dictionary = Arc<PyDicData>> + '_),
+        py: Python<'py>,
+    ) -> Bound<'py, PyString> {
         if self.matcher.matches_id(m.part_of_speech_id()) {
-            PyString::new(py, m.surface().deref())
+            PyString::new(py, m.surface().as_ref())
         } else {
             PyString::new(py, m.normalized_form())
         }
@@ -104,18 +134,22 @@ impl NormalizedNouns {
 }
 
 impl MorphemeProjection for NormalizedNouns {
-    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
+    fn project<'py>(
+        &self,
+        m: &(dyn MorphemeView<Dictionary = Arc<PyDicData>> + '_),
+        py: Python<'py>,
+    ) -> Bound<'py, PyString> {
         if self.matcher.matches_id(m.part_of_speech_id()) {
             PyString::new(py, m.normalized_form())
         } else {
-            PyString::new(py, m.surface().deref())
+            PyString::new(py, m.surface().as_ref())
         }
     }
 }
 
 fn conjugating_matcher<D: DictionaryAccess>(dic: &D) -> PosMatcher {
     make_matcher(dic, |pos| {
-        matches!(pos[0].deref(), "動詞" | "形容詞" | "助動詞")
+        matches!(pos[0].as_str(), "動詞" | "形容詞" | "助動詞")
     })
 }
 
@@ -127,13 +161,13 @@ pub(crate) fn morpheme_projection<D: DictionaryAccess>(
         // implement for surface to make this function full
         SurfaceProjection::Surface => Arc::new(Surface {}),
         SurfaceProjection::Normalized => Arc::new(Mapped {
-            func: |m| m.normalized_form(),
+            field: MappedField::Normalized,
         }),
         SurfaceProjection::Reading => Arc::new(Mapped {
-            func: |m| m.reading_form(),
+            field: MappedField::Reading,
         }),
         SurfaceProjection::Dictionary => Arc::new(Mapped {
-            func: |m| m.dictionary_form(),
+            field: MappedField::Dictionary,
         }),
         SurfaceProjection::DictionaryAndSurface => Arc::new(DictionaryAndSurface::new(dict)),
         SurfaceProjection::NormalizedAndSurface => Arc::new(NormalizedAndSurface::new(dict)),

--- a/python/src/projection.rs
+++ b/python/src/projection.rs
@@ -24,42 +24,28 @@ use pyo3::Python;
 use sudachi::config::SurfaceProjection;
 use sudachi::dic::DictionaryAccess;
 use sudachi::pos::PosMatcher;
-use sudachi::prelude::MorphemeListItem;
+use sudachi::prelude::Morpheme;
 
 use crate::dictionary::PyDicData;
 
 pub(crate) trait MorphemeProjection {
-    fn project<'py>(
-        &self,
-        m: &MorphemeListItem<Arc<PyDicData>>,
-        py: Python<'py>,
-    ) -> Bound<'py, PyString>;
+    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString>;
 }
 
 struct Surface {}
 
 impl MorphemeProjection for Surface {
-    fn project<'py>(
-        &self,
-        m: &MorphemeListItem<Arc<PyDicData>>,
-        py: Python<'py>,
-    ) -> Bound<'py, PyString> {
+    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
         PyString::new(py, m.surface().deref())
     }
 }
 
-struct Mapped<F: for<'a> Fn(&'a MorphemeListItem<'a, Arc<PyDicData>>) -> &'a str> {
+struct Mapped<F: for<'a> Fn(&'a Morpheme<'a, Arc<PyDicData>>) -> &'a str> {
     func: F,
 }
 
-impl<F: for<'a> Fn(&'a MorphemeListItem<'a, Arc<PyDicData>>) -> &'a str> MorphemeProjection
-    for Mapped<F>
-{
-    fn project<'py>(
-        &self,
-        m: &MorphemeListItem<Arc<PyDicData>>,
-        py: Python<'py>,
-    ) -> Bound<'py, PyString> {
+impl<F: for<'a> Fn(&'a Morpheme<'a, Arc<PyDicData>>) -> &'a str> MorphemeProjection for Mapped<F> {
+    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
         PyString::new(py, (self.func)(m))
     }
 }
@@ -76,11 +62,7 @@ impl DictionaryAndSurface {
 }
 
 impl MorphemeProjection for DictionaryAndSurface {
-    fn project<'py>(
-        &self,
-        m: &MorphemeListItem<Arc<PyDicData>>,
-        py: Python<'py>,
-    ) -> Bound<'py, PyString> {
+    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
         if self.matcher.matches_id(m.part_of_speech_id()) {
             PyString::new(py, m.surface().deref())
         } else {
@@ -101,11 +83,7 @@ impl NormalizedAndSurface {
 }
 
 impl MorphemeProjection for NormalizedAndSurface {
-    fn project<'py>(
-        &self,
-        m: &MorphemeListItem<Arc<PyDicData>>,
-        py: Python<'py>,
-    ) -> Bound<'py, PyString> {
+    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
         if self.matcher.matches_id(m.part_of_speech_id()) {
             PyString::new(py, m.surface().deref())
         } else {
@@ -126,11 +104,7 @@ impl NormalizedNouns {
 }
 
 impl MorphemeProjection for NormalizedNouns {
-    fn project<'py>(
-        &self,
-        m: &MorphemeListItem<Arc<PyDicData>>,
-        py: Python<'py>,
-    ) -> Bound<'py, PyString> {
+    fn project<'py>(&self, m: &Morpheme<Arc<PyDicData>>, py: Python<'py>) -> Bound<'py, PyString> {
         if self.matcher.matches_id(m.part_of_speech_id()) {
             PyString::new(py, m.normalized_form())
         } else {

--- a/python/src/tokenizer.rs
+++ b/python/src/tokenizer.rs
@@ -182,9 +182,11 @@ impl PyTokenizer {
             Some(list) => list,
         };
 
+        let dict = tokenizer.dict_clone();
+        let projection = self.projection.clone();
         let mut borrow = out_list.try_borrow_mut();
         let morphemes = match borrow {
-            Ok(ref mut ms) => ms.internal_mut(py),
+            Ok(ref mut ms) => ms.replace_with_empty_list(dict, projection)?,
             Err(_) => return errors::wrap(Err("out was used twice at the same time")),
         };
 

--- a/python/tests/test_morpheme.py
+++ b/python/tests/test_morpheme.py
@@ -81,6 +81,68 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(m.normalized_form(), 'ぴらる')
         self.assertEqual(m.reading_form(), 'ピラル')
 
+    def test_dictionary_form_morpheme(self):
+        m = self.tokenizer_obj.tokenize('行っ')[0]
+        df = m.dictionary_form_morpheme()
+
+        self.assertIsNotNone(df)
+        self.assertEqual(df.surface(), '行く')
+        self.assertEqual(df.raw_surface(), '行く')
+        self.assertEqual(df.dictionary_form(), '行く')
+        self.assertEqual(df.reading_form(), 'イク')
+
+    def test_normalized_form_morpheme(self):
+        m = self.tokenizer_obj.tokenize('いっ')[0]
+        nf = m.normalized_form_morpheme()
+
+        self.assertIsNotNone(nf)
+        self.assertEqual(nf.surface(), '行く')
+        self.assertEqual(nf.raw_surface(), '行く')
+        self.assertEqual(nf.normalized_form(), '行く')
+        self.assertEqual(nf.reading_form(), 'イク')
+
+    def test_form_morpheme_for_same_entry(self):
+        m = self.tokenizer_obj.tokenize('東京')[0]
+        df = m.dictionary_form_morpheme()
+        nf = m.normalized_form_morpheme()
+
+        self.assertIsNotNone(df)
+        self.assertIsNotNone(nf)
+        self.assertEqual(df.word_id(), m.word_id())
+        self.assertEqual(nf.word_id(), m.word_id())
+        self.assertEqual(df.surface(), '東京')
+        self.assertEqual(nf.surface(), '東京')
+
+    def test_form_morpheme_for_normalized_input_same_entry(self):
+        m = self.tokenizer_obj.tokenize('特Ａ東京')[0]
+        nf = m.normalized_form_morpheme()
+
+        self.assertIsNotNone(nf)
+        self.assertEqual(m.surface(), '特Ａ')
+        self.assertEqual(m.normalized_form(), '特A')
+        self.assertEqual(nf.word_id(), m.word_id())
+        self.assertEqual(nf.raw_surface(), '特A')
+
+    def test_form_morpheme_with_field_subset(self):
+        tokenizer = self.dict_.create(fields={'surface'})
+        m = tokenizer.tokenize('行っ')[0]
+        df = m.dictionary_form_morpheme()
+        nf = m.normalized_form_morpheme()
+
+        self.assertIsNotNone(df)
+        self.assertIsNotNone(nf)
+        self.assertEqual(df.surface(), '行く')
+        self.assertEqual(nf.surface(), '行く')
+        self.assertEqual(df.reading_form(), 'イク')
+        self.assertEqual(nf.reading_form(), 'イク')
+
+    def test_form_morpheme_oov_returns_none(self):
+        m = self.tokenizer_obj.tokenize('京')[0]
+
+        self.assertTrue(m.is_oov())
+        self.assertIsNone(m.dictionary_form_morpheme())
+        self.assertIsNone(m.normalized_form_morpheme())
+
     def test_morpheme_dictionary_id(self):
         m = self.tokenizer_obj.tokenize('京都')[0]
         self.assertEqual(m.dictionary_id(), 0)

--- a/python/tests/test_morpheme.py
+++ b/python/tests/test_morpheme.py
@@ -139,19 +139,24 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(nf.reading_form(), 'イク')
 
     def test_form_morpheme_oov_returns_self_equivalent(self):
-        m = self.tokenizer_obj.tokenize('京')[0]
-        df = m.dictionary_form_morpheme()
-        nf = m.normalized_form_morpheme()
+        for m in self.tokenizer_obj.tokenize('xyzzy123不在語'):
+            if not m.is_oov():
+                continue
 
-        self.assertTrue(m.is_oov())
-        self.assertTrue(df.is_oov())
-        self.assertTrue(nf.is_oov())
-        self.assertEqual(df.surface(), m.surface())
-        self.assertEqual(nf.surface(), m.surface())
-        self.assertEqual(df.begin(), m.begin())
-        self.assertEqual(df.end(), m.end())
-        self.assertEqual(nf.begin(), m.begin())
-        self.assertEqual(nf.end(), m.end())
+            df = m.dictionary_form_morpheme()
+            nf = m.normalized_form_morpheme()
+
+            self.assertTrue(df.is_oov())
+            self.assertTrue(nf.is_oov())
+            self.assertEqual(df.surface(), m.surface())
+            self.assertEqual(nf.surface(), m.surface())
+            self.assertEqual(df.begin(), m.begin())
+            self.assertEqual(df.end(), m.end())
+            self.assertEqual(nf.begin(), m.begin())
+            self.assertEqual(nf.end(), m.end())
+            return
+
+        self.skipTest('test dictionary contains all words; cannot verify OOV branch')
 
     def test_morpheme_dictionary_id(self):
         m = self.tokenizer_obj.tokenize('京都')[0]

--- a/python/tests/test_morpheme.py
+++ b/python/tests/test_morpheme.py
@@ -13,9 +13,13 @@
 # limitations under the License.
 
 import os
+import csv
+import json
+import tempfile
 import unittest
 
 from sudachipy import Dictionary, SplitMode
+from sudachipy.sudachipy import build_system_dic
 
 
 class TestTokenizer(unittest.TestCase):
@@ -102,6 +106,61 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(nf.reading_form(), 'イク')
         self.assertEqual(nf.begin(), 0)
         self.assertEqual(nf.end(), len(nf.surface()))
+
+    def test_form_morpheme_split_uses_standalone_offsets(self):
+        resource_dir = os.path.join(os.path.dirname(
+            os.path.abspath(__file__)), 'resources')
+        split_ref = '東京,3,トウキョウ/都,4,ト'
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            extra_lex = os.path.join(temp_dir, 'extra.csv')
+            system_dic = os.path.join(temp_dir, 'system.dic')
+            config_path = os.path.join(temp_dir, 'sudachi.json')
+
+            with open(extra_lex, 'w', encoding='utf-8', newline='') as out:
+                writer = csv.writer(out)
+                writer.writerow([
+                    'index_form', 'left_id', 'right_id', 'cost', 'headword',
+                    'pos1', 'pos2', 'pos3', 'pos4', 'pos5', 'pos6',
+                    'reading_form', 'normalized_form', 'dictionary_form',
+                    'split_a', 'split_b', 'split_c', 'word_structure',
+                    'synonym_groups',
+                ])
+                writer.writerow([
+                    '首都', 6, 6, 1000, '',
+                    '名詞', '固有名詞', '地名', '一般', '*', '*',
+                    'シュト', '', '', split_ref, '', '', split_ref, '',
+                ])
+                writer.writerow([
+                    '首都旧', 6, 6, 1000, '',
+                    '名詞', '固有名詞', '地名', '一般', '*', '*',
+                    'シュトキュウ', '首都',
+                    '首都,3,シュト',
+                    '', '', '', '', '',
+                ])
+
+            build_system_dic(
+                os.path.join(resource_dir, 'matrix.def'),
+                [os.path.join(resource_dir, 'lex.csv'), extra_lex],
+                system_dic,
+            )
+
+            with open(os.path.join(resource_dir, 'sudachi.json'), encoding='utf-8') as inp:
+                config = json.load(inp)
+            config['systemDict'] = system_dic
+            config.pop('userDict', None)
+            config.pop('path', None)
+            with open(config_path, 'w', encoding='utf-8') as out:
+                json.dump(config, out, ensure_ascii=False)
+
+            tokenizer = Dictionary(config_path, resource_dir).create()
+            m = tokenizer.tokenize('首都旧')[0]
+            nf = m.normalized_form_morpheme()
+            splits = nf.split(SplitMode.A, add_single=True)
+
+            self.assertEqual(nf.surface(), '首都')
+            self.assertEqual(['東京', '都'], [s.surface() for s in splits])
+            self.assertEqual([(0, 2), (2, 3)], [(s.begin(), s.end()) for s in splits])
 
     def test_form_morpheme_for_same_entry(self):
         m = self.tokenizer_obj.tokenize('東京')[0]

--- a/python/tests/test_morpheme.py
+++ b/python/tests/test_morpheme.py
@@ -157,10 +157,22 @@ class TestTokenizer(unittest.TestCase):
             m = tokenizer.tokenize('首都旧')[0]
             nf = m.normalized_form_morpheme()
             splits = nf.split(SplitMode.A, add_single=True)
+            out = self.tokenizer_obj.tokenize('東京都', SplitMode.C)[0].split(
+                SplitMode.A)
+            out_result = nf.split(SplitMode.A, out=out, add_single=True)
+            surface_tokenizer = Dictionary(config_path, resource_dir).create(
+                fields={'surface'})
+            surface_nf = surface_tokenizer.tokenize(
+                '首都旧')[0].normalized_form_morpheme()
+            surface_splits = surface_nf.split(SplitMode.A, add_single=True)
 
             self.assertEqual(nf.surface(), '首都')
             self.assertEqual(['東京', '都'], [s.surface() for s in splits])
             self.assertEqual([(0, 2), (2, 3)], [(s.begin(), s.end()) for s in splits])
+            self.assertIs(out_result, out)
+            self.assertEqual(['東京', '都'], [s.surface() for s in out_result])
+            self.assertEqual(['東京', '都'], [
+                s.surface() for s in surface_splits])
 
     def test_form_morpheme_for_same_entry(self):
         m = self.tokenizer_obj.tokenize('東京')[0]
@@ -186,8 +198,19 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(nf.raw_surface(), m.raw_surface())
         self.assertEqual(nf.surface(), m.surface())
 
-    def test_form_morpheme_with_field_subset(self):
+    def test_form_morpheme_with_surface_subset(self):
         tokenizer = self.dict_.create(fields={'surface'})
+        m = tokenizer.tokenize('行っ')[0]
+        df = m.dictionary_form_morpheme()
+        nf = m.normalized_form_morpheme()
+
+        self.assertEqual(df.surface(), '行く')
+        self.assertEqual(nf.surface(), '行く')
+        self.assertEqual(df.raw_surface(), '行く')
+        self.assertEqual(nf.raw_surface(), '行く')
+
+    def test_form_morpheme_with_reading_subset(self):
+        tokenizer = self.dict_.create(fields={'surface', 'reading_form'})
         m = tokenizer.tokenize('行っ')[0]
         df = m.dictionary_form_morpheme()
         nf = m.normalized_form_morpheme()
@@ -196,6 +219,50 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(nf.surface(), '行く')
         self.assertEqual(df.reading_form(), 'イク')
         self.assertEqual(nf.reading_form(), 'イク')
+
+    def test_single_backed_form_morpheme_uses_projection(self):
+        tokenizer = self.dict_.create(projection='reading')
+        m = tokenizer.tokenize('行っ')[0]
+        df = m.dictionary_form_morpheme()
+
+        self.assertEqual(df.raw_surface(), '行く')
+        self.assertEqual(df.surface(), 'イク')
+
+    def test_single_backed_form_morpheme_can_chain_form_accessors(self):
+        m = self.tokenizer_obj.tokenize('いっ')[0]
+        nf = m.normalized_form_morpheme()
+        df = nf.dictionary_form_morpheme()
+
+        self.assertEqual(nf.word_id(), df.word_id())
+        self.assertEqual(df.raw_surface(), '行く')
+        self.assertEqual(df.surface(), '行く')
+        self.assertEqual(df.dictionary_form(), '行く')
+
+    def test_single_backed_morpheme_list_protocol(self):
+        m = self.tokenizer_obj.tokenize('いっ')[0]
+        nf = m.normalized_form_morpheme()
+        result = nf.split(SplitMode.A, add_single=True)
+
+        self.assertEqual(1, len(result))
+        self.assertEqual('行く', result[0].surface())
+        self.assertEqual('行く', result[-1].surface())
+        self.assertEqual('行く', str(result))
+        self.assertIn('<Morpheme(行く, 0:2, ', repr(result))
+
+        with self.assertRaisesRegex(
+                Exception,
+                'standalone morpheme lists do not have a lattice path cost'):
+            result.get_internal_cost()
+
+    def test_single_backed_morpheme_list_can_be_reused_as_tokenize_out(self):
+        m = self.tokenizer_obj.tokenize('いっ')[0]
+        nf = m.normalized_form_morpheme()
+        out = nf.split(SplitMode.A, add_single=True)
+
+        result = self.tokenizer_obj.tokenize('東京', out=out)
+
+        self.assertIs(result, out)
+        self.assertEqual(['東京'], [m.surface() for m in result])
 
     def test_form_morpheme_oov_returns_self_equivalent(self):
         for m in self.tokenizer_obj.tokenize('xyzzy123不在語'):

--- a/python/tests/test_morpheme.py
+++ b/python/tests/test_morpheme.py
@@ -85,43 +85,47 @@ class TestTokenizer(unittest.TestCase):
         m = self.tokenizer_obj.tokenize('行っ')[0]
         df = m.dictionary_form_morpheme()
 
-        self.assertIsNotNone(df)
         self.assertEqual(df.surface(), '行く')
         self.assertEqual(df.raw_surface(), '行く')
         self.assertEqual(df.dictionary_form(), '行く')
         self.assertEqual(df.reading_form(), 'イク')
+        self.assertEqual(df.begin(), 0)
+        self.assertEqual(df.end(), len(df.surface()))
 
     def test_normalized_form_morpheme(self):
         m = self.tokenizer_obj.tokenize('いっ')[0]
         nf = m.normalized_form_morpheme()
 
-        self.assertIsNotNone(nf)
         self.assertEqual(nf.surface(), '行く')
         self.assertEqual(nf.raw_surface(), '行く')
         self.assertEqual(nf.normalized_form(), '行く')
         self.assertEqual(nf.reading_form(), 'イク')
+        self.assertEqual(nf.begin(), 0)
+        self.assertEqual(nf.end(), len(nf.surface()))
 
     def test_form_morpheme_for_same_entry(self):
         m = self.tokenizer_obj.tokenize('東京')[0]
         df = m.dictionary_form_morpheme()
         nf = m.normalized_form_morpheme()
 
-        self.assertIsNotNone(df)
-        self.assertIsNotNone(nf)
         self.assertEqual(df.word_id(), m.word_id())
         self.assertEqual(nf.word_id(), m.word_id())
         self.assertEqual(df.surface(), '東京')
         self.assertEqual(nf.surface(), '東京')
+        self.assertEqual(df.begin(), m.begin())
+        self.assertEqual(df.end(), m.end())
+        self.assertEqual(nf.begin(), m.begin())
+        self.assertEqual(nf.end(), m.end())
 
     def test_form_morpheme_for_normalized_input_same_entry(self):
         m = self.tokenizer_obj.tokenize('特Ａ東京')[0]
         nf = m.normalized_form_morpheme()
 
-        self.assertIsNotNone(nf)
         self.assertEqual(m.surface(), '特Ａ')
         self.assertEqual(m.normalized_form(), '特A')
         self.assertEqual(nf.word_id(), m.word_id())
-        self.assertEqual(nf.raw_surface(), '特A')
+        self.assertEqual(nf.raw_surface(), m.raw_surface())
+        self.assertEqual(nf.surface(), m.surface())
 
     def test_form_morpheme_with_field_subset(self):
         tokenizer = self.dict_.create(fields={'surface'})
@@ -129,19 +133,25 @@ class TestTokenizer(unittest.TestCase):
         df = m.dictionary_form_morpheme()
         nf = m.normalized_form_morpheme()
 
-        self.assertIsNotNone(df)
-        self.assertIsNotNone(nf)
         self.assertEqual(df.surface(), '行く')
         self.assertEqual(nf.surface(), '行く')
         self.assertEqual(df.reading_form(), 'イク')
         self.assertEqual(nf.reading_form(), 'イク')
 
-    def test_form_morpheme_oov_returns_none(self):
+    def test_form_morpheme_oov_returns_self_equivalent(self):
         m = self.tokenizer_obj.tokenize('京')[0]
+        df = m.dictionary_form_morpheme()
+        nf = m.normalized_form_morpheme()
 
         self.assertTrue(m.is_oov())
-        self.assertIsNone(m.dictionary_form_morpheme())
-        self.assertIsNone(m.normalized_form_morpheme())
+        self.assertTrue(df.is_oov())
+        self.assertTrue(nf.is_oov())
+        self.assertEqual(df.surface(), m.surface())
+        self.assertEqual(nf.surface(), m.surface())
+        self.assertEqual(df.begin(), m.begin())
+        self.assertEqual(df.end(), m.end())
+        self.assertEqual(nf.begin(), m.begin())
+        self.assertEqual(nf.end(), m.end())
 
     def test_morpheme_dictionary_id(self):
         m = self.tokenizer_obj.tokenize('京都')[0]

--- a/python/tests/test_morpheme.py
+++ b/python/tests/test_morpheme.py
@@ -157,11 +157,10 @@ class TestTokenizer(unittest.TestCase):
             m = tokenizer.tokenize('首都旧')[0]
             nf = m.normalized_form_morpheme()
             splits = nf.split(SplitMode.A, add_single=True)
-            out = self.tokenizer_obj.tokenize('東京都', SplitMode.C)[0].split(
-                SplitMode.A)
+            out = self.tokenizer_obj.tokenize('')
             out_result = nf.split(SplitMode.A, out=out, add_single=True)
             surface_tokenizer = Dictionary(config_path, resource_dir).create(
-                fields={'surface'})
+                fields={'surface', 'normalized_form', 'split_a'})
             surface_nf = surface_tokenizer.tokenize(
                 '首都旧')[0].normalized_form_morpheme()
             surface_splits = surface_nf.split(SplitMode.A, add_single=True)
@@ -199,7 +198,8 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(nf.surface(), m.surface())
 
     def test_form_morpheme_with_surface_subset(self):
-        tokenizer = self.dict_.create(fields={'surface'})
+        tokenizer = self.dict_.create(
+            fields={'surface', 'dictionary_form', 'normalized_form'})
         m = tokenizer.tokenize('行っ')[0]
         df = m.dictionary_form_morpheme()
         nf = m.normalized_form_morpheme()
@@ -210,7 +210,13 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(nf.raw_surface(), '行く')
 
     def test_form_morpheme_with_reading_subset(self):
-        tokenizer = self.dict_.create(fields={'surface', 'reading_form'})
+        tokenizer = self.dict_.create(
+            fields={
+                'surface',
+                'reading_form',
+                'dictionary_form',
+                'normalized_form',
+            })
         m = tokenizer.tokenize('行っ')[0]
         df = m.dictionary_form_morpheme()
         nf = m.normalized_form_morpheme()
@@ -221,7 +227,8 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(nf.reading_form(), 'イク')
 
     def test_single_backed_form_morpheme_uses_projection(self):
-        tokenizer = self.dict_.create(projection='reading')
+        tokenizer = self.dict_.create(
+            fields={'dictionary_form'}, projection='reading')
         m = tokenizer.tokenize('行っ')[0]
         df = m.dictionary_form_morpheme()
 

--- a/sudachi-cli/src/output.rs
+++ b/sudachi-cli/src/output.rs
@@ -103,10 +103,11 @@ impl<T: DictionaryAccess> SudachiOutput<T> for Simple {
 }
 
 #[inline]
-fn write_morpheme_basic<T: DictionaryAccess>(
-    writer: &mut Writer,
-    morpheme: &Morpheme<T>,
-) -> SudachiResult<()> {
+fn write_morpheme_basic<T, M>(writer: &mut Writer, morpheme: &M) -> SudachiResult<()>
+where
+    T: DictionaryAccess,
+    M: Morpheme<Dictionary = T> + ?Sized,
+{
     writer.write_all(morpheme.surface().as_bytes())?;
     writer.write_all(b"\t")?;
     let all_pos = morpheme.part_of_speech();
@@ -122,10 +123,11 @@ fn write_morpheme_basic<T: DictionaryAccess>(
 }
 
 #[inline]
-fn write_morpheme_extended<T: DictionaryAccess>(
-    writer: &mut Writer,
-    morpheme: &Morpheme<T>,
-) -> SudachiResult<()> {
+fn write_morpheme_extended<T, M>(writer: &mut Writer, morpheme: &M) -> SudachiResult<()>
+where
+    T: DictionaryAccess,
+    M: Morpheme<Dictionary = T> + ?Sized,
+{
     write!(
         writer,
         "\t{}\t{}\t{}\t{:?}\t{}",

--- a/sudachi-cli/src/output.rs
+++ b/sudachi-cli/src/output.rs
@@ -15,7 +15,7 @@
  */
 
 use std::io::{BufWriter, Write};
-use sudachi::analysis::morpheme::Morpheme;
+use sudachi::analysis::morpheme::MorphemeView;
 use sudachi::dic::subset::InfoSubset;
 use sudachi::dic::DictionaryAccess;
 
@@ -106,7 +106,7 @@ impl<T: DictionaryAccess> SudachiOutput<T> for Simple {
 fn write_morpheme_basic<T, M>(writer: &mut Writer, morpheme: &M) -> SudachiResult<()>
 where
     T: DictionaryAccess,
-    M: Morpheme<Dictionary = T> + ?Sized,
+    M: MorphemeView<Dictionary = T> + ?Sized,
 {
     writer.write_all(morpheme.surface().as_bytes())?;
     writer.write_all(b"\t")?;
@@ -126,7 +126,7 @@ where
 fn write_morpheme_extended<T, M>(writer: &mut Writer, morpheme: &M) -> SudachiResult<()>
 where
     T: DictionaryAccess,
-    M: Morpheme<Dictionary = T> + ?Sized,
+    M: MorphemeView<Dictionary = T> + ?Sized,
 {
     write!(
         writer,

--- a/sudachi-fuzz/src/main.rs
+++ b/sudachi-fuzz/src/main.rs
@@ -32,18 +32,18 @@ fn consume_mlist<'a, 'b: 'a>(
         black_box(m.begin_c());
         black_box(m.end());
         black_box(m.end_c());
-        black_box(m.word_id().word());
-        black_box(m.word_id().dic());
+        black_box(m.word_id().entry().as_raw());
+        black_box(m.word_id().dict().as_raw());
         black_box(m.part_of_speech_id());
         black_box(m.part_of_speech());
         black_box(m.get_word_info().a_unit_split());
         black_box(m.get_word_info().b_unit_split());
         black_box(m.get_word_info().synonym_group_ids());
-        black_box(m.get_word_info().dictionary_form());
-        black_box(m.get_word_info().dictionary_form_word_id());
-        black_box(m.get_word_info().reading_form());
-        black_box(m.get_word_info().surface());
-        black_box(m.get_word_info().normalized_form());
+        black_box(m.dictionary_form());
+        black_box(m.get_word_info().borrow_data().dictionary_form_word_id());
+        black_box(m.reading_form());
+        black_box(m.surface());
+        black_box(m.normalized_form());
 
         mlist2.clear();
         if m.split_into(Mode::A, mlist2).is_err() {
@@ -59,18 +59,18 @@ fn consume_mlist<'a, 'b: 'a>(
             black_box(m1.begin_c());
             black_box(m1.end());
             black_box(m1.end_c());
-            black_box(m1.word_id().word());
-            black_box(m1.word_id().dic());
+            black_box(m1.word_id().entry().as_raw());
+            black_box(m1.word_id().dict().as_raw());
             black_box(m1.part_of_speech_id());
             black_box(m1.part_of_speech());
             black_box(m1.get_word_info().a_unit_split());
             black_box(m1.get_word_info().b_unit_split());
             black_box(m1.get_word_info().synonym_group_ids());
-            black_box(m1.get_word_info().dictionary_form());
-            black_box(m1.get_word_info().dictionary_form_word_id());
-            black_box(m1.get_word_info().reading_form());
-            black_box(m1.get_word_info().surface());
-            black_box(m1.get_word_info().normalized_form());
+            black_box(m1.dictionary_form());
+            black_box(m1.get_word_info().borrow_data().dictionary_form_word_id());
+            black_box(m1.reading_form());
+            black_box(m1.surface());
+            black_box(m1.normalized_form());
         }
         if !mlist2.is_empty() {
             assert_eq!(surf.len(), mlen);

--- a/sudachi/src/analysis/mlist.rs
+++ b/sudachi/src/analysis/mlist.rs
@@ -19,7 +19,7 @@ use std::iter::FusedIterator;
 use std::ops::{Deref, DerefMut, Index};
 use std::rc::Rc;
 
-use crate::analysis::morpheme::MorphemeListItem;
+use crate::analysis::morpheme::{validate_dictionary_word_id, Morpheme};
 use crate::analysis::node::{PathCost, ResultNode};
 use crate::analysis::stateful_tokenizer::StatefulTokenizer;
 use crate::analysis::{Mode, Node};
@@ -137,8 +137,8 @@ impl<D: DictionaryAccess> MorphemeList<D> {
         self.nodes.data.is_empty()
     }
 
-    pub fn get(&self, idx: usize) -> MorphemeListItem<'_, D> {
-        MorphemeListItem::for_list(self, idx)
+    pub fn get(&self, idx: usize) -> Morpheme<'_, D> {
+        Morpheme::for_list(self, idx)
     }
 
     pub fn surface(&self) -> Ref<'_, str> {
@@ -226,35 +226,80 @@ impl<D: DictionaryAccess> MorphemeList<D> {
     /// surface, so it preserves homograph identity.
     #[allow(clippy::result_large_err)]
     pub fn reset_with_word_id(&mut self, word_id: WordId, subset: InfoSubset) -> SudachiResult<()> {
+        self.reset_with_word_ids(std::iter::once(word_id), subset)
+    }
+
+    /// Resets this list to dictionary entries for the given word IDs.
+    ///
+    /// This resolves exact dictionary entries instead of looking them up by
+    /// surface. The list surface is the concatenation of dictionary headwords,
+    /// and each entry receives offsets over that standalone surface.
+    #[allow(clippy::result_large_err)]
+    pub fn reset_with_word_ids<I>(&mut self, word_ids: I, subset: InfoSubset) -> SudachiResult<()>
+    where
+        I: IntoIterator<Item = WordId>,
+    {
         let subset = (subset | InfoSubset::HEADWORD).normalize();
         let lex = self.dict.lexicon();
-        let info = lex.get_word_info_subset(word_id, subset)?;
-        let headword = info.headword(lex).to_owned();
-        let (left_id, right_id, cost) = lex.get_word_param(word_id);
-        let end_bytes = headword.len();
+        let mut headwords = String::new();
+        let mut entries = Vec::new();
 
-        let end_chars = {
+        for word_id in word_ids {
+            validate_dictionary_word_id(&self.dict, word_id)?;
+            let info = lex.get_word_info_subset(word_id, subset)?;
+            let headword = info.headword(lex).to_owned();
+            let (left_id, right_id, cost) = lex.get_word_param_checked(word_id)?;
+            let begin_bytes = headwords.len();
+            headwords.push_str(&headword);
+            let end_bytes = headwords.len();
+            entries.push((
+                word_id,
+                info,
+                left_id,
+                right_id,
+                cost,
+                begin_bytes,
+                end_bytes,
+            ));
+        }
+
+        let ranges = {
             let mut input_part = self.input.borrow_mut();
             input_part.subset = subset;
             let input = &mut input_part.input;
-            input.reset().push_str(&headword);
+            input.reset().push_str(&headwords);
             input.start_build()?;
             input.build(self.dict.grammar())?;
-            input.ch_idx(end_bytes)
+            entries
+                .iter()
+                .map(|(_, _, _, _, _, begin_bytes, end_bytes)| {
+                    (input.ch_idx(*begin_bytes), input.ch_idx(*end_bytes))
+                })
+                .collect::<Vec<_>>()
         };
 
         self.clear();
-        let node = Node::new(
-            0,
-            end_chars as u16,
-            left_id as u16,
-            right_id as u16,
-            cost,
-            word_id,
-        );
-        self.nodes
-            .data
-            .push(ResultNode::new(node, 0, 0, end_bytes as u16, info));
+        for (
+            (word_id, info, left_id, right_id, cost, begin_bytes, end_bytes),
+            (begin_chars, end_chars),
+        ) in entries.into_iter().zip(ranges)
+        {
+            let node = Node::new(
+                begin_chars as u16,
+                end_chars as u16,
+                left_id as u16,
+                right_id as u16,
+                cost,
+                word_id,
+            );
+            self.nodes.data.push(ResultNode::new(
+                node,
+                0,
+                begin_bytes as u16,
+                end_bytes as u16,
+                info,
+            ));
+        }
         Ok(())
     }
 }
@@ -287,14 +332,14 @@ pub struct MorphemeIter<'a, T> {
 }
 
 impl<'a, T: DictionaryAccess> Iterator for MorphemeIter<'a, T> {
-    type Item = MorphemeListItem<'a, T>;
+    type Item = Morpheme<'a, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.index >= self.list.len() {
             return None;
         }
 
-        let morpheme = MorphemeListItem::for_list(self.list, self.index);
+        let morpheme = Morpheme::for_list(self.list, self.index);
 
         self.index += 1;
         Some(morpheme)

--- a/sudachi/src/analysis/mlist.rs
+++ b/sudachi/src/analysis/mlist.rs
@@ -221,8 +221,11 @@ impl<D: DictionaryAccess> MorphemeList<D> {
     }
 
     /// Resets this list to a single dictionary entry for the given word ID.
+    ///
+    /// This resolves the exact dictionary entry instead of looking up by
+    /// surface, so it preserves homograph identity.
     #[allow(clippy::result_large_err)]
-    pub fn lookup_word_id(&mut self, word_id: WordId, subset: InfoSubset) -> SudachiResult<()> {
+    pub fn reset_with_word_id(&mut self, word_id: WordId, subset: InfoSubset) -> SudachiResult<()> {
         let lex = self.dict.lexicon();
         let info = lex.get_word_info_subset(word_id, subset)?;
         let headword = info.headword(lex).to_owned();

--- a/sudachi/src/analysis/mlist.rs
+++ b/sudachi/src/analysis/mlist.rs
@@ -226,6 +226,7 @@ impl<D: DictionaryAccess> MorphemeList<D> {
     /// surface, so it preserves homograph identity.
     #[allow(clippy::result_large_err)]
     pub fn reset_with_word_id(&mut self, word_id: WordId, subset: InfoSubset) -> SudachiResult<()> {
+        let subset = (subset | InfoSubset::HEADWORD).normalize();
         let lex = self.dict.lexicon();
         let info = lex.get_word_info_subset(word_id, subset)?;
         let headword = info.headword(lex).to_owned();
@@ -233,7 +234,9 @@ impl<D: DictionaryAccess> MorphemeList<D> {
         let end_bytes = headword.len();
 
         let end_chars = {
-            let input = &mut self.input.borrow_mut().input;
+            let mut input_part = self.input.borrow_mut();
+            input_part.subset = subset;
+            let input = &mut input_part.input;
             input.reset().push_str(&headword);
             input.start_build()?;
             input.build(self.dict.grammar())?;

--- a/sudachi/src/analysis/mlist.rs
+++ b/sudachi/src/analysis/mlist.rs
@@ -19,12 +19,11 @@ use std::iter::FusedIterator;
 use std::ops::{Deref, DerefMut, Index};
 use std::rc::Rc;
 
-use crate::analysis::morpheme::{validate_dictionary_word_id, Morpheme};
+use crate::analysis::morpheme::Morpheme;
 use crate::analysis::node::{PathCost, ResultNode};
 use crate::analysis::stateful_tokenizer::StatefulTokenizer;
 use crate::analysis::{Mode, Node};
 use crate::dic::subset::InfoSubset;
-use crate::dic::word_id::WordId;
 use crate::dic::DictionaryAccess;
 use crate::error::{SudachiError, SudachiResult};
 use crate::input_text::InputBuffer;
@@ -218,89 +217,6 @@ impl<D: DictionaryAccess> MorphemeList<D> {
             result += 1;
         }
         Ok(result)
-    }
-
-    /// Resets this list to a single dictionary entry for the given word ID.
-    ///
-    /// This resolves the exact dictionary entry instead of looking up by
-    /// surface, so it preserves homograph identity.
-    #[allow(clippy::result_large_err)]
-    pub fn reset_with_word_id(&mut self, word_id: WordId, subset: InfoSubset) -> SudachiResult<()> {
-        self.reset_with_word_ids(std::iter::once(word_id), subset)
-    }
-
-    /// Resets this list to dictionary entries for the given word IDs.
-    ///
-    /// This resolves exact dictionary entries instead of looking them up by
-    /// surface. The list surface is the concatenation of dictionary headwords,
-    /// and each entry receives offsets over that standalone surface.
-    #[allow(clippy::result_large_err)]
-    pub fn reset_with_word_ids<I>(&mut self, word_ids: I, subset: InfoSubset) -> SudachiResult<()>
-    where
-        I: IntoIterator<Item = WordId>,
-    {
-        let subset = (subset | InfoSubset::HEADWORD).normalize();
-        let lex = self.dict.lexicon();
-        let mut headwords = String::new();
-        let mut entries = Vec::new();
-
-        for word_id in word_ids {
-            validate_dictionary_word_id(&self.dict, word_id)?;
-            let info = lex.get_word_info_subset(word_id, subset)?;
-            let headword = info.headword(lex).to_owned();
-            let (left_id, right_id, cost) = lex.get_word_param_checked(word_id)?;
-            let begin_bytes = headwords.len();
-            headwords.push_str(&headword);
-            let end_bytes = headwords.len();
-            entries.push((
-                word_id,
-                info,
-                left_id,
-                right_id,
-                cost,
-                begin_bytes,
-                end_bytes,
-            ));
-        }
-
-        let ranges = {
-            let mut input_part = self.input.borrow_mut();
-            input_part.subset = subset;
-            let input = &mut input_part.input;
-            input.reset().push_str(&headwords);
-            input.start_build()?;
-            input.build(self.dict.grammar())?;
-            entries
-                .iter()
-                .map(|(_, _, _, _, _, begin_bytes, end_bytes)| {
-                    (input.ch_idx(*begin_bytes), input.ch_idx(*end_bytes))
-                })
-                .collect::<Vec<_>>()
-        };
-
-        self.clear();
-        for (
-            (word_id, info, left_id, right_id, cost, begin_bytes, end_bytes),
-            (begin_chars, end_chars),
-        ) in entries.into_iter().zip(ranges)
-        {
-            let node = Node::new(
-                begin_chars as u16,
-                end_chars as u16,
-                left_id as u16,
-                right_id as u16,
-                cost,
-                word_id,
-            );
-            self.nodes.data.push(ResultNode::new(
-                node,
-                0,
-                begin_bytes as u16,
-                end_bytes as u16,
-                info,
-            ));
-        }
-        Ok(())
     }
 }
 

--- a/sudachi/src/analysis/mlist.rs
+++ b/sudachi/src/analysis/mlist.rs
@@ -24,6 +24,7 @@ use crate::analysis::node::{PathCost, ResultNode};
 use crate::analysis::stateful_tokenizer::StatefulTokenizer;
 use crate::analysis::{Mode, Node};
 use crate::dic::subset::InfoSubset;
+use crate::dic::word_id::WordId;
 use crate::dic::DictionaryAccess;
 use crate::error::{SudachiError, SudachiResult};
 use crate::input_text::InputBuffer;
@@ -217,6 +218,38 @@ impl<D: DictionaryAccess> MorphemeList<D> {
             result += 1;
         }
         Ok(result)
+    }
+
+    /// Resets this list to a single dictionary entry for the given word ID.
+    #[allow(clippy::result_large_err)]
+    pub fn lookup_word_id(&mut self, word_id: WordId, subset: InfoSubset) -> SudachiResult<()> {
+        let lex = self.dict.lexicon();
+        let info = lex.get_word_info_subset(word_id, subset)?;
+        let headword = info.headword(lex).to_owned();
+        let (left_id, right_id, cost) = lex.get_word_param(word_id);
+        let end_bytes = headword.len();
+
+        let end_chars = {
+            let input = &mut self.input.borrow_mut().input;
+            input.reset().push_str(&headword);
+            input.start_build()?;
+            input.build(self.dict.grammar())?;
+            input.ch_idx(end_bytes)
+        };
+
+        self.clear();
+        let node = Node::new(
+            0,
+            end_chars as u16,
+            left_id as u16,
+            right_id as u16,
+            cost,
+            word_id,
+        );
+        self.nodes
+            .data
+            .push(ResultNode::new(node, 0, 0, end_bytes as u16, info));
+        Ok(())
     }
 }
 

--- a/sudachi/src/analysis/mlist.rs
+++ b/sudachi/src/analysis/mlist.rs
@@ -19,7 +19,7 @@ use std::iter::FusedIterator;
 use std::ops::{Deref, DerefMut, Index};
 use std::rc::Rc;
 
-use crate::analysis::morpheme::Morpheme;
+use crate::analysis::morpheme::MorphemeListItem;
 use crate::analysis::node::{PathCost, ResultNode};
 use crate::analysis::stateful_tokenizer::StatefulTokenizer;
 use crate::analysis::{Mode, Node};
@@ -137,8 +137,8 @@ impl<D: DictionaryAccess> MorphemeList<D> {
         self.nodes.data.is_empty()
     }
 
-    pub fn get(&self, idx: usize) -> Morpheme<'_, D> {
-        return Morpheme::for_list(self, idx);
+    pub fn get(&self, idx: usize) -> MorphemeListItem<'_, D> {
+        MorphemeListItem::for_list(self, idx)
     }
 
     pub fn surface(&self) -> Ref<'_, str> {
@@ -287,14 +287,14 @@ pub struct MorphemeIter<'a, T> {
 }
 
 impl<'a, T: DictionaryAccess> Iterator for MorphemeIter<'a, T> {
-    type Item = Morpheme<'a, T>;
+    type Item = MorphemeListItem<'a, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.index >= self.list.len() {
             return None;
         }
 
-        let morpheme = Morpheme::for_list(self.list, self.index);
+        let morpheme = MorphemeListItem::for_list(self.list, self.index);
 
         self.index += 1;
         Some(morpheme)

--- a/sudachi/src/analysis/morpheme.rs
+++ b/sudachi/src/analysis/morpheme.rs
@@ -595,11 +595,9 @@ impl<D: DictionaryAccess + Clone> SingleMorpheme<D> {
     /// Returns standalone sub-morphemes for the requested split mode.
     ///
     /// When the dictionary entry has no splits for the mode, returns a clone of
-    /// this morpheme. Split metadata is loaded on demand when it was not part
-    /// of the original subset, while returned morphemes still use the original
-    /// subset. Offsets match Java's standalone morpheme behavior: a single
-    /// replacement split preserves this morpheme's span, while multi-splits
-    /// advance over each split surface.
+    /// this morpheme. Offsets match Java's standalone morpheme behavior: a
+    /// single replacement split preserves this morpheme's span, while
+    /// multi-splits advance over each split surface.
     #[allow(clippy::result_large_err)]
     pub fn split(&self, mode: Mode) -> SudachiResult<Vec<SingleMorpheme<D>>> {
         let split_subset = match mode {

--- a/sudachi/src/analysis/morpheme.rs
+++ b/sudachi/src/analysis/morpheme.rs
@@ -23,6 +23,7 @@ use crate::dic::word_info::{WordInfo, WordInfoData, WordInfoResolver};
 use crate::dic::{DictionaryAccess, LexiconAccess};
 use crate::error::{SudachiError, SudachiResult};
 use crate::input_text::InputTextIndex;
+use std::borrow::Cow;
 use std::cell::Ref;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Deref;
@@ -80,6 +81,9 @@ pub trait MorphemeView: private::Sealed {
 
     #[doc(hidden)]
     fn dict(&self) -> &Self::Dictionary;
+
+    #[doc(hidden)]
+    fn subset(&self) -> InfoSubset;
 
     /// Returns the begin index in bytes of the morpheme.
     fn begin(&self) -> usize;
@@ -144,7 +148,10 @@ pub trait MorphemeView: private::Sealed {
     /// are `0..surface.len()` in bytes and `0..surface.chars().count()` in
     /// codepoints.
     #[allow(clippy::result_large_err)]
-    fn dictionary_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, Self::Dictionary>> {
+    fn dictionary_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, Self::Dictionary>>
+    where
+        Self::Dictionary: Clone,
+    {
         resolve_referenced_form_morpheme(
             self,
             InfoSubset::DICTIONARY_FORM,
@@ -171,7 +178,10 @@ pub trait MorphemeView: private::Sealed {
     /// are `0..surface.len()` in bytes and `0..surface.chars().count()` in
     /// codepoints.
     #[allow(clippy::result_large_err)]
-    fn normalized_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, Self::Dictionary>> {
+    fn normalized_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, Self::Dictionary>>
+    where
+        Self::Dictionary: Clone,
+    {
         resolve_referenced_form_morpheme(
             self,
             InfoSubset::NORMALIZED_FORM,
@@ -230,11 +240,12 @@ pub(crate) fn validate_dictionary_word_id<D: DictionaryAccess>(
 #[allow(clippy::result_large_err)]
 fn resolve_referenced_form_morpheme<'a, M, F>(
     morpheme: &'a M,
-    subset: InfoSubset,
+    reference_subset: InfoSubset,
     form_word_id: F,
 ) -> SudachiResult<MorphemeRef<'a, M::Dictionary>>
 where
     M: MorphemeView + ?Sized,
+    M::Dictionary: Clone,
     F: FnOnce(&WordInfoData) -> WordId,
 {
     let word_id = morpheme.word_id();
@@ -245,7 +256,7 @@ where
     let word_info = morpheme
         .dict()
         .lexicon()
-        .get_word_info_subset(word_id, subset)?;
+        .get_word_info_subset(word_id, reference_subset)?;
     let form_word_id = form_word_id(word_info.borrow_data());
     if form_word_id == WordId::INVALID
         || form_word_id == word_id
@@ -255,7 +266,9 @@ where
         return Ok(morpheme.self_morpheme());
     }
 
-    SingleMorpheme::from_word_id(morpheme.dict(), form_word_id, InfoSubset::all())
+    let materialized_subset = (morpheme.subset() | InfoSubset::HEADWORD).normalize();
+
+    SingleMorpheme::from_word_id(morpheme.dict().clone(), form_word_id, materialized_subset)
         .map(Box::new)
         .map(MorphemeRef::Single)
 }
@@ -338,7 +351,10 @@ impl<'a, D: DictionaryAccess> Morpheme<'a, D> {
 
     /// Returns the morpheme corresponding to this morpheme's dictionary form.
     #[allow(clippy::result_large_err)]
-    pub fn dictionary_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>> {
+    pub fn dictionary_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>>
+    where
+        D: Clone,
+    {
         <Self as MorphemeView>::dictionary_form_morpheme(self)
     }
 
@@ -352,7 +368,10 @@ impl<'a, D: DictionaryAccess> Morpheme<'a, D> {
 
     /// Returns the morpheme corresponding to this morpheme's normalized form.
     #[allow(clippy::result_large_err)]
-    pub fn normalized_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>> {
+    pub fn normalized_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>>
+    where
+        D: Clone,
+    {
         <Self as MorphemeView>::normalized_form_morpheme(self)
     }
 
@@ -421,6 +440,10 @@ impl<D: DictionaryAccess> MorphemeView for Morpheme<'_, D> {
         self.list.dict()
     }
 
+    fn subset(&self) -> InfoSubset {
+        self.list.subset()
+    }
+
     fn begin(&self) -> usize {
         Morpheme::begin(self)
     }
@@ -467,22 +490,24 @@ impl<D: DictionaryAccess> Debug for Morpheme<'_, D> {
 }
 
 /// A standalone morpheme materialized from a single dictionary entry.
-pub struct SingleMorpheme<'a, D> {
-    dict: &'a D,
+pub struct SingleMorpheme<D> {
+    dict: D,
     word_id: WordId,
     word_info: WordInfo,
+    subset: InfoSubset,
     begin: usize,
     end: usize,
     begin_c: usize,
     end_c: usize,
 }
 
-impl<D> Clone for SingleMorpheme<'_, D> {
+impl<D: Clone> Clone for SingleMorpheme<D> {
     fn clone(&self) -> Self {
         Self {
-            dict: self.dict,
+            dict: self.dict.clone(),
             word_id: self.word_id,
             word_info: self.word_info.clone(),
+            subset: self.subset,
             begin: self.begin,
             end: self.end,
             begin_c: self.begin_c,
@@ -491,14 +516,15 @@ impl<D> Clone for SingleMorpheme<'_, D> {
     }
 }
 
-impl<'a, D: DictionaryAccess> SingleMorpheme<'a, D> {
+impl<D: DictionaryAccess> SingleMorpheme<D> {
     /// Creates a standalone morpheme for the exact dictionary entry.
     ///
     /// The entry is resolved by `WordId`, not by surface lookup, so homograph
-    /// identity is preserved.
+    /// identity is preserved. `HEADWORD` is always loaded because standalone
+    /// offsets and surface are based on the dictionary headword.
     #[allow(clippy::result_large_err)]
-    pub fn from_word_id(dict: &'a D, word_id: WordId, subset: InfoSubset) -> SudachiResult<Self> {
-        validate_dictionary_word_id(dict, word_id)?;
+    pub fn from_word_id(dict: D, word_id: WordId, subset: InfoSubset) -> SudachiResult<Self> {
+        validate_dictionary_word_id(&dict, word_id)?;
         let subset = (subset | InfoSubset::HEADWORD).normalize();
         let word_info = dict.lexicon().get_word_info_subset(word_id, subset)?;
         let surface = word_info.headword(dict.lexicon());
@@ -509,6 +535,7 @@ impl<'a, D: DictionaryAccess> SingleMorpheme<'a, D> {
             dict,
             word_id,
             word_info,
+            subset,
             begin: 0,
             end,
             begin_c: 0,
@@ -516,9 +543,12 @@ impl<'a, D: DictionaryAccess> SingleMorpheme<'a, D> {
         })
     }
 
-    /// Returns the part of speech.
-    pub fn part_of_speech(&self) -> &[String] {
-        <Self as MorphemeView>::part_of_speech(self)
+    pub(crate) fn subset(&self) -> InfoSubset {
+        self.subset
+    }
+
+    pub(crate) fn dict(&self) -> &D {
+        &self.dict
     }
 
     /// Returns the begin index in bytes of this standalone morpheme.
@@ -546,37 +576,78 @@ impl<'a, D: DictionaryAccess> SingleMorpheme<'a, D> {
         self.word_info.headword(self.dict.lexicon())
     }
 
+    /// Returns the word id of morpheme.
+    pub fn word_id(&self) -> WordId {
+        self.word_id
+    }
+
+    pub fn get_word_info(&self) -> &WordInfo {
+        &self.word_info
+    }
+}
+
+impl<D: DictionaryAccess + Clone> SingleMorpheme<D> {
+    /// Returns the part of speech.
+    pub fn part_of_speech(&self) -> &[String] {
+        <Self as MorphemeView>::part_of_speech(self)
+    }
+
     /// Returns standalone sub-morphemes for the requested split mode.
     ///
     /// When the dictionary entry has no splits for the mode, returns a clone of
-    /// this morpheme. Offsets are assigned by advancing over each split
-    /// surface, matching Java's standalone morpheme behavior.
+    /// this morpheme. Split metadata is loaded on demand when it was not part
+    /// of the original subset, while returned morphemes still use the original
+    /// subset. Offsets match Java's standalone morpheme behavior: a single
+    /// replacement split preserves this morpheme's span, while multi-splits
+    /// advance over each split surface.
     #[allow(clippy::result_large_err)]
-    pub fn split(&self, mode: Mode) -> SudachiResult<Vec<SingleMorpheme<'a, D>>> {
-        let subset = match mode {
+    pub fn split(&self, mode: Mode) -> SudachiResult<Vec<SingleMorpheme<D>>> {
+        let split_subset = match mode {
             Mode::A => InfoSubset::SPLIT_A,
             Mode::B => InfoSubset::SPLIT_B,
             Mode::C => return Ok(vec![self.clone()]),
         };
-        let word_info = self
-            .dict
-            .lexicon()
-            .get_word_info_subset(self.word_id, subset.normalize())?;
-        let splits = match mode {
-            Mode::A => word_info.a_unit_split(),
-            Mode::B => word_info.b_unit_split(),
-            Mode::C => unreachable!(),
+
+        let word_info = if self.subset.contains(split_subset) {
+            Cow::Borrowed(&self.word_info)
+        } else {
+            Cow::Owned(
+                self.dict
+                    .lexicon()
+                    .get_word_info_subset(self.word_id, (self.subset | split_subset).normalize())?,
+            )
+        };
+
+        let splits = if mode == Mode::A {
+            word_info.a_unit_split()
+        } else {
+            word_info.b_unit_split()
         };
 
         if splits.is_empty() {
             return Ok(vec![self.clone()]);
         }
 
+        if let [word_id] = splits {
+            if *word_id == self.word_id {
+                return Ok(vec![self.clone()]);
+            }
+
+            let mut morpheme =
+                SingleMorpheme::from_word_id(self.dict.clone(), *word_id, self.subset)?;
+            morpheme.begin = self.begin;
+            morpheme.end = self.end;
+            morpheme.begin_c = self.begin_c;
+            morpheme.end_c = self.end_c;
+            return Ok(vec![morpheme]);
+        }
+
         let mut result = Vec::with_capacity(splits.len());
         let mut begin = self.begin;
         let mut begin_c = self.begin_c;
         for &word_id in splits {
-            let mut morpheme = SingleMorpheme::from_word_id(self.dict, word_id, InfoSubset::all())?;
+            let mut morpheme =
+                SingleMorpheme::from_word_id(self.dict.clone(), word_id, self.subset)?;
             let end = begin + morpheme.surface().len();
             let end_c = begin_c + morpheme.surface().chars().count();
             morpheme.begin = begin;
@@ -627,11 +698,6 @@ impl<'a, D: DictionaryAccess> SingleMorpheme<'a, D> {
         <Self as MorphemeView>::is_oov(self)
     }
 
-    /// Returns the word id of morpheme.
-    pub fn word_id(&self) -> WordId {
-        self.word_id
-    }
-
     /// Returns the dictionary id where the morpheme belongs.
     pub fn dictionary_id(&self) -> i32 {
         <Self as MorphemeView>::dictionary_id(self)
@@ -645,19 +711,19 @@ impl<'a, D: DictionaryAccess> SingleMorpheme<'a, D> {
     pub fn user_data(&self) -> &str {
         <Self as MorphemeView>::user_data(self)
     }
-
-    pub fn get_word_info(&self) -> &WordInfo {
-        &self.word_info
-    }
 }
 
-impl<D> private::Sealed for SingleMorpheme<'_, D> {}
+impl<D> private::Sealed for SingleMorpheme<D> {}
 
-impl<D: DictionaryAccess> MorphemeView for SingleMorpheme<'_, D> {
+impl<D: DictionaryAccess + Clone> MorphemeView for SingleMorpheme<D> {
     type Dictionary = D;
 
     fn dict(&self) -> &D {
-        self.dict
+        &self.dict
+    }
+
+    fn subset(&self) -> InfoSubset {
+        self.subset
     }
 
     fn begin(&self) -> usize {
@@ -693,7 +759,7 @@ impl<D: DictionaryAccess> MorphemeView for SingleMorpheme<'_, D> {
     }
 }
 
-impl<D: DictionaryAccess> Debug for SingleMorpheme<'_, D> {
+impl<D: DictionaryAccess + Clone> Debug for SingleMorpheme<D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SingleMorpheme")
             .field("surface", &self.surface())
@@ -709,10 +775,10 @@ impl<D: DictionaryAccess> Debug for SingleMorpheme<'_, D> {
 #[non_exhaustive]
 pub enum MorphemeRef<'a, D> {
     ListItem(Morpheme<'a, D>),
-    Single(Box<SingleMorpheme<'a, D>>),
+    Single(Box<SingleMorpheme<D>>),
 }
 
-impl<D> Clone for MorphemeRef<'_, D> {
+impl<D: Clone> Clone for MorphemeRef<'_, D> {
     fn clone(&self) -> Self {
         match self {
             MorphemeRef::ListItem(m) => MorphemeRef::ListItem(*m),
@@ -721,7 +787,7 @@ impl<D> Clone for MorphemeRef<'_, D> {
     }
 }
 
-impl<D: DictionaryAccess> MorphemeRef<'_, D> {
+impl<D: DictionaryAccess + Clone> MorphemeRef<'_, D> {
     /// Returns user-defined data associated with this morpheme.
     pub fn user_data(&self) -> &str {
         <Self as MorphemeView>::user_data(self)
@@ -730,13 +796,20 @@ impl<D: DictionaryAccess> MorphemeRef<'_, D> {
 
 impl<D> private::Sealed for MorphemeRef<'_, D> {}
 
-impl<D: DictionaryAccess> MorphemeView for MorphemeRef<'_, D> {
+impl<D: DictionaryAccess + Clone> MorphemeView for MorphemeRef<'_, D> {
     type Dictionary = D;
 
     fn dict(&self) -> &D {
         match self {
             MorphemeRef::ListItem(m) => m.dict(),
             MorphemeRef::Single(m) => m.dict(),
+        }
+    }
+
+    fn subset(&self) -> InfoSubset {
+        match self {
+            MorphemeRef::ListItem(m) => m.subset(),
+            MorphemeRef::Single(m) => m.subset(),
         }
     }
 
@@ -794,7 +867,7 @@ impl<D: DictionaryAccess> MorphemeView for MorphemeRef<'_, D> {
     }
 }
 
-impl<D: DictionaryAccess> Debug for MorphemeRef<'_, D> {
+impl<D: DictionaryAccess + Clone> Debug for MorphemeRef<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             MorphemeRef::ListItem(m) => Debug::fmt(m, f),

--- a/sudachi/src/analysis/morpheme.rs
+++ b/sudachi/src/analysis/morpheme.rs
@@ -21,7 +21,7 @@ use crate::dic::subset::InfoSubset;
 use crate::dic::word_id::WordId;
 use crate::dic::word_info::{WordInfo, WordInfoData, WordInfoResolver};
 use crate::dic::{DictionaryAccess, LexiconAccess};
-use crate::error::SudachiResult;
+use crate::error::{SudachiError, SudachiResult};
 use crate::input_text::InputTextIndex;
 use std::cell::Ref;
 use std::fmt::{Debug, Display, Formatter};
@@ -66,12 +66,16 @@ impl Display for MorphemeSurface<'_> {
     }
 }
 
-/// A morpheme (basic semantic unit of language).
+mod private {
+    pub trait Sealed {}
+}
+
+/// Common accessor interface for morphemes.
 ///
 /// This trait is implemented by morphemes that are part of an analysis result
-/// (`MorphemeListItem`) and by standalone morphemes materialized from a
+/// (`Morpheme`) and by standalone morphemes materialized from a
 /// dictionary entry (`SingleMorpheme`).
-pub trait Morpheme {
+pub trait MorphemeView: private::Sealed {
     type Dictionary: DictionaryAccess;
 
     #[doc(hidden)]
@@ -205,6 +209,22 @@ pub trait Morpheme {
     fn synonym_group_ids(&self) -> &[i32] {
         self.get_word_info().synonym_group_ids()
     }
+
+    /// Returns user-defined data associated with this morpheme.
+    fn user_data(&self) -> &str {
+        self.get_word_info().user_data()
+    }
+}
+
+pub(crate) fn validate_dictionary_word_id<D: DictionaryAccess>(
+    dict: &D,
+    word_id: WordId,
+) -> SudachiResult<()> {
+    if word_id == WordId::INVALID || word_id.is_oov() || word_id.is_special() {
+        return Err(SudachiError::InvalidWordId(word_id));
+    }
+
+    dict.lexicon().get_word_param_checked(word_id).map(|_| ())
 }
 
 #[allow(clippy::result_large_err)]
@@ -214,7 +234,7 @@ fn resolve_referenced_form_morpheme<'a, M, F>(
     form_word_id: F,
 ) -> SudachiResult<MorphemeRef<'a, M::Dictionary>>
 where
-    M: Morpheme + ?Sized,
+    M: MorphemeView + ?Sized,
     F: FnOnce(&WordInfoData) -> WordId,
 {
     let word_id = morpheme.word_id();
@@ -241,20 +261,20 @@ where
 }
 
 /// A morpheme as a part of an analysis result.
-pub struct MorphemeListItem<'a, D> {
+pub struct Morpheme<'a, D> {
     list: &'a MorphemeList<D>,
     index: usize,
 }
 
-impl<D> Clone for MorphemeListItem<'_, D> {
+impl<D> Clone for Morpheme<'_, D> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<D> Copy for MorphemeListItem<'_, D> {}
+impl<D> Copy for Morpheme<'_, D> {}
 
-impl<D: DictionaryAccess + Clone> MorphemeListItem<'_, D> {
+impl<D: DictionaryAccess + Clone> Morpheme<'_, D> {
     /// Returns new morpheme list splitting the morpheme with given mode.
     #[deprecated(note = "use split_into", since = "0.6.1")]
     #[allow(clippy::result_large_err)]
@@ -264,9 +284,9 @@ impl<D: DictionaryAccess + Clone> MorphemeListItem<'_, D> {
     }
 }
 
-impl<'a, D: DictionaryAccess> MorphemeListItem<'a, D> {
+impl<'a, D: DictionaryAccess> Morpheme<'a, D> {
     pub(crate) fn for_list(list: &'a MorphemeList<D>, index: usize) -> Self {
-        MorphemeListItem { list, index }
+        Morpheme { list, index }
     }
 
     #[inline]
@@ -276,7 +296,7 @@ impl<'a, D: DictionaryAccess> MorphemeListItem<'a, D> {
 
     /// Returns the part of speech.
     pub fn part_of_speech(&self) -> &[String] {
-        <Self as Morpheme>::part_of_speech(self)
+        <Self as MorphemeView>::part_of_speech(self)
     }
 
     /// Returns the begin index in bytes of the morpheme in the original text.
@@ -306,20 +326,20 @@ impl<'a, D: DictionaryAccess> MorphemeListItem<'a, D> {
     }
 
     pub fn part_of_speech_id(&self) -> u16 {
-        <Self as Morpheme>::part_of_speech_id(self)
+        <Self as MorphemeView>::part_of_speech_id(self)
     }
 
     /// Returns the dictionary form of morpheme.
     ///
     /// "Dictionary form" means a word's lemma and "終止形" in Japanese.
     pub fn dictionary_form(&self) -> &str {
-        <Self as Morpheme>::dictionary_form(self)
+        <Self as MorphemeView>::dictionary_form(self)
     }
 
     /// Returns the morpheme corresponding to this morpheme's dictionary form.
     #[allow(clippy::result_large_err)]
     pub fn dictionary_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>> {
-        <Self as Morpheme>::dictionary_form_morpheme(self)
+        <Self as MorphemeView>::dictionary_form_morpheme(self)
     }
 
     /// Returns the normalized form of morpheme.
@@ -327,25 +347,25 @@ impl<'a, D: DictionaryAccess> MorphemeListItem<'a, D> {
     /// This method returns the form normalizing inconsistent spellings and
     /// inflected forms.
     pub fn normalized_form(&self) -> &str {
-        <Self as Morpheme>::normalized_form(self)
+        <Self as MorphemeView>::normalized_form(self)
     }
 
     /// Returns the morpheme corresponding to this morpheme's normalized form.
     #[allow(clippy::result_large_err)]
     pub fn normalized_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>> {
-        <Self as Morpheme>::normalized_form_morpheme(self)
+        <Self as MorphemeView>::normalized_form_morpheme(self)
     }
 
     /// Returns the reading form of morpheme.
     ///
     /// Returns Japanese syllabaries 'フリガナ' in katakana.
     pub fn reading_form(&self) -> &str {
-        <Self as Morpheme>::reading_form(self)
+        <Self as MorphemeView>::reading_form(self)
     }
 
     /// Returns if this morpheme is out of vocabulary.
     pub fn is_oov(&self) -> bool {
-        <Self as Morpheme>::is_oov(self)
+        <Self as MorphemeView>::is_oov(self)
     }
 
     /// Returns the word id of morpheme.
@@ -357,11 +377,16 @@ impl<'a, D: DictionaryAccess> MorphemeListItem<'a, D> {
     ///
     /// Returns -1 if the morpheme is oov.
     pub fn dictionary_id(&self) -> i32 {
-        <Self as Morpheme>::dictionary_id(self)
+        <Self as MorphemeView>::dictionary_id(self)
     }
 
     pub fn synonym_group_ids(&self) -> &[i32] {
-        <Self as Morpheme>::synonym_group_ids(self)
+        <Self as MorphemeView>::synonym_group_ids(self)
+    }
+
+    /// Returns user-defined data associated with this morpheme.
+    pub fn user_data(&self) -> &str {
+        <Self as MorphemeView>::user_data(self)
     }
 
     pub fn get_word_info(&self) -> &WordInfo {
@@ -387,7 +412,9 @@ impl<'a, D: DictionaryAccess> MorphemeListItem<'a, D> {
     }
 }
 
-impl<D: DictionaryAccess> Morpheme for MorphemeListItem<'_, D> {
+impl<D> private::Sealed for Morpheme<'_, D> {}
+
+impl<D: DictionaryAccess> MorphemeView for Morpheme<'_, D> {
     type Dictionary = D;
 
     fn dict(&self) -> &D {
@@ -395,31 +422,31 @@ impl<D: DictionaryAccess> Morpheme for MorphemeListItem<'_, D> {
     }
 
     fn begin(&self) -> usize {
-        MorphemeListItem::begin(self)
+        Morpheme::begin(self)
     }
 
     fn end(&self) -> usize {
-        MorphemeListItem::end(self)
+        Morpheme::end(self)
     }
 
     fn begin_c(&self) -> usize {
-        MorphemeListItem::begin_c(self)
+        Morpheme::begin_c(self)
     }
 
     fn end_c(&self) -> usize {
-        MorphemeListItem::end_c(self)
+        Morpheme::end_c(self)
     }
 
     fn surface(&self) -> MorphemeSurface<'_> {
-        MorphemeSurface::Input(MorphemeListItem::surface(self))
+        MorphemeSurface::Input(Morpheme::surface(self))
     }
 
     fn word_id(&self) -> WordId {
-        MorphemeListItem::word_id(self)
+        Morpheme::word_id(self)
     }
 
     fn get_word_info(&self) -> &WordInfo {
-        MorphemeListItem::get_word_info(self)
+        Morpheme::get_word_info(self)
     }
 
     fn self_morpheme(&self) -> MorphemeRef<'_, D> {
@@ -427,9 +454,9 @@ impl<D: DictionaryAccess> Morpheme for MorphemeListItem<'_, D> {
     }
 }
 
-impl<D: DictionaryAccess> Debug for MorphemeListItem<'_, D> {
+impl<D: DictionaryAccess> Debug for Morpheme<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MorphemeListItem")
+        f.debug_struct("Morpheme")
             .field("surface", &self.surface())
             .field("pos", &self.part_of_speech())
             .field("normalized_form", &self.normalized_form())
@@ -471,6 +498,7 @@ impl<'a, D: DictionaryAccess> SingleMorpheme<'a, D> {
     /// identity is preserved.
     #[allow(clippy::result_large_err)]
     pub fn from_word_id(dict: &'a D, word_id: WordId, subset: InfoSubset) -> SudachiResult<Self> {
+        validate_dictionary_word_id(dict, word_id)?;
         let subset = (subset | InfoSubset::HEADWORD).normalize();
         let word_info = dict.lexicon().get_word_info_subset(word_id, subset)?;
         let surface = word_info.headword(dict.lexicon());
@@ -490,7 +518,7 @@ impl<'a, D: DictionaryAccess> SingleMorpheme<'a, D> {
 
     /// Returns the part of speech.
     pub fn part_of_speech(&self) -> &[String] {
-        <Self as Morpheme>::part_of_speech(self)
+        <Self as MorphemeView>::part_of_speech(self)
     }
 
     /// Returns the begin index in bytes of this standalone morpheme.
@@ -518,40 +546,85 @@ impl<'a, D: DictionaryAccess> SingleMorpheme<'a, D> {
         self.word_info.headword(self.dict.lexicon())
     }
 
+    /// Returns standalone sub-morphemes for the requested split mode.
+    ///
+    /// When the dictionary entry has no splits for the mode, returns a clone of
+    /// this morpheme. Offsets are assigned by advancing over each split
+    /// surface, matching Java's standalone morpheme behavior.
+    #[allow(clippy::result_large_err)]
+    pub fn split(&self, mode: Mode) -> SudachiResult<Vec<SingleMorpheme<'a, D>>> {
+        let subset = match mode {
+            Mode::A => InfoSubset::SPLIT_A,
+            Mode::B => InfoSubset::SPLIT_B,
+            Mode::C => return Ok(vec![self.clone()]),
+        };
+        let word_info = self
+            .dict
+            .lexicon()
+            .get_word_info_subset(self.word_id, subset.normalize())?;
+        let splits = match mode {
+            Mode::A => word_info.a_unit_split(),
+            Mode::B => word_info.b_unit_split(),
+            Mode::C => unreachable!(),
+        };
+
+        if splits.is_empty() {
+            return Ok(vec![self.clone()]);
+        }
+
+        let mut result = Vec::with_capacity(splits.len());
+        let mut begin = self.begin;
+        let mut begin_c = self.begin_c;
+        for &word_id in splits {
+            let mut morpheme = SingleMorpheme::from_word_id(self.dict, word_id, InfoSubset::all())?;
+            let end = begin + morpheme.surface().len();
+            let end_c = begin_c + morpheme.surface().chars().count();
+            morpheme.begin = begin;
+            morpheme.end = end;
+            morpheme.begin_c = begin_c;
+            morpheme.end_c = end_c;
+            begin = end;
+            begin_c = end_c;
+            result.push(morpheme);
+        }
+
+        Ok(result)
+    }
+
     pub fn part_of_speech_id(&self) -> u16 {
-        <Self as Morpheme>::part_of_speech_id(self)
+        <Self as MorphemeView>::part_of_speech_id(self)
     }
 
     /// Returns the dictionary form of morpheme.
     pub fn dictionary_form(&self) -> &str {
-        <Self as Morpheme>::dictionary_form(self)
+        <Self as MorphemeView>::dictionary_form(self)
     }
 
     /// Returns the morpheme corresponding to this morpheme's dictionary form.
     #[allow(clippy::result_large_err)]
     pub fn dictionary_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>> {
-        <Self as Morpheme>::dictionary_form_morpheme(self)
+        <Self as MorphemeView>::dictionary_form_morpheme(self)
     }
 
     /// Returns the normalized form of morpheme.
     pub fn normalized_form(&self) -> &str {
-        <Self as Morpheme>::normalized_form(self)
+        <Self as MorphemeView>::normalized_form(self)
     }
 
     /// Returns the morpheme corresponding to this morpheme's normalized form.
     #[allow(clippy::result_large_err)]
     pub fn normalized_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>> {
-        <Self as Morpheme>::normalized_form_morpheme(self)
+        <Self as MorphemeView>::normalized_form_morpheme(self)
     }
 
     /// Returns the reading form of morpheme.
     pub fn reading_form(&self) -> &str {
-        <Self as Morpheme>::reading_form(self)
+        <Self as MorphemeView>::reading_form(self)
     }
 
     /// Returns if this morpheme is out of vocabulary.
     pub fn is_oov(&self) -> bool {
-        <Self as Morpheme>::is_oov(self)
+        <Self as MorphemeView>::is_oov(self)
     }
 
     /// Returns the word id of morpheme.
@@ -561,11 +634,16 @@ impl<'a, D: DictionaryAccess> SingleMorpheme<'a, D> {
 
     /// Returns the dictionary id where the morpheme belongs.
     pub fn dictionary_id(&self) -> i32 {
-        <Self as Morpheme>::dictionary_id(self)
+        <Self as MorphemeView>::dictionary_id(self)
     }
 
     pub fn synonym_group_ids(&self) -> &[i32] {
-        <Self as Morpheme>::synonym_group_ids(self)
+        <Self as MorphemeView>::synonym_group_ids(self)
+    }
+
+    /// Returns user-defined data associated with this morpheme.
+    pub fn user_data(&self) -> &str {
+        <Self as MorphemeView>::user_data(self)
     }
 
     pub fn get_word_info(&self) -> &WordInfo {
@@ -573,7 +651,9 @@ impl<'a, D: DictionaryAccess> SingleMorpheme<'a, D> {
     }
 }
 
-impl<D: DictionaryAccess> Morpheme for SingleMorpheme<'_, D> {
+impl<D> private::Sealed for SingleMorpheme<'_, D> {}
+
+impl<D: DictionaryAccess> MorphemeView for SingleMorpheme<'_, D> {
     type Dictionary = D;
 
     fn dict(&self) -> &D {
@@ -626,8 +706,9 @@ impl<D: DictionaryAccess> Debug for SingleMorpheme<'_, D> {
 }
 
 /// A morpheme reference that can be either list-backed or standalone.
+#[non_exhaustive]
 pub enum MorphemeRef<'a, D> {
-    ListItem(MorphemeListItem<'a, D>),
+    ListItem(Morpheme<'a, D>),
     Single(Box<SingleMorpheme<'a, D>>),
 }
 
@@ -640,7 +721,16 @@ impl<D> Clone for MorphemeRef<'_, D> {
     }
 }
 
-impl<D: DictionaryAccess> Morpheme for MorphemeRef<'_, D> {
+impl<D: DictionaryAccess> MorphemeRef<'_, D> {
+    /// Returns user-defined data associated with this morpheme.
+    pub fn user_data(&self) -> &str {
+        <Self as MorphemeView>::user_data(self)
+    }
+}
+
+impl<D> private::Sealed for MorphemeRef<'_, D> {}
+
+impl<D: DictionaryAccess> MorphemeView for MorphemeRef<'_, D> {
     type Dictionary = D;
 
     fn dict(&self) -> &D {

--- a/sudachi/src/analysis/morpheme.rs
+++ b/sudachi/src/analysis/morpheme.rs
@@ -14,118 +14,186 @@
  *  limitations under the License.
  */
 
+use crate::analysis::mlist::MorphemeList;
 use crate::analysis::node::{LatticeNode, PathCost, ResultNode};
+use crate::analysis::Mode;
+use crate::dic::subset::InfoSubset;
 use crate::dic::word_id::WordId;
-use crate::dic::word_info::{WordInfo, WordInfoResolver};
-use crate::dic::DictionaryAccess;
+use crate::dic::word_info::{WordInfo, WordInfoData, WordInfoResolver};
+use crate::dic::{DictionaryAccess, LexiconAccess};
+use crate::error::SudachiResult;
 use crate::input_text::InputTextIndex;
-use crate::prelude::*;
 use std::cell::Ref;
+use std::fmt::{Debug, Display, Formatter};
+use std::ops::Deref;
 
-/// A morpheme (basic semantic unit of language)
-pub struct Morpheme<'a, D> {
-    list: &'a MorphemeList<D>,
-    index: usize,
+/// Surface text returned by a morpheme.
+///
+/// Analysis-result morphemes borrow their surface from an `InputBuffer`, while
+/// standalone morphemes expose a dictionary headword. This wrapper keeps both
+/// cases usable through the same `Deref<Target = str>` interface.
+pub enum MorphemeSurface<'a> {
+    Input(Ref<'a, str>),
+    Headword(&'a str),
 }
 
-impl<D: DictionaryAccess> Morpheme<'_, D> {
-    /// Returns the part of speech
-    pub fn part_of_speech(&self) -> &[String] {
-        self.list
-            .dict()
+impl Deref for MorphemeSurface<'_> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            MorphemeSurface::Input(surface) => surface.deref(),
+            MorphemeSurface::Headword(surface) => surface,
+        }
+    }
+}
+
+impl AsRef<str> for MorphemeSurface<'_> {
+    fn as_ref(&self) -> &str {
+        self.deref()
+    }
+}
+
+impl Debug for MorphemeSurface<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(self.deref(), f)
+    }
+}
+
+impl Display for MorphemeSurface<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self.deref(), f)
+    }
+}
+
+/// A morpheme (basic semantic unit of language).
+///
+/// This trait is implemented by morphemes that are part of an analysis result
+/// (`MorphemeListItem`) and by standalone morphemes materialized from a
+/// dictionary entry (`SingleMorpheme`).
+pub trait Morpheme {
+    type Dictionary: DictionaryAccess;
+
+    #[doc(hidden)]
+    fn dict(&self) -> &Self::Dictionary;
+
+    /// Returns the begin index in bytes of the morpheme.
+    fn begin(&self) -> usize;
+
+    /// Returns the end index in bytes of the morpheme.
+    fn end(&self) -> usize;
+
+    /// Returns the codepoint offset of the morpheme begin.
+    fn begin_c(&self) -> usize;
+
+    /// Returns the codepoint offset of the morpheme end.
+    fn end_c(&self) -> usize;
+
+    /// Returns text corresponding to the morpheme.
+    fn surface(&self) -> MorphemeSurface<'_>;
+
+    /// Returns the ID of part of speech of the morpheme.
+    fn part_of_speech_id(&self) -> u16 {
+        self.get_word_info().pos_id()
+    }
+
+    /// Returns the word id of morpheme.
+    fn word_id(&self) -> WordId;
+
+    /// Returns the dictionary information for this morpheme.
+    fn get_word_info(&self) -> &WordInfo;
+
+    fn self_morpheme(&self) -> MorphemeRef<'_, Self::Dictionary>;
+
+    fn resolver<'a>(&'a self) -> &'a dyn WordInfoResolver
+    where
+        Self::Dictionary: 'a,
+    {
+        self.dict().lexicon()
+    }
+
+    /// Returns the part of speech.
+    fn part_of_speech<'a>(&'a self) -> &'a [String]
+    where
+        Self::Dictionary: 'a,
+    {
+        self.dict()
             .grammar()
             .pos_components(self.part_of_speech_id())
     }
-}
 
-impl<D: DictionaryAccess + Clone> Morpheme<'_, D> {
-    /// Returns new morpheme list splitting the morpheme with given mode.
-    #[deprecated(note = "use split_into", since = "0.6.1")]
-    pub fn split(&self, mode: Mode) -> SudachiResult<MorphemeList<D>> {
-        #[allow(deprecated)]
-        self.list.split(mode, self.index)
-    }
-}
-
-impl<'a, D: DictionaryAccess> Morpheme<'a, D> {
-    pub(crate) fn for_list(list: &'a MorphemeList<D>, index: usize) -> Self {
-        Morpheme { list, index }
-    }
-
-    #[inline]
-    pub(crate) fn node(&self) -> &ResultNode {
-        self.list.node(self.index)
-    }
-
-    fn resolver(&self) -> &dyn WordInfoResolver {
-        self.list.dict().lexicon()
-    }
-
-    /// Returns the begin index in bytes of the morpheme in the original text
-    pub fn begin(&self) -> usize {
-        self.list.input().to_orig_byte_idx(self.node().begin())
-    }
-
-    /// Returns the end index in bytes of the morpheme in the original text
-    pub fn end(&self) -> usize {
-        self.list.input().to_orig_byte_idx(self.node().end())
-    }
-
-    /// Returns the codepoint offset of the morpheme begin in the original text
-    pub fn begin_c(&self) -> usize {
-        self.list.input().to_orig_char_idx(self.node().begin())
-    }
-
-    /// Returns the codepoint offset of the morpheme begin in the original text
-    pub fn end_c(&self) -> usize {
-        self.list.input().to_orig_char_idx(self.node().end())
-    }
-
-    /// Returns a substring of the original text which corresponds to the morpheme
-    pub fn surface(&self) -> Ref<'_, str> {
-        let inp = self.list.input();
-        Ref::map(inp, |i| i.orig_slice(self.node().bytes_range()))
-    }
-
-    pub fn part_of_speech_id(&self) -> u16 {
-        self.node().word_info().pos_id()
-    }
-
-    /// Returns the dictionary form of morpheme
+    /// Returns the dictionary form of morpheme.
     ///
     /// "Dictionary form" means a word's lemma and "終止形" in Japanese.
-    pub fn dictionary_form(&self) -> &str {
+    fn dictionary_form<'a>(&'a self) -> &'a str
+    where
+        Self::Dictionary: 'a,
+    {
         self.get_word_info().dictionary_form(self.resolver())
     }
 
-    /// Returns the normalized form of morpheme
+    /// Returns the morpheme corresponding to this morpheme's dictionary form.
     ///
-    /// This method returns the form normalizing inconsistent spellings and inflected forms
-    pub fn normalized_form(&self) -> &str {
+    /// For OOV morphemes, invalid references, and references to the same
+    /// dictionary entry, returns a morpheme equivalent to `self`. For a
+    /// distinct referenced entry, returns a standalone morpheme whose offsets
+    /// are `0..surface.len()` in bytes and `0..surface.chars().count()` in
+    /// codepoints.
+    #[allow(clippy::result_large_err)]
+    fn dictionary_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, Self::Dictionary>> {
+        resolve_referenced_form_morpheme(
+            self,
+            InfoSubset::DICTIONARY_FORM,
+            WordInfoData::dictionary_form_word_id,
+        )
+    }
+
+    /// Returns the normalized form of morpheme.
+    ///
+    /// This method returns the form normalizing inconsistent spellings and
+    /// inflected forms.
+    fn normalized_form<'a>(&'a self) -> &'a str
+    where
+        Self::Dictionary: 'a,
+    {
         self.get_word_info().normalized_form(self.resolver())
+    }
+
+    /// Returns the morpheme corresponding to this morpheme's normalized form.
+    ///
+    /// For OOV morphemes, invalid references, and references to the same
+    /// dictionary entry, returns a morpheme equivalent to `self`. For a
+    /// distinct referenced entry, returns a standalone morpheme whose offsets
+    /// are `0..surface.len()` in bytes and `0..surface.chars().count()` in
+    /// codepoints.
+    #[allow(clippy::result_large_err)]
+    fn normalized_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, Self::Dictionary>> {
+        resolve_referenced_form_morpheme(
+            self,
+            InfoSubset::NORMALIZED_FORM,
+            WordInfoData::normalized_form_word_id,
+        )
     }
 
     /// Returns the reading form of morpheme.
     ///
     /// Returns Japanese syllabaries 'フリガナ' in katakana.
-    pub fn reading_form(&self) -> &str {
+    fn reading_form<'a>(&'a self) -> &'a str
+    where
+        Self::Dictionary: 'a,
+    {
         self.get_word_info().reading_form(self.resolver())
     }
 
-    /// Returns if this morpheme is out of vocabulary
-    pub fn is_oov(&self) -> bool {
+    /// Returns if this morpheme is out of vocabulary.
+    fn is_oov(&self) -> bool {
         self.word_id().is_oov()
     }
 
-    /// Returns the word id of morpheme
-    pub fn word_id(&self) -> WordId {
-        self.node().word_id()
-    }
-
-    /// Returns the dictionary id where the morpheme belongs
+    /// Returns the dictionary id where the morpheme belongs.
     ///
-    /// Returns -1 if the morpheme is oov
-    pub fn dictionary_id(&self) -> i32 {
+    /// Returns -1 if the morpheme is oov.
+    fn dictionary_id(&self) -> i32 {
         let wid = self.word_id();
         if wid.is_oov() {
             -1
@@ -134,15 +202,173 @@ impl<'a, D: DictionaryAccess> Morpheme<'a, D> {
         }
     }
 
-    pub fn synonym_group_ids(&self) -> &[i32] {
+    fn synonym_group_ids(&self) -> &[i32] {
         self.get_word_info().synonym_group_ids()
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn resolve_referenced_form_morpheme<'a, M, F>(
+    morpheme: &'a M,
+    subset: InfoSubset,
+    form_word_id: F,
+) -> SudachiResult<MorphemeRef<'a, M::Dictionary>>
+where
+    M: Morpheme + ?Sized,
+    F: FnOnce(&WordInfoData) -> WordId,
+{
+    let word_id = morpheme.word_id();
+    if word_id.is_oov() || word_id.is_special() {
+        return Ok(morpheme.self_morpheme());
+    }
+
+    let word_info = morpheme
+        .dict()
+        .lexicon()
+        .get_word_info_subset(word_id, subset)?;
+    let form_word_id = form_word_id(word_info.borrow_data());
+    if form_word_id == WordId::INVALID
+        || form_word_id == word_id
+        || form_word_id.is_oov()
+        || form_word_id.is_special()
+    {
+        return Ok(morpheme.self_morpheme());
+    }
+
+    SingleMorpheme::from_word_id(morpheme.dict(), form_word_id, InfoSubset::all())
+        .map(Box::new)
+        .map(MorphemeRef::Single)
+}
+
+/// A morpheme as a part of an analysis result.
+pub struct MorphemeListItem<'a, D> {
+    list: &'a MorphemeList<D>,
+    index: usize,
+}
+
+impl<D> Clone for MorphemeListItem<'_, D> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<D> Copy for MorphemeListItem<'_, D> {}
+
+impl<D: DictionaryAccess + Clone> MorphemeListItem<'_, D> {
+    /// Returns new morpheme list splitting the morpheme with given mode.
+    #[deprecated(note = "use split_into", since = "0.6.1")]
+    #[allow(clippy::result_large_err)]
+    pub fn split(&self, mode: Mode) -> SudachiResult<MorphemeList<D>> {
+        #[allow(deprecated)]
+        self.list.split(mode, self.index)
+    }
+}
+
+impl<'a, D: DictionaryAccess> MorphemeListItem<'a, D> {
+    pub(crate) fn for_list(list: &'a MorphemeList<D>, index: usize) -> Self {
+        MorphemeListItem { list, index }
+    }
+
+    #[inline]
+    pub(crate) fn node(&self) -> &ResultNode {
+        self.list.node(self.index)
+    }
+
+    /// Returns the part of speech.
+    pub fn part_of_speech(&self) -> &[String] {
+        <Self as Morpheme>::part_of_speech(self)
+    }
+
+    /// Returns the begin index in bytes of the morpheme in the original text.
+    pub fn begin(&self) -> usize {
+        self.list.input().to_orig_byte_idx(self.node().begin())
+    }
+
+    /// Returns the end index in bytes of the morpheme in the original text.
+    pub fn end(&self) -> usize {
+        self.list.input().to_orig_byte_idx(self.node().end())
+    }
+
+    /// Returns the codepoint offset of the morpheme begin in the original text.
+    pub fn begin_c(&self) -> usize {
+        self.list.input().to_orig_char_idx(self.node().begin())
+    }
+
+    /// Returns the codepoint offset of the morpheme end in the original text.
+    pub fn end_c(&self) -> usize {
+        self.list.input().to_orig_char_idx(self.node().end())
+    }
+
+    /// Returns a substring of the original text which corresponds to the morpheme.
+    pub fn surface(&self) -> Ref<'_, str> {
+        let inp = self.list.input();
+        Ref::map(inp, |i| i.orig_slice(self.node().bytes_range()))
+    }
+
+    pub fn part_of_speech_id(&self) -> u16 {
+        <Self as Morpheme>::part_of_speech_id(self)
+    }
+
+    /// Returns the dictionary form of morpheme.
+    ///
+    /// "Dictionary form" means a word's lemma and "終止形" in Japanese.
+    pub fn dictionary_form(&self) -> &str {
+        <Self as Morpheme>::dictionary_form(self)
+    }
+
+    /// Returns the morpheme corresponding to this morpheme's dictionary form.
+    #[allow(clippy::result_large_err)]
+    pub fn dictionary_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>> {
+        <Self as Morpheme>::dictionary_form_morpheme(self)
+    }
+
+    /// Returns the normalized form of morpheme.
+    ///
+    /// This method returns the form normalizing inconsistent spellings and
+    /// inflected forms.
+    pub fn normalized_form(&self) -> &str {
+        <Self as Morpheme>::normalized_form(self)
+    }
+
+    /// Returns the morpheme corresponding to this morpheme's normalized form.
+    #[allow(clippy::result_large_err)]
+    pub fn normalized_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>> {
+        <Self as Morpheme>::normalized_form_morpheme(self)
+    }
+
+    /// Returns the reading form of morpheme.
+    ///
+    /// Returns Japanese syllabaries 'フリガナ' in katakana.
+    pub fn reading_form(&self) -> &str {
+        <Self as Morpheme>::reading_form(self)
+    }
+
+    /// Returns if this morpheme is out of vocabulary.
+    pub fn is_oov(&self) -> bool {
+        <Self as Morpheme>::is_oov(self)
+    }
+
+    /// Returns the word id of morpheme.
+    pub fn word_id(&self) -> WordId {
+        self.node().word_id()
+    }
+
+    /// Returns the dictionary id where the morpheme belongs.
+    ///
+    /// Returns -1 if the morpheme is oov.
+    pub fn dictionary_id(&self) -> i32 {
+        <Self as Morpheme>::dictionary_id(self)
+    }
+
+    pub fn synonym_group_ids(&self) -> &[i32] {
+        <Self as Morpheme>::synonym_group_ids(self)
     }
 
     pub fn get_word_info(&self) -> &WordInfo {
         self.node().word_info()
     }
 
-    /// Returns the index of this morpheme
+    /// Returns the index of this morpheme.
     pub fn index(&self) -> usize {
         self.index
     }
@@ -150,24 +376,339 @@ impl<'a, D: DictionaryAccess> Morpheme<'a, D> {
     /// Splits morpheme and writes sub-morphemes into the provided list.
     /// The resulting list is _not_ cleared before that.
     /// Returns true if split has produced any elements.
+    #[allow(clippy::result_large_err)]
     pub fn split_into(&self, mode: Mode, out: &mut MorphemeList<D>) -> SudachiResult<bool> {
         self.list.split_into(mode, self.index, out)
     }
 
-    /// Returns total cost from the beginning of the path
+    /// Returns total cost from the beginning of the path.
     pub fn total_cost(&self) -> i32 {
-        return self.node().total_cost();
+        self.node().total_cost()
     }
 }
 
-impl<D: DictionaryAccess> std::fmt::Debug for Morpheme<'_, D> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Morpheme")
+impl<D: DictionaryAccess> Morpheme for MorphemeListItem<'_, D> {
+    type Dictionary = D;
+
+    fn dict(&self) -> &D {
+        self.list.dict()
+    }
+
+    fn begin(&self) -> usize {
+        MorphemeListItem::begin(self)
+    }
+
+    fn end(&self) -> usize {
+        MorphemeListItem::end(self)
+    }
+
+    fn begin_c(&self) -> usize {
+        MorphemeListItem::begin_c(self)
+    }
+
+    fn end_c(&self) -> usize {
+        MorphemeListItem::end_c(self)
+    }
+
+    fn surface(&self) -> MorphemeSurface<'_> {
+        MorphemeSurface::Input(MorphemeListItem::surface(self))
+    }
+
+    fn word_id(&self) -> WordId {
+        MorphemeListItem::word_id(self)
+    }
+
+    fn get_word_info(&self) -> &WordInfo {
+        MorphemeListItem::get_word_info(self)
+    }
+
+    fn self_morpheme(&self) -> MorphemeRef<'_, D> {
+        MorphemeRef::ListItem(*self)
+    }
+}
+
+impl<D: DictionaryAccess> Debug for MorphemeListItem<'_, D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MorphemeListItem")
             .field("surface", &self.surface())
             .field("pos", &self.part_of_speech())
             .field("normalized_form", &self.normalized_form())
             .field("reading_form", &self.reading_form())
             .field("dictionary_form", &self.dictionary_form())
             .finish()
+    }
+}
+
+/// A standalone morpheme materialized from a single dictionary entry.
+pub struct SingleMorpheme<'a, D> {
+    dict: &'a D,
+    word_id: WordId,
+    word_info: WordInfo,
+    begin: usize,
+    end: usize,
+    begin_c: usize,
+    end_c: usize,
+}
+
+impl<D> Clone for SingleMorpheme<'_, D> {
+    fn clone(&self) -> Self {
+        Self {
+            dict: self.dict,
+            word_id: self.word_id,
+            word_info: self.word_info.clone(),
+            begin: self.begin,
+            end: self.end,
+            begin_c: self.begin_c,
+            end_c: self.end_c,
+        }
+    }
+}
+
+impl<'a, D: DictionaryAccess> SingleMorpheme<'a, D> {
+    /// Creates a standalone morpheme for the exact dictionary entry.
+    ///
+    /// The entry is resolved by `WordId`, not by surface lookup, so homograph
+    /// identity is preserved.
+    #[allow(clippy::result_large_err)]
+    pub fn from_word_id(dict: &'a D, word_id: WordId, subset: InfoSubset) -> SudachiResult<Self> {
+        let subset = (subset | InfoSubset::HEADWORD).normalize();
+        let word_info = dict.lexicon().get_word_info_subset(word_id, subset)?;
+        let surface = word_info.headword(dict.lexicon());
+        let end = surface.len();
+        let end_c = surface.chars().count();
+
+        Ok(Self {
+            dict,
+            word_id,
+            word_info,
+            begin: 0,
+            end,
+            begin_c: 0,
+            end_c,
+        })
+    }
+
+    /// Returns the part of speech.
+    pub fn part_of_speech(&self) -> &[String] {
+        <Self as Morpheme>::part_of_speech(self)
+    }
+
+    /// Returns the begin index in bytes of this standalone morpheme.
+    pub fn begin(&self) -> usize {
+        self.begin
+    }
+
+    /// Returns the end index in bytes of this standalone morpheme.
+    pub fn end(&self) -> usize {
+        self.end
+    }
+
+    /// Returns the codepoint offset of this standalone morpheme begin.
+    pub fn begin_c(&self) -> usize {
+        self.begin_c
+    }
+
+    /// Returns the codepoint offset of this standalone morpheme end.
+    pub fn end_c(&self) -> usize {
+        self.end_c
+    }
+
+    /// Returns the dictionary headword surface.
+    pub fn surface(&self) -> &str {
+        self.word_info.headword(self.dict.lexicon())
+    }
+
+    pub fn part_of_speech_id(&self) -> u16 {
+        <Self as Morpheme>::part_of_speech_id(self)
+    }
+
+    /// Returns the dictionary form of morpheme.
+    pub fn dictionary_form(&self) -> &str {
+        <Self as Morpheme>::dictionary_form(self)
+    }
+
+    /// Returns the morpheme corresponding to this morpheme's dictionary form.
+    #[allow(clippy::result_large_err)]
+    pub fn dictionary_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>> {
+        <Self as Morpheme>::dictionary_form_morpheme(self)
+    }
+
+    /// Returns the normalized form of morpheme.
+    pub fn normalized_form(&self) -> &str {
+        <Self as Morpheme>::normalized_form(self)
+    }
+
+    /// Returns the morpheme corresponding to this morpheme's normalized form.
+    #[allow(clippy::result_large_err)]
+    pub fn normalized_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>> {
+        <Self as Morpheme>::normalized_form_morpheme(self)
+    }
+
+    /// Returns the reading form of morpheme.
+    pub fn reading_form(&self) -> &str {
+        <Self as Morpheme>::reading_form(self)
+    }
+
+    /// Returns if this morpheme is out of vocabulary.
+    pub fn is_oov(&self) -> bool {
+        <Self as Morpheme>::is_oov(self)
+    }
+
+    /// Returns the word id of morpheme.
+    pub fn word_id(&self) -> WordId {
+        self.word_id
+    }
+
+    /// Returns the dictionary id where the morpheme belongs.
+    pub fn dictionary_id(&self) -> i32 {
+        <Self as Morpheme>::dictionary_id(self)
+    }
+
+    pub fn synonym_group_ids(&self) -> &[i32] {
+        <Self as Morpheme>::synonym_group_ids(self)
+    }
+
+    pub fn get_word_info(&self) -> &WordInfo {
+        &self.word_info
+    }
+}
+
+impl<D: DictionaryAccess> Morpheme for SingleMorpheme<'_, D> {
+    type Dictionary = D;
+
+    fn dict(&self) -> &D {
+        self.dict
+    }
+
+    fn begin(&self) -> usize {
+        SingleMorpheme::begin(self)
+    }
+
+    fn end(&self) -> usize {
+        SingleMorpheme::end(self)
+    }
+
+    fn begin_c(&self) -> usize {
+        SingleMorpheme::begin_c(self)
+    }
+
+    fn end_c(&self) -> usize {
+        SingleMorpheme::end_c(self)
+    }
+
+    fn surface(&self) -> MorphemeSurface<'_> {
+        MorphemeSurface::Headword(SingleMorpheme::surface(self))
+    }
+
+    fn word_id(&self) -> WordId {
+        SingleMorpheme::word_id(self)
+    }
+
+    fn get_word_info(&self) -> &WordInfo {
+        SingleMorpheme::get_word_info(self)
+    }
+
+    fn self_morpheme(&self) -> MorphemeRef<'_, D> {
+        MorphemeRef::Single(Box::new(self.clone()))
+    }
+}
+
+impl<D: DictionaryAccess> Debug for SingleMorpheme<'_, D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SingleMorpheme")
+            .field("surface", &self.surface())
+            .field("pos", &self.part_of_speech())
+            .field("normalized_form", &self.normalized_form())
+            .field("reading_form", &self.reading_form())
+            .field("dictionary_form", &self.dictionary_form())
+            .finish()
+    }
+}
+
+/// A morpheme reference that can be either list-backed or standalone.
+pub enum MorphemeRef<'a, D> {
+    ListItem(MorphemeListItem<'a, D>),
+    Single(Box<SingleMorpheme<'a, D>>),
+}
+
+impl<D> Clone for MorphemeRef<'_, D> {
+    fn clone(&self) -> Self {
+        match self {
+            MorphemeRef::ListItem(m) => MorphemeRef::ListItem(*m),
+            MorphemeRef::Single(m) => MorphemeRef::Single(m.clone()),
+        }
+    }
+}
+
+impl<D: DictionaryAccess> Morpheme for MorphemeRef<'_, D> {
+    type Dictionary = D;
+
+    fn dict(&self) -> &D {
+        match self {
+            MorphemeRef::ListItem(m) => m.dict(),
+            MorphemeRef::Single(m) => m.dict(),
+        }
+    }
+
+    fn begin(&self) -> usize {
+        match self {
+            MorphemeRef::ListItem(m) => m.begin(),
+            MorphemeRef::Single(m) => m.begin(),
+        }
+    }
+
+    fn end(&self) -> usize {
+        match self {
+            MorphemeRef::ListItem(m) => m.end(),
+            MorphemeRef::Single(m) => m.end(),
+        }
+    }
+
+    fn begin_c(&self) -> usize {
+        match self {
+            MorphemeRef::ListItem(m) => m.begin_c(),
+            MorphemeRef::Single(m) => m.begin_c(),
+        }
+    }
+
+    fn end_c(&self) -> usize {
+        match self {
+            MorphemeRef::ListItem(m) => m.end_c(),
+            MorphemeRef::Single(m) => m.end_c(),
+        }
+    }
+
+    fn surface(&self) -> MorphemeSurface<'_> {
+        match self {
+            MorphemeRef::ListItem(m) => MorphemeSurface::Input(m.surface()),
+            MorphemeRef::Single(m) => MorphemeSurface::Headword(m.surface()),
+        }
+    }
+
+    fn word_id(&self) -> WordId {
+        match self {
+            MorphemeRef::ListItem(m) => m.word_id(),
+            MorphemeRef::Single(m) => m.word_id(),
+        }
+    }
+
+    fn get_word_info(&self) -> &WordInfo {
+        match self {
+            MorphemeRef::ListItem(m) => m.get_word_info(),
+            MorphemeRef::Single(m) => m.get_word_info(),
+        }
+    }
+
+    fn self_morpheme(&self) -> MorphemeRef<'_, D> {
+        self.clone()
+    }
+}
+
+impl<D: DictionaryAccess> Debug for MorphemeRef<'_, D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MorphemeRef::ListItem(m) => Debug::fmt(m, f),
+            MorphemeRef::Single(m) => Debug::fmt(m, f),
+        }
     }
 }

--- a/sudachi/src/dic/lexicon.rs
+++ b/sudachi/src/dic/lexicon.rs
@@ -133,6 +133,11 @@ impl<'a> Lexicon<'a> {
         (params.left_id(), params.right_id(), params.cost())
     }
 
+    pub fn get_word_param_checked(&self, entry_id: EntryId) -> Option<(i16, i16, i16)> {
+        let params = self.word_params.get_params_checked(entry_id)?;
+        Some((params.left_id(), params.right_id(), params.cost()))
+    }
+
     #[inline]
     pub fn get_string(&self, strptr: strings::StringPointer) -> SudachiResult<String> {
         self.strings.get_string(strptr)

--- a/sudachi/src/dic/lexicon/word_params.rs
+++ b/sudachi/src/dic/lexicon/word_params.rs
@@ -70,6 +70,12 @@ impl<'a> WordParams<'a> {
     }
 
     #[inline]
+    pub fn get_params_checked(&self, entry_id: EntryId) -> Option<WordParameter> {
+        let offset = entry_id.as_raw() as usize;
+        self.data.get(offset).copied().map(WordParameter)
+    }
+
+    #[inline]
     pub fn get_cost(&self, entry_id: EntryId) -> i16 {
         self.get_params(entry_id).cost()
     }

--- a/sudachi/src/dic/lexicon_set.rs
+++ b/sudachi/src/dic/lexicon_set.rs
@@ -132,9 +132,16 @@ impl LexiconSet<'_> {
     /// Rest will be of default values (0 or empty).
     pub fn get_word_info_subset(&self, id: WordId, subset: InfoSubset) -> SudachiResult<WordInfo> {
         let dict_id = id.dict();
-        let word_info_data = self.lexicons[dict_id.as_raw() as usize]
-            .get_word_info(id.entry(), subset)?
-            .resolve(dict_id, self.num_system_pos, &self.pos_offsets, subset);
+        let lexicon = self
+            .lexicons
+            .get(dict_id.as_raw() as usize)
+            .ok_or(SudachiError::InvalidWordId(id))?;
+        let word_info_data = lexicon.get_word_info(id.entry(), subset)?.resolve(
+            dict_id,
+            self.num_system_pos,
+            &self.pos_offsets,
+            subset,
+        );
 
         Ok(WordInfo::new(word_info_data, id))
     }
@@ -143,6 +150,17 @@ impl LexiconSet<'_> {
     pub fn get_word_param(&self, id: WordId) -> (i16, i16, i16) {
         let dict_id = id.dict().as_raw() as usize;
         self.lexicons[dict_id].get_word_param(id.entry())
+    }
+
+    /// Returns word_param for given word_id.
+    pub fn get_word_param_checked(&self, id: WordId) -> SudachiResult<(i16, i16, i16)> {
+        let dict_id = id.dict().as_raw() as usize;
+        match self.lexicons.get(dict_id) {
+            Some(lexicon) => lexicon
+                .get_word_param_checked(id.entry())
+                .ok_or(SudachiError::InvalidWordId(id)),
+            None => Err(SudachiError::InvalidWordId(id)),
+        }
     }
 
     #[inline]

--- a/sudachi/src/dic/word_info/infos.rs
+++ b/sudachi/src/dic/word_info/infos.rs
@@ -98,7 +98,13 @@ impl<'a> WordInfos<'a> {
     ) -> SudachiResult<WordInfoRefData> {
         let offset = Self::entry_id_to_offset(entry_id);
         let parser = WordInfoParser::subset(subset);
-        let word_info = parser.parse(&self.bytes[offset..])?;
+        let bytes = self.bytes.get(offset..).ok_or_else(|| {
+            SudachiError::InvalidDataFormat(
+                0,
+                format!("invalid word info entry id: {}", entry_id.as_raw()),
+            )
+        })?;
+        let word_info = parser.parse(bytes)?;
         Ok(WordInfoRefData::from_raw(word_info))
     }
 }

--- a/sudachi/src/error.rs
+++ b/sudachi/src/error.rs
@@ -25,6 +25,7 @@ use crate::dic::description::DescriptionError;
 use crate::dic::header::HeaderError;
 use crate::dic::lexicon_set::LexiconSetError;
 use crate::dic::read::error::SudachiNomError;
+use crate::dic::word_id::WordId;
 use crate::plugin::PluginError;
 
 pub type SudachiResult<T> = Result<T, SudachiError>;
@@ -98,6 +99,9 @@ pub enum SudachiError {
 
     #[error("Invalid part of speech: {0}")]
     InvalidPartOfSpeech(String),
+
+    #[error("Invalid word id: {0}")]
+    InvalidWordId(WordId),
 
     #[error("Invalid range: {0}..{1}")]
     InvalidRange(usize, usize),

--- a/sudachi/src/lib.rs
+++ b/sudachi/src/lib.rs
@@ -41,7 +41,10 @@ pub mod text_normalizer;
 
 pub mod prelude {
     pub use crate::{
-        analysis::mlist::MorphemeList, analysis::morpheme::Morpheme, analysis::Mode,
-        error::SudachiError, error::SudachiResult,
+        analysis::mlist::MorphemeList,
+        analysis::morpheme::{Morpheme, MorphemeListItem, MorphemeRef, SingleMorpheme},
+        analysis::Mode,
+        error::SudachiError,
+        error::SudachiResult,
     };
 }

--- a/sudachi/src/lib.rs
+++ b/sudachi/src/lib.rs
@@ -42,7 +42,7 @@ pub mod text_normalizer;
 pub mod prelude {
     pub use crate::{
         analysis::mlist::MorphemeList,
-        analysis::morpheme::{Morpheme, MorphemeListItem, MorphemeRef, SingleMorpheme},
+        analysis::morpheme::{Morpheme, MorphemeRef, MorphemeView, SingleMorpheme},
         analysis::Mode,
         error::SudachiError,
         error::SudachiResult,

--- a/sudachi/tests/morpheme.rs
+++ b/sudachi/tests/morpheme.rs
@@ -68,6 +68,92 @@ fn reset_with_word_id_uses_exact_homograph_entry() {
 }
 
 #[test]
+fn dictionary_form_morpheme_returns_standalone_entry() {
+    let tok = TestTokenizer::new();
+    let ms = tok.tokenize("行っ", Mode::C);
+    let m = ms.get(0);
+
+    let df = m
+        .dictionary_form_morpheme()
+        .expect("failed to resolve dictionary form morpheme");
+
+    assert!(matches!(df, MorphemeRef::Single(_)));
+    assert_eq!("行く", df.surface().deref());
+    assert_eq!(m.dictionary_form(), df.surface().deref());
+    assert_eq!("行く", df.dictionary_form());
+    assert_eq!("イク", df.reading_form());
+    assert_eq!(0, df.begin());
+    assert_eq!("行く".len(), df.end());
+    assert_eq!(0, df.begin_c());
+    assert_eq!("行く".chars().count(), df.end_c());
+    assert!(!df.is_oov());
+}
+
+#[test]
+fn normalized_form_morpheme_returns_standalone_entry() {
+    let tok = TestTokenizer::new();
+    let ms = tok.tokenize("いっ", Mode::C);
+    let m = ms.get(0);
+
+    let nf = m
+        .normalized_form_morpheme()
+        .expect("failed to resolve normalized form morpheme");
+
+    assert!(matches!(nf, MorphemeRef::Single(_)));
+    assert_eq!("行く", nf.surface().deref());
+    assert_eq!(m.normalized_form(), nf.surface().deref());
+    assert_eq!("行く", nf.normalized_form());
+    assert_eq!("イク", nf.reading_form());
+    assert_eq!(0, nf.begin());
+    assert_eq!("行く".len(), nf.end());
+    assert_eq!(0, nf.begin_c());
+    assert_eq!("行く".chars().count(), nf.end_c());
+    assert!(!nf.is_oov());
+}
+
+#[test]
+fn form_morpheme_returns_self_equivalent_for_same_entry_and_oov() {
+    let tok = TestTokenizer::new();
+    let ms = tok.tokenize("東京", Mode::C);
+    let m = ms.get(0);
+
+    let df = m
+        .dictionary_form_morpheme()
+        .expect("failed to resolve dictionary form morpheme");
+    let nf = m
+        .normalized_form_morpheme()
+        .expect("failed to resolve normalized form morpheme");
+
+    assert!(matches!(df, MorphemeRef::ListItem(_)));
+    assert!(matches!(nf, MorphemeRef::ListItem(_)));
+    assert_eq!(m.word_id(), df.word_id());
+    assert_eq!(m.word_id(), nf.word_id());
+    assert_eq!(m.surface().deref(), df.surface().deref());
+    assert_eq!(m.surface().deref(), nf.surface().deref());
+
+    let ms = tok.tokenize("xyzzy123不在語", Mode::C);
+    let oov = ms
+        .iter()
+        .find(|m| m.is_oov())
+        .expect("expected at least one OOV morpheme");
+    let df = oov
+        .dictionary_form_morpheme()
+        .expect("failed to resolve OOV dictionary form morpheme");
+    let nf = oov
+        .normalized_form_morpheme()
+        .expect("failed to resolve OOV normalized form morpheme");
+
+    assert!(matches!(df, MorphemeRef::ListItem(_)));
+    assert!(matches!(nf, MorphemeRef::ListItem(_)));
+    assert_eq!(oov.word_id(), df.word_id());
+    assert_eq!(oov.word_id(), nf.word_id());
+    assert_eq!(oov.surface().deref(), df.surface().deref());
+    assert_eq!(oov.surface().deref(), nf.surface().deref());
+    assert!(df.is_oov());
+    assert!(nf.is_oov());
+}
+
+#[test]
 fn morpheme_attributes() {
     let tok = TestTokenizer::new();
     let ms = tok.tokenize("京都", Mode::C);

--- a/sudachi/tests/morpheme.rs
+++ b/sudachi/tests/morpheme.rs
@@ -66,40 +66,6 @@ fn empty_morpheme_list() {
 }
 
 #[test]
-fn reset_with_word_id_uses_exact_homograph_entry() {
-    let tok = TestTokenizer::new();
-    let mut ms = MorphemeList::empty(tok.dict());
-
-    // These are "x" homographs in tests/resources/lex.csv;
-    // they share headword "X" but have different POS metadata.
-    let (first_x, place_name_x) = x_homograph_word_ids(&tok);
-
-    ms.reset_with_word_id(first_x, InfoSubset::POS_ID)
-        .expect("failed to materialize first x entry");
-    assert_eq!(1, ms.len());
-    assert_eq!(first_x, ms.get(0).word_id());
-    assert_eq!("X", ms.get(0).surface().deref());
-    assert_eq!(0, ms.get(0).begin());
-    assert_eq!(1, ms.get(0).end());
-    assert_eq!(
-        ["補助記号", "一般", "*", "*", "*", "*"],
-        ms.get(0).part_of_speech()
-    );
-    assert_eq!("", ms.get(0).user_data());
-
-    ms.reset_with_word_id(place_name_x, InfoSubset::all())
-        .expect("failed to materialize place-name x entry");
-    assert_eq!(1, ms.len());
-    assert_eq!(place_name_x, ms.get(0).word_id());
-    assert_eq!("X", ms.get(0).surface().deref());
-    assert_eq!(
-        ["名詞", "固有名詞", "地名", "一般", "*", "*"],
-        ms.get(0).part_of_speech()
-    );
-    assert_eq!("", ms.get(0).user_data());
-}
-
-#[test]
 fn single_morpheme_from_word_id_uses_exact_homograph_entry() {
     let tok = TestTokenizer::new();
 
@@ -131,15 +97,10 @@ fn single_morpheme_from_word_id_uses_exact_homograph_entry() {
 #[test]
 fn word_id_materialization_rejects_invalid_oov_and_special_ids() {
     let tok = TestTokenizer::new();
-    let mut ms = MorphemeList::empty(tok.dict());
 
     for word_id in [WordId::INVALID, WordId::oov(0), WordId::BOS, WordId::EOS] {
         assert!(matches!(
             SingleMorpheme::from_word_id(tok.dict(), word_id, InfoSubset::all()),
-            Err(SudachiError::InvalidWordId(err_word_id)) if err_word_id == word_id
-        ));
-        assert!(matches!(
-            ms.reset_with_word_id(word_id, InfoSubset::all()),
             Err(SudachiError::InvalidWordId(err_word_id)) if err_word_id == word_id
         ));
     }
@@ -215,37 +176,6 @@ fn single_morpheme_split_materializes_standalone_entries() {
     assert_eq!("東京都".chars().count(), splits[1].end_c());
     assert_eq!("", splits[0].user_data());
     assert_eq!("", splits[1].user_data());
-}
-
-#[test]
-fn single_morpheme_split_loads_split_subset_on_demand() {
-    let tok = TestTokenizer::new();
-    let ms = tok.tokenize("東京都", Mode::C);
-    let word_id = ms.get(0).word_id();
-
-    let surface_only = SingleMorpheme::from_word_id(tok.dict(), word_id, InfoSubset::HEADWORD)
-        .expect("failed to materialize standalone morpheme");
-
-    let splits = surface_only
-        .split(Mode::A)
-        .expect("failed to split standalone morpheme");
-    assert_eq!(2, splits.len());
-    assert_eq!("東京", splits[0].surface());
-    assert_eq!("都", splits[1].surface());
-
-    let with_splits = SingleMorpheme::from_word_id(
-        tok.dict(),
-        word_id,
-        InfoSubset::HEADWORD | InfoSubset::SPLIT_A,
-    )
-    .expect("failed to materialize standalone morpheme with splits");
-
-    let splits = with_splits
-        .split(Mode::A)
-        .expect("failed to split standalone morpheme");
-    assert_eq!(2, splits.len());
-    assert_eq!("東京", splits[0].surface());
-    assert_eq!("都", splits[1].surface());
 }
 
 #[test]

--- a/sudachi/tests/morpheme.rs
+++ b/sudachi/tests/morpheme.rs
@@ -18,10 +18,11 @@ extern crate lazy_static;
 extern crate sudachi;
 
 use std::ops::Deref;
+use sudachi::dic::subset::InfoSubset;
 use sudachi::prelude::*;
 
 mod common;
-use crate::common::TestTokenizer;
+use crate::common::{TestTokenizer, LEXICON_SET};
 
 #[test]
 fn empty_morpheme_list() {
@@ -30,6 +31,38 @@ fn empty_morpheme_list() {
 
     assert_eq!("", empty.surface().deref());
     assert_eq!(0, empty.len());
+}
+
+#[test]
+fn reset_with_word_id_uses_exact_homograph_entry() {
+    let tok = TestTokenizer::new();
+    let word_ids = LEXICON_SET.system_word_ids_in_order();
+    let mut ms = MorphemeList::empty(tok.dict());
+
+    let first_x = *word_ids.get(40).unwrap();
+    let place_name_x = *word_ids.get(45).unwrap();
+
+    ms.reset_with_word_id(first_x, InfoSubset::all())
+        .expect("failed to materialize first x entry");
+    assert_eq!(1, ms.len());
+    assert_eq!(first_x, ms.get(0).word_id());
+    assert_eq!("X", ms.get(0).surface().deref());
+    assert_eq!(0, ms.get(0).begin());
+    assert_eq!(1, ms.get(0).end());
+    assert_eq!(
+        ["補助記号", "一般", "*", "*", "*", "*"],
+        ms.get(0).part_of_speech()
+    );
+
+    ms.reset_with_word_id(place_name_x, InfoSubset::all())
+        .expect("failed to materialize place-name x entry");
+    assert_eq!(1, ms.len());
+    assert_eq!(place_name_x, ms.get(0).word_id());
+    assert_eq!("X", ms.get(0).surface().deref());
+    assert_eq!(
+        ["名詞", "固有名詞", "地名", "一般", "*", "*"],
+        ms.get(0).part_of_speech()
+    );
 }
 
 #[test]

--- a/sudachi/tests/morpheme.rs
+++ b/sudachi/tests/morpheme.rs
@@ -19,10 +19,36 @@ extern crate sudachi;
 
 use std::ops::Deref;
 use sudachi::dic::subset::InfoSubset;
+use sudachi::dic::word_id::WordId;
 use sudachi::prelude::*;
 
 mod common;
 use crate::common::{TestTokenizer, LEXICON_SET};
+
+fn find_system_word_id(tok: &TestTokenizer, headword: &str, pos: [&str; 6]) -> WordId {
+    LEXICON_SET
+        .system_word_ids_in_order()
+        .into_iter()
+        .find(|&word_id| {
+            let word_info = LEXICON_SET
+                .get_word_info_subset(word_id, InfoSubset::HEADWORD | InfoSubset::POS_ID)
+                .expect("failed to load word info");
+            let actual_pos = tok.dict().grammar().pos_components(word_info.pos_id());
+            word_info.headword(&*LEXICON_SET) == headword
+                && actual_pos
+                    .iter()
+                    .map(String::as_str)
+                    .eq(pos.iter().copied())
+        })
+        .expect("expected test dictionary entry")
+}
+
+fn x_homograph_word_ids(tok: &TestTokenizer) -> (WordId, WordId) {
+    let first_x = find_system_word_id(tok, "X", ["補助記号", "一般", "*", "*", "*", "*"]);
+    let place_name_x =
+        find_system_word_id(tok, "X", ["名詞", "固有名詞", "地名", "一般", "*", "*"]);
+    (first_x, place_name_x)
+}
 
 #[test]
 fn empty_morpheme_list() {
@@ -36,13 +62,11 @@ fn empty_morpheme_list() {
 #[test]
 fn reset_with_word_id_uses_exact_homograph_entry() {
     let tok = TestTokenizer::new();
-    let word_ids = LEXICON_SET.system_word_ids_in_order();
     let mut ms = MorphemeList::empty(tok.dict());
 
-    // These are the first and last "x" homographs in tests/resources/lex.csv;
+    // These are "x" homographs in tests/resources/lex.csv;
     // they share headword "X" but have different POS metadata.
-    let first_x = *word_ids.get(40).unwrap();
-    let place_name_x = *word_ids.get(45).unwrap();
+    let (first_x, place_name_x) = x_homograph_word_ids(&tok);
 
     ms.reset_with_word_id(first_x, InfoSubset::POS_ID)
         .expect("failed to materialize first x entry");
@@ -55,6 +79,7 @@ fn reset_with_word_id_uses_exact_homograph_entry() {
         ["補助記号", "一般", "*", "*", "*", "*"],
         ms.get(0).part_of_speech()
     );
+    assert_eq!("", ms.get(0).user_data());
 
     ms.reset_with_word_id(place_name_x, InfoSubset::all())
         .expect("failed to materialize place-name x entry");
@@ -65,6 +90,53 @@ fn reset_with_word_id_uses_exact_homograph_entry() {
         ["名詞", "固有名詞", "地名", "一般", "*", "*"],
         ms.get(0).part_of_speech()
     );
+    assert_eq!("", ms.get(0).user_data());
+}
+
+#[test]
+fn single_morpheme_from_word_id_uses_exact_homograph_entry() {
+    let tok = TestTokenizer::new();
+
+    // These are "x" homographs in tests/resources/lex.csv;
+    // they share headword "X" but have different POS metadata.
+    let (first_x, place_name_x) = x_homograph_word_ids(&tok);
+
+    let first = SingleMorpheme::from_word_id(tok.dict(), first_x, InfoSubset::all())
+        .expect("failed to materialize first x entry");
+    let place = SingleMorpheme::from_word_id(tok.dict(), place_name_x, InfoSubset::all())
+        .expect("failed to materialize place-name x entry");
+
+    assert_eq!(first_x, first.word_id());
+    assert_eq!(place_name_x, place.word_id());
+    assert_eq!("X", first.surface());
+    assert_eq!("X", place.surface());
+    assert_eq!(
+        ["補助記号", "一般", "*", "*", "*", "*"],
+        first.part_of_speech()
+    );
+    assert_eq!(
+        ["名詞", "固有名詞", "地名", "一般", "*", "*"],
+        place.part_of_speech()
+    );
+    assert_eq!("", first.user_data());
+    assert_eq!("", place.user_data());
+}
+
+#[test]
+fn word_id_materialization_rejects_invalid_oov_and_special_ids() {
+    let tok = TestTokenizer::new();
+    let mut ms = MorphemeList::empty(tok.dict());
+
+    for word_id in [WordId::INVALID, WordId::oov(0), WordId::BOS, WordId::EOS] {
+        assert!(matches!(
+            SingleMorpheme::from_word_id(tok.dict(), word_id, InfoSubset::all()),
+            Err(SudachiError::InvalidWordId(err_word_id)) if err_word_id == word_id
+        ));
+        assert!(matches!(
+            ms.reset_with_word_id(word_id, InfoSubset::all()),
+            Err(SudachiError::InvalidWordId(err_word_id)) if err_word_id == word_id
+        ));
+    }
 }
 
 #[test]
@@ -87,6 +159,7 @@ fn dictionary_form_morpheme_returns_standalone_entry() {
     assert_eq!(0, df.begin_c());
     assert_eq!("行く".chars().count(), df.end_c());
     assert!(!df.is_oov());
+    assert_eq!("", df.user_data());
 }
 
 #[test]
@@ -109,6 +182,33 @@ fn normalized_form_morpheme_returns_standalone_entry() {
     assert_eq!(0, nf.begin_c());
     assert_eq!("行く".chars().count(), nf.end_c());
     assert!(!nf.is_oov());
+    assert_eq!("", nf.user_data());
+}
+
+#[test]
+fn single_morpheme_split_materializes_standalone_entries() {
+    let tok = TestTokenizer::new();
+    let ms = tok.tokenize("東京都", Mode::C);
+    let morpheme = SingleMorpheme::from_word_id(tok.dict(), ms.get(0).word_id(), InfoSubset::all())
+        .expect("failed to materialize standalone morpheme");
+
+    let splits = morpheme
+        .split(Mode::A)
+        .expect("failed to split standalone morpheme");
+
+    assert_eq!(2, splits.len());
+    assert_eq!("東京", splits[0].surface());
+    assert_eq!("都", splits[1].surface());
+    assert_eq!(0, splits[0].begin());
+    assert_eq!("東京".len(), splits[0].end());
+    assert_eq!("東京".len(), splits[1].begin());
+    assert_eq!("東京都".len(), splits[1].end());
+    assert_eq!(0, splits[0].begin_c());
+    assert_eq!("東京".chars().count(), splits[0].end_c());
+    assert_eq!("東京".chars().count(), splits[1].begin_c());
+    assert_eq!("東京都".chars().count(), splits[1].end_c());
+    assert_eq!("", splits[0].user_data());
+    assert_eq!("", splits[1].user_data());
 }
 
 #[test]

--- a/sudachi/tests/morpheme.rs
+++ b/sudachi/tests/morpheme.rs
@@ -39,10 +39,12 @@ fn reset_with_word_id_uses_exact_homograph_entry() {
     let word_ids = LEXICON_SET.system_word_ids_in_order();
     let mut ms = MorphemeList::empty(tok.dict());
 
+    // These are the first and last "x" homographs in tests/resources/lex.csv;
+    // they share headword "X" but have different POS metadata.
     let first_x = *word_ids.get(40).unwrap();
     let place_name_x = *word_ids.get(45).unwrap();
 
-    ms.reset_with_word_id(first_x, InfoSubset::all())
+    ms.reset_with_word_id(first_x, InfoSubset::POS_ID)
         .expect("failed to materialize first x entry");
     assert_eq!(1, ms.len());
     assert_eq!(first_x, ms.get(0).word_id());

--- a/sudachi/tests/morpheme.rs
+++ b/sudachi/tests/morpheme.rs
@@ -23,7 +23,13 @@ use sudachi::dic::word_id::WordId;
 use sudachi::prelude::*;
 
 mod common;
-use crate::common::{TestTokenizer, LEXICON_SET};
+use crate::common::{TestStatefulTokenizer, TestTokenizer, LEXICON_SET};
+
+const SINGLE_SPLIT_DIC: &str = "\
+index_form,left_id,right_id,cost,headword,pos1,pos2,pos3,pos4,pos5,pos6,reading_form,normalized_form,dictionary_form,split_a,split_b,split_c,word_structure,synonym_groups
+ab,6,6,1000,AB,名詞,普通名詞,一般,*,*,*,AB,,,\"A,1,A\",,,,
+a,-1,6,1000,A,名詞,数詞,*,*,*,*,A,,,,,,,
+";
 
 fn find_system_word_id(tok: &TestTokenizer, headword: &str, pos: [&str; 6]) -> WordId {
     LEXICON_SET
@@ -209,6 +215,68 @@ fn single_morpheme_split_materializes_standalone_entries() {
     assert_eq!("東京都".chars().count(), splits[1].end_c());
     assert_eq!("", splits[0].user_data());
     assert_eq!("", splits[1].user_data());
+}
+
+#[test]
+fn single_morpheme_split_loads_split_subset_on_demand() {
+    let tok = TestTokenizer::new();
+    let ms = tok.tokenize("東京都", Mode::C);
+    let word_id = ms.get(0).word_id();
+
+    let surface_only = SingleMorpheme::from_word_id(tok.dict(), word_id, InfoSubset::HEADWORD)
+        .expect("failed to materialize standalone morpheme");
+
+    let splits = surface_only
+        .split(Mode::A)
+        .expect("failed to split standalone morpheme");
+    assert_eq!(2, splits.len());
+    assert_eq!("東京", splits[0].surface());
+    assert_eq!("都", splits[1].surface());
+
+    let with_splits = SingleMorpheme::from_word_id(
+        tok.dict(),
+        word_id,
+        InfoSubset::HEADWORD | InfoSubset::SPLIT_A,
+    )
+    .expect("failed to materialize standalone morpheme with splits");
+
+    let splits = with_splits
+        .split(Mode::A)
+        .expect("failed to split standalone morpheme");
+    assert_eq!(2, splits.len());
+    assert_eq!("東京", splits[0].surface());
+    assert_eq!("都", splits[1].surface());
+}
+
+#[test]
+fn single_morpheme_split_single_replacement_preserves_span() {
+    let mut tok = TestStatefulTokenizer::builder(SINGLE_SPLIT_DIC.as_bytes())
+        .mode(Mode::C)
+        .build();
+    let word_id = {
+        let ms = tok.tokenize("ＡＢ");
+        assert_eq!(1, ms.len());
+        assert_eq!("ＡＢ", ms.get(0).surface().deref());
+        ms.get(0).word_id()
+    };
+    let morpheme = SingleMorpheme::from_word_id(
+        tok.dict(),
+        word_id,
+        InfoSubset::HEADWORD | InfoSubset::SPLIT_A,
+    )
+    .expect("failed to materialize standalone morpheme");
+
+    let splits = morpheme
+        .split(Mode::A)
+        .expect("failed to split standalone morpheme");
+
+    assert_eq!(1, splits.len());
+    assert_ne!(morpheme.word_id(), splits[0].word_id());
+    assert_eq!("A", splits[0].surface());
+    assert_eq!(morpheme.begin(), splits[0].begin());
+    assert_eq!(morpheme.end(), splits[0].end());
+    assert_eq!(morpheme.begin_c(), splits[0].begin_c());
+    assert_eq!(morpheme.end_c(), splits[0].end_c());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- implement morpheme form entry accessors in Rust core, not only in Python bindings
- keep the existing list-backed Rust `Morpheme` type name and add `MorphemeView` as the shared accessor trait
- add `SingleMorpheme` and `MorphemeRef` for exact-`WordId` standalone dictionary entries, including standalone split support and `user_data()` access
- guard invalid, OOV, and special `WordId`s in public exact-entry materialization APIs
- delegate Python `dictionary_form_morpheme()` / `normalized_form_morpheme()` to Rust core and back Python `Morpheme` / `MorphemeList` with list-backed or `SingleMorpheme` variants while preserving the public Python API
- materialize form morphemes with the source `InfoSubset + HEADWORD`, while loading only the required form-reference field internally
- align standalone split behavior with Java empty / single / multi split semantics, including parent span preservation for single replacement splits and lazy split metadata loading
- preserve standalone split behavior for Python form morphemes and add Rust/Python regression coverage
- add changelog entries for the Rust and Python API changes

Fixes #322.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p sudachi`
- `cargo check -p sudachipy`
- `cargo test -p sudachi`
- `cargo test -p sudachipy`
- `cargo test --workspace`
- `cd python && .env/bin/python -m unittest tests.test_morpheme -v`
- `cd python && bash build_and_test.sh`
- Cross-runtime compatibility check against Java `develop-v0.8`, Rust, and Python with a rebuilt full SudachiDict `20260428` dictionary
