### PR TITLE
Update PyO3 to 0.28.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "default_input_text"
-version = "0.6.11"
+version = "0.6.12-a1"
 dependencies = [
  "sudachi",
 ]
@@ -429,15 +429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,14 +471,14 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "join_katakana_oov"
-version = "0.6.11"
+version = "0.6.12-a1"
 dependencies = [
  "sudachi",
 ]
 
 [[package]]
 name = "join_numeric"
-version = "0.6.11"
+version = "0.6.12-a1"
 dependencies = [
  "sudachi",
 ]
@@ -555,15 +546,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -664,35 +646,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -700,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -712,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -887,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "simple_oov"
-version = "0.6.11"
+version = "0.6.12-a1"
 dependencies = [
  "sudachi",
 ]
@@ -900,7 +879,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "sudachi"
-version = "0.6.11"
+version = "0.6.12-a1"
 dependencies = [
  "aho-corasick",
  "bitflags",
@@ -928,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "sudachi-cli"
-version = "0.6.11"
+version = "0.6.12-a1"
 dependencies = [
  "cfg-if",
  "clap",
@@ -948,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "sudachipy"
-version = "0.6.11"
+version = "0.6.12-a1"
 dependencies = [
  "pyo3",
  "scopeguard",
@@ -1060,12 +1039,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -3,7 +3,7 @@ name = "sudachipy"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
+rust-version = "1.83"
 description = "Python bindings of sudachi.rs, the Japanese Morphological Analyzer"
 readme = "README.md"
 homepage.workspace = true
@@ -15,7 +15,7 @@ name = "sudachipy"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27", features = ["extension-module"] }
+pyo3 = { version = "0.28.3", features = ["extension-module"] }
 scopeguard = "1" # Apache 2.0/MIT
 thread_local = "1.1" # Apache 2.0/MIT
 

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -97,7 +97,11 @@ impl PyDicData {
 /// :type resource_dir: pathlib.Path | str | None
 /// :type dict: pathlib.Path | str | None
 /// :type dict_type: pathlib.Path | str | None
-#[pyclass(module = "sudachipy.dictionary", name = "Dictionary")]
+#[pyclass(
+    module = "sudachipy.dictionary",
+    name = "Dictionary",
+    skip_from_py_object
+)]
 #[derive(Clone)]
 pub struct PyDictionary {
     pub(super) dictionary: Option<Arc<PyDicData>>,

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -29,7 +29,7 @@ mod word_info;
 /// SudachiPy raw module root.
 ///
 /// Users should not use this directly.
-#[pymodule]
+#[pymodule(gil_used = false)]
 fn sudachipy(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<dictionary::PyDictionary>()?;
     m.add_class::<tokenizer::PySplitMode>()?;

--- a/python/src/tokenizer.rs
+++ b/python/src/tokenizer.rs
@@ -41,7 +41,14 @@ use crate::projection::PyProjector;
 ///     If None, returns SplitMode.C.
 ///
 /// :type mode: str | None
-#[pyclass(module = "sudachipy.tokenizer", name = "SplitMode", eq, eq_int, frozen)]
+#[pyclass(
+    module = "sudachipy.tokenizer",
+    name = "SplitMode",
+    eq,
+    eq_int,
+    frozen,
+    from_py_object
+)]
 #[derive(Clone, PartialEq, Eq, Copy, Debug)]
 #[repr(u8)]
 pub enum PySplitMode {

--- a/python/tests/test_free_threaded.py
+++ b/python/tests/test_free_threaded.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+import sys
+import sysconfig
+import textwrap
+import unittest
+
+
+@unittest.skipUnless(
+    sysconfig.get_config_var("Py_GIL_DISABLED"),
+    "requires a free-threaded Python build",
+)
+class TestFreeThreadedImport(unittest.TestCase):
+    def test_import_does_not_enable_gil(self):
+        script = textwrap.dedent(
+            """
+            import sys
+
+            import sudachipy
+
+            if sys._is_gil_enabled():
+                raise AssertionError("sudachipy import enabled the GIL")
+            """
+        )
+        env = os.environ.copy()
+        env["PYTHON_GIL"] = "0"
+
+        subprocess.run(
+            [sys.executable, "-Xgil=0", "-c", script],
+            check=True,
+            env=env,
+            text=True,
+        )


### PR DESCRIPTION
Update the Python bindings to PyO3 0.28.3.

Also mark the module as free-threaded compatible and add a small import test for free-threaded Python.

Checks:
- `cargo test --workspace`
- `python -m unittest`
- `python3.14t` free-threaded import test

This update is intended as a small first step before packaging changes.

The next planned work is to enable `abi3` wheels and move the Python extension build to `maturin`. Updating PyO3 first keeps those changes based on the current PyO3 API and separates the dependency/API migration from build-backend and wheel-tagging changes. 

