### PR TITLE
Add dictionary entry iteration and lookup_all_entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Also check [python changelog](python/CHANGELOG.md).
 ### Added
 
 - Add Rust-side morpheme form accessors and standalone morpheme materialization.
+- Added dictionary entry iteration APIs: `JapaneseDictionary::entries`,
+  `entries_subset`, `lookup_all_entries`, and `lookup_all_entries_subset`.
+
+### Changed
+
+- Changed `MorphemeList::lookup` to normalize queries with dictionary input-text
+  plugins before indexed lookup, matching Java Sudachi behavior.
 
 ### Fixed
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -9,6 +9,12 @@ Also check [rust changelog](../CHANGELOG.md).
 ### Added
 
 - Add `Morpheme.dictionary_form_morpheme()` and `Morpheme.normalized_form_morpheme()`.
+- Added `Dictionary.entries()` and `Dictionary.lookup_all_entries()`.
+
+### Changed
+
+- Changed `Dictionary.lookup()` to normalize queries before indexed lookup,
+  matching Java Sudachi behavior.
 
 ### Fixed
 

--- a/python/py_src/sudachipy/sudachipy.pyi
+++ b/python/py_src/sudachipy/sudachipy.pyi
@@ -178,7 +178,7 @@ class Dictionary:
         Inside a dictionary, morphemes are outputted in-binary-dictionary order.
         Morphemes which are not indexed are not returned.
 
-        :param surface: find all morphemes with the given surface
+        :param surface: input surface; normalized before indexed lookup.
         :param out: if passed, reuse the given morpheme list instead of creating a new one.
             See https://worksapplications.github.io/sudachi.rs/python/topics/out_param.html for details.
         """
@@ -190,7 +190,8 @@ class Dictionary:
 
         The given surface is normalized before matching. This scans public
         lexicon entries and can find entries which are not indexed for normal
-        lookup.
+        lookup. This can be slow on large dictionaries; use `lookup()` for
+        normal indexed lookup.
 
         :param surface: find all morphemes whose normalized surface matches this value
         :param out: if passed, reuse the given morpheme list instead of creating a new one.

--- a/python/py_src/sudachipy/sudachipy.pyi
+++ b/python/py_src/sudachipy/sudachipy.pyi
@@ -159,10 +159,12 @@ class Dictionary:
 
     def entries(self) -> Iterator[Morpheme]:
         """
-        Iterates over dictionary entries as morphemes.
+        Iterates over public lexicon entries as morphemes.
 
-        Non-indexed entries are included. Internal entries automatically added
-        to store literal normalization forms are excluded.
+        Entries referred to from other entries, such as split or constituent
+        units, are included even when they are not indexed for normal lookup.
+        Internal entries automatically generated for literal normalized forms
+        are not exposed. The iteration order is not part of the public contract.
         """
         ...
 
@@ -186,8 +188,9 @@ class Dictionary:
         """
         Look up morphemes by scanning all dictionary entries.
 
-        The given surface is normalized before matching. This can find
-        non-indexed entries, but is much slower than lookup.
+        The given surface is normalized before matching. This scans public
+        lexicon entries and can find entries which are not indexed for normal
+        lookup.
 
         :param surface: find all morphemes whose normalized surface matches this value
         :param out: if passed, reuse the given morpheme list instead of creating a new one.

--- a/python/py_src/sudachipy/sudachipy.pyi
+++ b/python/py_src/sudachipy/sudachipy.pyi
@@ -157,16 +157,39 @@ class Dictionary:
         """
         ...
 
+    def entries(self) -> Iterator[Morpheme]:
+        """
+        Iterates over dictionary entries as morphemes.
+
+        Non-indexed entries are included. Internal entries automatically added
+        to store literal normalization forms are excluded.
+        """
+        ...
+
     def lookup(self, surface: str, out: Optional[MorphemeList] = None) -> MorphemeList:
         """
         Look up morphemes in the binary dictionary without performing the analysis.
 
-        All morphemes from the dictionary with the given surface string are returned,
+        The given surface is normalized before lookup.
+        All morphemes from the dictionary with the normalized surface string are returned,
         with the last user dictionary searched first and the system dictionary searched last.
         Inside a dictionary, morphemes are outputted in-binary-dictionary order.
         Morphemes which are not indexed are not returned.
 
         :param surface: find all morphemes with the given surface
+        :param out: if passed, reuse the given morpheme list instead of creating a new one.
+            See https://worksapplications.github.io/sudachi.rs/python/topics/out_param.html for details.
+        """
+        ...
+
+    def lookup_all_entries(self, surface: str, out: Optional[MorphemeList] = None) -> MorphemeList:
+        """
+        Look up morphemes by scanning all dictionary entries.
+
+        The given surface is normalized before matching. This can find
+        non-indexed entries, but is much slower than lookup.
+
+        :param surface: find all morphemes whose normalized surface matches this value
         :param out: if passed, reuse the given morpheme list instead of creating a new one.
             See https://worksapplications.github.io/sudachi.rs/python/topics/out_param.html for details.
         """

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -31,9 +31,9 @@ use sudachi::dic::dictionary::JapaneseDictionary;
 use sudachi::dic::grammar::Grammar;
 use sudachi::dic::lexicon_set::{LexiconSet, WordIdCursor};
 use sudachi::dic::subset::InfoSubset;
-use sudachi::dic::{
-    lookup_all_entries as lookup_all_dictionary_entries, DictionaryAccess, LexiconAccess,
-};
+use sudachi::dic::{DictionaryAccess, LexiconAccess};
+use sudachi::error::SudachiResult;
+use sudachi::input_text::InputBuffer;
 use sudachi::plugin::input_text::InputTextPlugin;
 use sudachi::plugin::oov::OovProviderPlugin;
 use sudachi::plugin::path_rewrite::PathRewritePlugin;
@@ -84,6 +84,43 @@ impl PyDicData {
     }
 }
 
+fn normalize_input_text(
+    dict: &PyDicData,
+    text: &str,
+    buffer: &mut InputBuffer,
+) -> SudachiResult<()> {
+    buffer.reset().push_str(text);
+    buffer.start_build()?;
+    for plugin in dict.input_text_plugins() {
+        plugin.rewrite(buffer)?;
+    }
+    buffer.build(dict.grammar())
+}
+
+fn lookup_all_dictionary_entries(
+    dict: Arc<PyDicData>,
+    surface: &str,
+    subset: InfoSubset,
+) -> SudachiResult<Vec<SingleMorpheme<Arc<PyDicData>>>> {
+    let mut query_buffer = InputBuffer::new();
+    normalize_input_text(&dict, surface, &mut query_buffer)?;
+    let mut entry_buffer = InputBuffer::new();
+    let mut result = Vec::new();
+
+    for word_id in dict.lexicon().word_ids() {
+        let word_id = word_id?;
+        let word_info = dict
+            .lexicon()
+            .get_word_info_subset(word_id, InfoSubset::HEADWORD)?;
+        normalize_input_text(&dict, word_info.headword(dict.lexicon()), &mut entry_buffer)?;
+        if entry_buffer.current() == query_buffer.current() {
+            result.push(SingleMorpheme::from_word_id(dict.clone(), word_id, subset)?);
+        }
+    }
+
+    Ok(result)
+}
+
 #[pyclass(module = "sudachipy.dictionary", name = "DictionaryEntryIterator")]
 pub struct PyDictionaryEntryIterator {
     dict: Arc<PyDicData>,
@@ -98,7 +135,11 @@ impl PyDictionaryEntryIterator {
     }
 
     fn __next__(&mut self) -> PyResult<Option<PyMorpheme>> {
-        let Some(word_id) = self.dict.lexicon().next_word_id(&mut self.cursor) else {
+        let Some(word_id) = errors::wrap_ctx(
+            self.dict.lexicon().next_word_id(&mut self.cursor),
+            "failed to scan dictionary entries",
+        )?
+        else {
             return Ok(None);
         };
         let morpheme = errors::wrap_ctx(
@@ -409,8 +450,11 @@ impl PyDictionary {
 
     /// Iterates over dictionary entries as standalone morphemes.
     ///
-    /// This includes non-indexed entries such as split units, and excludes
-    /// internal entries automatically added to store literal normalization forms.
+    /// This iterates public lexicon entries. It includes entries that are
+    /// referred to from other entries, such as split or constituent units, even
+    /// when they are not indexed for normal lookup. Internal entries
+    /// automatically generated for literal normalized forms are not exposed.
+    /// The iteration order is not part of the public contract.
     #[pyo3(text_signature = "(self, /) -> Iterator[Morpheme]")]
     fn entries(&self) -> PyDictionaryEntryIterator {
         let dict = self.dictionary.clone().unwrap();
@@ -471,9 +515,9 @@ impl PyDictionary {
 
     /// Look up morphemes by scanning all dictionary entries.
     ///
-    /// The given surface is normalized before matching. This can find entries
-    /// which are not indexed and appear only when referred from other words, but
-    /// it is much slower than lookup.
+    /// The given surface is normalized before matching. This scans public
+    /// lexicon entries and can find entries which are not indexed for normal
+    /// lookup.
     ///
     /// :param surface: find all morphemes whose normalized surface matches this value
     /// :param out: if passed, reuse the given morpheme list instead of creating a new one.

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -84,7 +84,12 @@ impl PyDicData {
     }
 }
 
-fn normalize_input_text(
+/// Applies input-text plugins and leaves the rewritten text in `buffer.current()`.
+///
+/// This intentionally does not build grammar/index metadata and must only be
+/// used when the rewritten string is needed for comparison, not for morpheme
+/// offsets or analysis.
+fn rewrite_input_text_for_comparison(
     dict: &PyDicData,
     text: &str,
     buffer: &mut InputBuffer,
@@ -94,7 +99,7 @@ fn normalize_input_text(
     for plugin in dict.input_text_plugins() {
         plugin.rewrite(buffer)?;
     }
-    buffer.build(dict.grammar())
+    Ok(())
 }
 
 fn lookup_all_dictionary_entries(
@@ -103,7 +108,8 @@ fn lookup_all_dictionary_entries(
     subset: InfoSubset,
 ) -> SudachiResult<Vec<SingleMorpheme<Arc<PyDicData>>>> {
     let mut query_buffer = InputBuffer::new();
-    normalize_input_text(&dict, surface, &mut query_buffer)?;
+    rewrite_input_text_for_comparison(&dict, surface, &mut query_buffer)?;
+    let query = query_buffer.current().to_owned();
     let mut entry_buffer = InputBuffer::new();
     let mut result = Vec::new();
 
@@ -112,8 +118,12 @@ fn lookup_all_dictionary_entries(
         let word_info = dict
             .lexicon()
             .get_word_info_subset(word_id, InfoSubset::HEADWORD)?;
-        normalize_input_text(&dict, word_info.headword(dict.lexicon()), &mut entry_buffer)?;
-        if entry_buffer.current() == query_buffer.current() {
+        rewrite_input_text_for_comparison(
+            &dict,
+            word_info.headword(dict.lexicon()),
+            &mut entry_buffer,
+        )?;
+        if entry_buffer.current() == query {
             result.push(SingleMorpheme::from_word_id(dict.clone(), word_id, subset)?);
         }
     }
@@ -475,7 +485,7 @@ impl PyDictionary {
     /// Inside a dictionary, morphemes are outputted in-binary-dictionary order.
     /// Morphemes which are not indexed are not returned.
     ///
-    /// :param surface: find all morphemes with the given surface
+    /// :param surface: input surface; normalized before indexed lookup.
     /// :param out: if passed, reuse the given morpheme list instead of creating a new one.
     ///     See https://worksapplications.github.io/sudachi.rs/python/topics/out_param.html for details.
     ///
@@ -517,7 +527,8 @@ impl PyDictionary {
     ///
     /// The given surface is normalized before matching. This scans public
     /// lexicon entries and can find entries which are not indexed for normal
-    /// lookup.
+    /// lookup. This can be slow on large dictionaries; use `lookup()` for
+    /// normal indexed lookup.
     ///
     /// :param surface: find all morphemes whose normalized surface matches this value
     /// :param out: if passed, reuse the given morpheme list instead of creating a new one.

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -24,19 +24,22 @@ use pyo3::ffi::c_str;
 use pyo3::prelude::*;
 use pyo3::types::{PySet, PyString, PyTuple};
 
+use sudachi::analysis::morpheme::SingleMorpheme;
 use sudachi::analysis::Mode;
 use sudachi::config::{Config, ConfigBuilder, SurfaceProjection};
 use sudachi::dic::dictionary::JapaneseDictionary;
 use sudachi::dic::grammar::Grammar;
-use sudachi::dic::lexicon_set::LexiconSet;
+use sudachi::dic::lexicon_set::{LexiconSet, WordIdCursor};
 use sudachi::dic::subset::InfoSubset;
-use sudachi::dic::{DictionaryAccess, LexiconAccess};
+use sudachi::dic::{
+    lookup_all_entries as lookup_all_dictionary_entries, DictionaryAccess, LexiconAccess,
+};
 use sudachi::plugin::input_text::InputTextPlugin;
 use sudachi::plugin::oov::OovProviderPlugin;
 use sudachi::plugin::path_rewrite::PathRewritePlugin;
 
 use crate::errors;
-use crate::morpheme::PyMorphemeListWrapper;
+use crate::morpheme::{PyMorpheme, PyMorphemeListWrapper};
 use crate::pos_matcher::PyPosMatcher;
 use crate::pretokenizer::PyPretokenizer;
 use crate::projection::{pyprojection, PyProjector};
@@ -78,6 +81,34 @@ impl LexiconAccess for PyDicData {
 impl PyDicData {
     pub fn pos_of(&self, pos_id: u16) -> &Py<PyTuple> {
         &self.pos[pos_id as usize]
+    }
+}
+
+#[pyclass(module = "sudachipy.dictionary", name = "DictionaryEntryIterator")]
+pub struct PyDictionaryEntryIterator {
+    dict: Arc<PyDicData>,
+    projection: PyProjector,
+    cursor: WordIdCursor,
+}
+
+#[pymethods]
+impl PyDictionaryEntryIterator {
+    fn __iter__(slf: PyRef<Self>) -> PyRef<Self> {
+        slf
+    }
+
+    fn __next__(&mut self) -> PyResult<Option<PyMorpheme>> {
+        let Some(word_id) = self.dict.lexicon().next_word_id(&mut self.cursor) else {
+            return Ok(None);
+        };
+        let morpheme = errors::wrap_ctx(
+            SingleMorpheme::from_word_id(self.dict.clone(), word_id, InfoSubset::all()),
+            "failed to load dictionary entry",
+        )?;
+        Ok(Some(PyMorpheme::single_backed(
+            morpheme,
+            self.projection.clone(),
+        )))
     }
 }
 
@@ -376,10 +407,27 @@ impl PyDictionary {
             .call1((pretokenizer,))
     }
 
+    /// Iterates over dictionary entries as standalone morphemes.
+    ///
+    /// This includes non-indexed entries such as split units, and excludes
+    /// internal entries automatically added to store literal normalization forms.
+    #[pyo3(text_signature = "(self, /) -> Iterator[Morpheme]")]
+    fn entries(&self) -> PyDictionaryEntryIterator {
+        let dict = self.dictionary.clone().unwrap();
+        let projection = dict.projection.clone();
+        let cursor = dict.lexicon().word_id_cursor();
+        PyDictionaryEntryIterator {
+            dict,
+            projection,
+            cursor,
+        }
+    }
+
     /// Look up morphemes in the binary dictionary without performing the analysis.
     ///
-    /// All morphemes from the dictionary with the given surface string are returned,
-    /// with the last user dictionary searched first and the system dictionary searched last.
+    /// The given surface is normalized before lookup. All morphemes from the
+    /// dictionary with the normalized surface string are returned, with the last
+    /// user dictionary searched first and the system dictionary searched last.
     /// Inside a dictionary, morphemes are outputted in-binary-dictionary order.
     /// Morphemes which are not indexed are not returned.
     ///
@@ -419,6 +467,49 @@ impl PyDictionary {
         out_list.clear();
         errors::wrap_ctx(out_list.lookup(surface, InfoSubset::all()), surface)?;
         Ok(l)
+    }
+
+    /// Look up morphemes by scanning all dictionary entries.
+    ///
+    /// The given surface is normalized before matching. This can find entries
+    /// which are not indexed and appear only when referred from other words, but
+    /// it is much slower than lookup.
+    ///
+    /// :param surface: find all morphemes whose normalized surface matches this value
+    /// :param out: if passed, reuse the given morpheme list instead of creating a new one.
+    ///
+    /// :type surface: str
+    /// :type out: MorphemeList | None
+    #[pyo3(
+        signature = (surface, out=None),
+        text_signature = "(self, /, surface, out=None) -> MorphemeList",
+    )]
+    fn lookup_all_entries<'py>(
+        &'py self,
+        py: Python<'py>,
+        surface: &'py str,
+        out: Option<Bound<'py, PyMorphemeListWrapper>>,
+    ) -> PyResult<Bound<'py, PyMorphemeListWrapper>> {
+        let dict = self.dictionary.clone().unwrap();
+        let projection = dict.projection.clone();
+        let singles = errors::wrap_ctx(
+            lookup_all_dictionary_entries(dict, surface, InfoSubset::all()),
+            surface,
+        )?;
+
+        match out {
+            None => Bound::new(py, PyMorphemeListWrapper::from_singles(singles, projection)),
+            Some(cell) => {
+                {
+                    let mut wrapper = match cell.try_borrow_mut() {
+                        Ok(wrapper) => wrapper,
+                        Err(_) => return errors::wrap(Err("out was used twice at the same time")),
+                    };
+                    wrapper.replace_with_singles(singles, projection);
+                }
+                Ok(cell)
+            }
+        }
     }
 
     /// Close this dictionary.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -31,6 +31,7 @@ mod tokenizer;
 #[pymodule]
 fn sudachipy(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<dictionary::PyDictionary>()?;
+    m.add_class::<dictionary::PyDictionaryEntryIterator>()?;
     m.add_class::<tokenizer::PySplitMode>()?;
     m.add_class::<tokenizer::PyTokenizer>()?;
     m.add_class::<morpheme::PyMorphemeListWrapper>()?;

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -356,7 +356,10 @@ impl PyMorpheme {
         }
     }
 
-    fn single_backed(morpheme: SingleMorpheme<Arc<PyDicData>>, projection: PyProjector) -> Self {
+    pub(crate) fn single_backed(
+        morpheme: SingleMorpheme<Arc<PyDicData>>,
+        projection: PyProjector,
+    ) -> Self {
         Self {
             backing: PyMorphemeBacking::Single {
                 morpheme,

--- a/python/tests/test_dictionary.py
+++ b/python/tests/test_dictionary.py
@@ -23,7 +23,7 @@ from sudachipy.config import Config
 from sudachipy.sudachipy import build_system_dic
 
 
-HIDDEN_ENTRY_LEXICON = (
+NON_INDEXED_ENTRY_LEXICON = (
     "index_form,left_id,right_id,cost,pos1,pos2,pos3,pos4,pos5,pos6,reading_form,"
     "normalized_form,dictionary_form,mode,split_a,split_b,word_structure\n"
     "京都,6,6,5293,名詞,固有名詞,地名,一般,*,*,キョウト,,,A,,,\n"
@@ -119,9 +119,9 @@ class TestDictionary(unittest.TestCase):
     def test_entries_include_non_indexed_entries_and_exclude_phantoms(self):
         resource_dir = Path(__file__).parent / "resources"
         with tempfile.TemporaryDirectory() as temp_dir:
-            lexicon = Path(temp_dir) / "hidden.csv"
+            lexicon = Path(temp_dir) / "non_indexed.csv"
             system_dic = Path(temp_dir) / "system.dic"
-            lexicon.write_text(HIDDEN_ENTRY_LEXICON, encoding="utf-8")
+            lexicon.write_text(NON_INDEXED_ENTRY_LEXICON, encoding="utf-8")
             build_system_dic(
                 matrix=resource_dir / "matrix.def",
                 lex=[lexicon],

--- a/python/tests/test_dictionary.py
+++ b/python/tests/test_dictionary.py
@@ -13,10 +13,23 @@
 # limitations under the License.
 
 import os
+import tempfile
 import unittest
+from pathlib import Path
 
 import sudachipy
 from sudachipy import Dictionary, Tokenizer
+from sudachipy.config import Config
+from sudachipy.sudachipy import build_system_dic
+
+
+HIDDEN_ENTRY_LEXICON = (
+    "index_form,left_id,right_id,cost,pos1,pos2,pos3,pos4,pos5,pos6,reading_form,"
+    "normalized_form,dictionary_form,mode,split_a,split_b,word_structure\n"
+    "京都,6,6,5293,名詞,固有名詞,地名,一般,*,*,キョウト,,,A,,,\n"
+    "隠し,-1,-1,5293,名詞,普通名詞,一般,*,*,*,カクシ,,,A,,,\n"
+    "舞台藝術,1,1,2816,名詞,普通名詞,一般,*,*,*,ブタイゲイジュツ,舞台芸術,,A,,,\n"
+)
 
 
 class TestDictionary(unittest.TestCase):
@@ -54,6 +67,9 @@ class TestDictionary(unittest.TestCase):
         self.assertEqual("キョウト", ms[0].reading_form())
         self.assertEqual(0, ms[0].begin())
         self.assertEqual(2, ms[0].end())
+        normalized = self.dict_.lookup("特A")
+        self.assertEqual(1, len(normalized))
+        self.assertEqual("トクエー", normalized[0].reading_form())
 
     def test_entries(self):
         entries = list(self.dict_.entries())
@@ -62,7 +78,16 @@ class TestDictionary(unittest.TestCase):
         self.assertIn("東京都", surfaces)
         self.assertIn("すだち", surfaces)
         self.assertTrue(any(m.dictionary_id() == 0 for m in entries))
-        self.assertEqual(1, next(m for m in entries if m.raw_surface() == "すだち").dictionary_id())
+        tokyo = next(m for m in entries if m.raw_surface() == "東京都")
+        self.assertEqual(("名詞", "固有名詞", "地名", "一般", "*", "*"), tokyo.part_of_speech())
+        self.assertEqual("東京都", tokyo.normalized_form())
+        self.assertEqual("東京都", tokyo.dictionary_form())
+        self.assertEqual("東京都", str(tokyo))
+        self.assertGreater(tokyo.word_id(), 0)
+
+        user_entry = next(m for m in entries if m.raw_surface() == "すだち")
+        self.assertEqual(1, user_entry.dictionary_id())
+        self.assertEqual("すだち", user_entry.normalized_form())
 
     def test_lookup_all_entries(self):
         self.assertFalse(self.dict_.lookup_all_entries("存在しない語"))
@@ -73,6 +98,9 @@ class TestDictionary(unittest.TestCase):
         self.assertEqual("東京都", tokyo[0].raw_surface())
         self.assertEqual(0, tokyo[0].begin())
         self.assertEqual(3, tokyo[0].end())
+        self.assertEqual(2, len(tokyo[0].split(sudachipy.SplitMode.A)))
+        with self.assertRaises(sudachipy.errors.SudachiError):
+            tokyo.get_internal_cost()
 
         normalized = self.dict_.lookup_all_entries("特A")
         self.assertEqual(1, len(normalized))
@@ -87,6 +115,61 @@ class TestDictionary(unittest.TestCase):
         reused = self.dict_.lookup_all_entries("東京都", out=out)
         self.assertIs(reused, out)
         self.assertEqual("東京都", reused[0].raw_surface())
+
+    def test_entries_include_non_indexed_entries_and_exclude_phantoms(self):
+        resource_dir = Path(__file__).parent / "resources"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            lexicon = Path(temp_dir) / "hidden.csv"
+            system_dic = Path(temp_dir) / "system.dic"
+            lexicon.write_text(HIDDEN_ENTRY_LEXICON, encoding="utf-8")
+            build_system_dic(
+                matrix=resource_dir / "matrix.def",
+                lex=[lexicon],
+                output=system_dic,
+            )
+
+            dictionary = Dictionary(config=Config(
+                system=str(system_dic),
+                characterDefinitionFile=str(resource_dir / "char.def"),
+                inputTextPlugin=[
+                    {"class": "com.worksap.nlp.sudachi.DefaultInputTextPlugin"},
+                    {"class": "com.worksap.nlp.sudachi.IgnoreYomiganaPlugin",
+                     "leftBrackets": ["(", "（"],
+                     "rightBrackets": [")", "）"],
+                     "maxYomiganaLength": 4},
+                ],
+                oovProviderPlugin=[
+                    {"class": "com.worksap.nlp.sudachi.SimpleOovPlugin",
+                     "oovPOS": ["名詞", "普通名詞", "一般", "*", "*", "*"],
+                     "leftId": 8,
+                     "rightId": 8,
+                     "cost": 6000},
+                ],
+                pathRewritePlugin=[],
+            ))
+            try:
+                surfaces = [m.raw_surface() for m in dictionary.entries()]
+                self.assertIn("京都", surfaces)
+                self.assertIn("隠し", surfaces)
+                self.assertIn("舞台藝術", surfaces)
+                self.assertNotIn("舞台芸術", surfaces)
+
+                non_indexed = dictionary.lookup_all_entries("隠し")
+                self.assertEqual(1, len(non_indexed))
+                self.assertEqual("隠し", non_indexed[0].raw_surface())
+                self.assertFalse(dictionary.lookup("隠し"))
+
+                yomigana = dictionary.lookup("京都（キョウト）")
+                self.assertEqual(1, len(yomigana))
+                self.assertEqual("京都", yomigana[0].surface())
+                self.assertEqual("京都", yomigana[0].raw_surface())
+                self.assertEqual(0, yomigana[0].begin())
+                self.assertEqual(2, yomigana[0].end())
+
+                phantom = dictionary.lookup_all_entries("舞台芸術")
+                self.assertFalse(phantom)
+            finally:
+                dictionary.close()
 
 
 if __name__ == '__main__':

--- a/python/tests/test_dictionary.py
+++ b/python/tests/test_dictionary.py
@@ -55,6 +55,39 @@ class TestDictionary(unittest.TestCase):
         self.assertEqual(0, ms[0].begin())
         self.assertEqual(2, ms[0].end())
 
+    def test_entries(self):
+        entries = list(self.dict_.entries())
+        surfaces = [m.raw_surface() for m in entries]
+
+        self.assertIn("東京都", surfaces)
+        self.assertIn("すだち", surfaces)
+        self.assertTrue(any(m.dictionary_id() == 0 for m in entries))
+        self.assertEqual(1, next(m for m in entries if m.raw_surface() == "すだち").dictionary_id())
+
+    def test_lookup_all_entries(self):
+        self.assertFalse(self.dict_.lookup_all_entries("存在しない語"))
+
+        tokyo = self.dict_.lookup_all_entries("東京都")
+        self.assertEqual(1, len(tokyo))
+        self.assertEqual("トウキョウト", tokyo[0].reading_form())
+        self.assertEqual("東京都", tokyo[0].raw_surface())
+        self.assertEqual(0, tokyo[0].begin())
+        self.assertEqual(3, tokyo[0].end())
+
+        normalized = self.dict_.lookup_all_entries("特A")
+        self.assertEqual(1, len(normalized))
+        self.assertEqual("特A", normalized[0].raw_surface())
+
+        user_entry = self.dict_.lookup_all_entries("すだち")
+        self.assertEqual(1, len(user_entry))
+        self.assertEqual(1, user_entry[0].dictionary_id())
+        self.assertEqual("スダチ", user_entry[0].reading_form())
+
+        out = self.dict_.lookup("京都")
+        reused = self.dict_.lookup_all_entries("東京都", out=out)
+        self.assertIs(reused, out)
+        self.assertEqual("東京都", reused[0].raw_surface())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/sudachi/src/analysis/mlist.rs
+++ b/sudachi/src/analysis/mlist.rs
@@ -24,7 +24,7 @@ use crate::analysis::node::{PathCost, ResultNode};
 use crate::analysis::stateful_tokenizer::StatefulTokenizer;
 use crate::analysis::{Mode, Node};
 use crate::dic::subset::InfoSubset;
-use crate::dic::DictionaryAccess;
+use crate::dic::{normalize_input_text, DictionaryAccess};
 use crate::error::{SudachiError, SudachiResult};
 use crate::input_text::InputBuffer;
 
@@ -193,27 +193,30 @@ impl<D: DictionaryAccess> MorphemeList<D> {
     }
 
     /// Looks up the given query and reset the morpheme list to the result.
+    ///
+    /// The query is normalized with dictionary input-text plugins before lookup.
     /// Returns the number of found entries.
     pub fn lookup(&mut self, query: &str, subset: InfoSubset) -> SudachiResult<usize> {
-        let end_chars = {
+        let (normalized, end_chars) = {
+            let dict = &self.dict;
             let input = &mut self.input.borrow_mut().input;
-            input.reset().push_str(query);
-            input.start_build()?;
-            input.build(self.dict.grammar())?;
-            input.ch_idx(query.len())
+            normalize_input_text(dict, query, input)?;
+            let normalized = input.current().to_owned();
+            let end_chars = input.ch_idx(normalized.len());
+            (normalized, end_chars)
         };
 
         let mut result = 0;
         let lex = self.dict.lexicon();
-        for entry in lex.lookup(query.as_bytes(), 0) {
-            if entry.end != query.len() {
+        for entry in lex.lookup(normalized.as_bytes(), 0) {
+            if entry.end != normalized.len() {
                 continue;
             }
             let info = lex.get_word_info_subset(entry.word_id, subset)?;
             let node = Node::new(0, end_chars as _, 0, 0, 0, entry.word_id);
             self.nodes
                 .data
-                .push(ResultNode::new(node, 0, 0, query.len() as _, info));
+                .push(ResultNode::new(node, 0, 0, normalized.len() as _, info));
             result += 1;
         }
         Ok(result)

--- a/sudachi/src/analysis/mlist.rs
+++ b/sudachi/src/analysis/mlist.rs
@@ -202,6 +202,9 @@ impl<D: DictionaryAccess> MorphemeList<D> {
             let input = &mut self.input.borrow_mut().input;
             normalize_input_text(dict, query, input)?;
             let normalized = input.current().to_owned();
+            input.reset().push_str(&normalized);
+            input.start_build()?;
+            input.build(dict.grammar())?;
             let end_chars = input.ch_idx(normalized.len());
             (normalized, end_chars)
         };

--- a/sudachi/src/dic.rs
+++ b/sudachi/src/dic.rs
@@ -35,7 +35,7 @@ pub mod subset;
 pub mod word_id;
 pub mod word_info;
 
+pub(crate) use dictionary_access::{lookup_all_entries, normalize_input_text};
 pub use dictionary_access::{
-    lookup_all_entries, normalize_input_text, DescriptionAccess, DictionaryAccess, LexiconAccess,
-    ReferenceIdAccess,
+    DescriptionAccess, DictionaryAccess, LexiconAccess, ReferenceIdAccess,
 };

--- a/sudachi/src/dic.rs
+++ b/sudachi/src/dic.rs
@@ -36,5 +36,6 @@ pub mod word_id;
 pub mod word_info;
 
 pub use dictionary_access::{
-    DescriptionAccess, DictionaryAccess, LexiconAccess, ReferenceIdAccess,
+    lookup_all_entries, normalize_input_text, DescriptionAccess, DictionaryAccess, LexiconAccess,
+    ReferenceIdAccess,
 };

--- a/sudachi/src/dic/binary_loader.rs
+++ b/sudachi/src/dic/binary_loader.rs
@@ -169,6 +169,7 @@ impl<'a> BinaryLexicon<'a> {
         let entries_bytes = description.slice(buf, Block::Entries)?;
         let word_params = WordParams::from_bytes(entries_bytes);
         let word_infos = WordInfos::from_bytes(entries_bytes);
+        word_infos.validate_entry_boundaries(description.num_total_entries())?;
 
         let strings = CompactedStrings::from_bytes(description.slice(buf, Block::Strings)?);
 

--- a/sudachi/src/dic/dictionary.rs
+++ b/sudachi/src/dic/dictionary.rs
@@ -19,6 +19,7 @@ use std::path::Path;
 
 use memmap2::Mmap;
 
+use crate::analysis::morpheme::SingleMorpheme;
 use crate::config::Config;
 use crate::dic::binary_loader::BinaryDictionary;
 use crate::dic::character_category::CharacterCategory;
@@ -28,7 +29,10 @@ use crate::dic::grammar::Grammar;
 use crate::dic::lexicon::Lexicon;
 use crate::dic::lexicon_set::LexiconSet;
 use crate::dic::storage::{Storage, SudachiDicData};
-use crate::dic::{DescriptionAccess, DictionaryAccess, LexiconAccess, ReferenceIdAccess};
+use crate::dic::subset::InfoSubset;
+use crate::dic::{
+    lookup_all_entries, DescriptionAccess, DictionaryAccess, LexiconAccess, ReferenceIdAccess,
+};
 use crate::error::{SudachiError, SudachiResult};
 use crate::plugin::input_text::InputTextPlugin;
 use crate::plugin::oov::OovProviderPlugin;
@@ -164,6 +168,44 @@ impl JapaneseDictionary {
 
     pub fn description(&self) -> &Description {
         &self.description
+    }
+
+    /// Iterates over dictionary entries as standalone morphemes.
+    ///
+    /// This corresponds to lexicon CSV rows: it includes non-indexed entries
+    /// such as split units, and excludes internal phantom entries generated for
+    /// literal normalization forms.
+    pub fn entries(&self) -> impl Iterator<Item = SudachiResult<SingleMorpheme<&Self>>> + '_ {
+        self.entries_subset(InfoSubset::all())
+    }
+
+    /// Iterates over dictionary entries, loading only the requested word-info fields.
+    pub fn entries_subset(
+        &self,
+        subset: InfoSubset,
+    ) -> impl Iterator<Item = SudachiResult<SingleMorpheme<&Self>>> + '_ {
+        self.lexicon()
+            .word_ids()
+            .map(move |word_id| SingleMorpheme::from_word_id(self, word_id, subset))
+    }
+
+    /// Looks up all dictionary entries whose normalized surface matches `surface`.
+    ///
+    /// This scans every public dictionary entry, including non-indexed entries,
+    /// so it is much slower than indexed lookup.
+    #[allow(clippy::result_large_err)]
+    pub fn lookup_all_entries(&self, surface: &str) -> SudachiResult<Vec<SingleMorpheme<&Self>>> {
+        self.lookup_all_entries_subset(surface, InfoSubset::all())
+    }
+
+    /// Looks up all matching dictionary entries, loading only requested fields.
+    #[allow(clippy::result_large_err)]
+    pub fn lookup_all_entries_subset(
+        &self,
+        surface: &str,
+        subset: InfoSubset,
+    ) -> SudachiResult<Vec<SingleMorpheme<&Self>>> {
+        lookup_all_entries(self, surface, subset)
     }
 
     fn merge_user_dictionary(

--- a/sudachi/src/dic/dictionary.rs
+++ b/sudachi/src/dic/dictionary.rs
@@ -172,9 +172,11 @@ impl JapaneseDictionary {
 
     /// Iterates over dictionary entries as standalone morphemes.
     ///
-    /// This corresponds to lexicon CSV rows: it includes non-indexed entries
-    /// such as split units, and excludes internal phantom entries generated for
-    /// literal normalization forms.
+    /// This corresponds to public lexicon CSV rows. It includes entries that
+    /// are referred to from other entries, such as split or constituent units,
+    /// even when they are not indexed for normal lookup. Internal entries
+    /// automatically generated for literal normalized forms are not exposed.
+    /// The iteration order is not part of the public contract.
     pub fn entries(&self) -> impl Iterator<Item = SudachiResult<SingleMorpheme<&Self>>> + '_ {
         self.entries_subset(InfoSubset::all())
     }
@@ -186,13 +188,14 @@ impl JapaneseDictionary {
     ) -> impl Iterator<Item = SudachiResult<SingleMorpheme<&Self>>> + '_ {
         self.lexicon()
             .word_ids()
-            .map(move |word_id| SingleMorpheme::from_word_id(self, word_id, subset))
+            .map(move |word_id| SingleMorpheme::from_word_id(self, word_id?, subset))
     }
 
     /// Looks up all dictionary entries whose normalized surface matches `surface`.
     ///
-    /// This scans every public dictionary entry, including non-indexed entries,
-    /// so it is much slower than indexed lookup.
+    /// This normalizes the query using dictionary input-text plugins and scans
+    /// every public lexicon entry. It can find entries that are not indexed for
+    /// normal lookup. Use `lookup` for normal indexed lookup.
     #[allow(clippy::result_large_err)]
     pub fn lookup_all_entries(&self, surface: &str) -> SudachiResult<Vec<SingleMorpheme<&Self>>> {
         self.lookup_all_entries_subset(surface, InfoSubset::all())

--- a/sudachi/src/dic/dictionary_access.rs
+++ b/sudachi/src/dic/dictionary_access.rs
@@ -17,9 +17,13 @@
 use std::collections::HashMap;
 use std::ops::Deref;
 
+use crate::analysis::morpheme::SingleMorpheme;
 use crate::dic::description::Description;
 use crate::dic::grammar::Grammar;
 use crate::dic::lexicon_set::LexiconSet;
+use crate::dic::subset::InfoSubset;
+use crate::error::SudachiResult;
+use crate::input_text::InputBuffer;
 use crate::plugin::input_text::InputTextPlugin;
 use crate::plugin::oov::OovProviderPlugin;
 use crate::plugin::path_rewrite::PathRewritePlugin;
@@ -96,4 +100,45 @@ where
     fn path_rewrite_plugins(&self) -> &[Box<dyn PathRewritePlugin + Sync + Send>] {
         <T as Deref>::deref(self).path_rewrite_plugins()
     }
+}
+
+/// Build normalized input text by applying dictionary input-text plugins.
+pub fn normalize_input_text<D: DictionaryAccess + ?Sized>(
+    dict: &D,
+    text: &str,
+    buffer: &mut InputBuffer,
+) -> SudachiResult<()> {
+    buffer.reset().push_str(text);
+    buffer.start_build()?;
+    for plugin in dict.input_text_plugins() {
+        plugin.rewrite(buffer)?;
+    }
+    buffer.build(dict.grammar())
+}
+
+/// Look up entries by scanning every public dictionary entry.
+pub fn lookup_all_entries<D>(
+    dict: D,
+    surface: &str,
+    subset: InfoSubset,
+) -> SudachiResult<Vec<SingleMorpheme<D>>>
+where
+    D: DictionaryAccess + Clone,
+{
+    let mut query_buffer = InputBuffer::new();
+    normalize_input_text(&dict, surface, &mut query_buffer)?;
+    let mut entry_buffer = InputBuffer::new();
+    let mut result = Vec::new();
+
+    for word_id in dict.lexicon().word_ids() {
+        let word_info = dict
+            .lexicon()
+            .get_word_info_subset(word_id, InfoSubset::HEADWORD)?;
+        normalize_input_text(&dict, word_info.headword(dict.lexicon()), &mut entry_buffer)?;
+        if entry_buffer.current() == query_buffer.current() {
+            result.push(SingleMorpheme::from_word_id(dict.clone(), word_id, subset)?);
+        }
+    }
+
+    Ok(result)
 }

--- a/sudachi/src/dic/dictionary_access.rs
+++ b/sudachi/src/dic/dictionary_access.rs
@@ -116,6 +116,24 @@ pub(crate) fn normalize_input_text<D: DictionaryAccess + ?Sized>(
     buffer.build(dict.grammar())
 }
 
+/// Applies input-text plugins and leaves the rewritten text in `buffer.current()`.
+///
+/// This intentionally does not build grammar/index metadata and must only be
+/// used when the rewritten string is needed for comparison, not for morpheme
+/// offsets or analysis.
+pub(crate) fn rewrite_input_text_for_comparison<D: DictionaryAccess + ?Sized>(
+    dict: &D,
+    text: &str,
+    buffer: &mut InputBuffer,
+) -> SudachiResult<()> {
+    buffer.reset().push_str(text);
+    buffer.start_build()?;
+    for plugin in dict.input_text_plugins() {
+        plugin.rewrite(buffer)?;
+    }
+    Ok(())
+}
+
 /// Look up entries by scanning every public dictionary entry.
 pub(crate) fn lookup_all_entries<D>(
     dict: D,
@@ -126,7 +144,8 @@ where
     D: DictionaryAccess + Clone,
 {
     let mut query_buffer = InputBuffer::new();
-    normalize_input_text(&dict, surface, &mut query_buffer)?;
+    rewrite_input_text_for_comparison(&dict, surface, &mut query_buffer)?;
+    let query = query_buffer.current().to_owned();
     let mut entry_buffer = InputBuffer::new();
     let mut result = Vec::new();
 
@@ -135,8 +154,12 @@ where
         let word_info = dict
             .lexicon()
             .get_word_info_subset(word_id, InfoSubset::HEADWORD)?;
-        normalize_input_text(&dict, word_info.headword(dict.lexicon()), &mut entry_buffer)?;
-        if entry_buffer.current() == query_buffer.current() {
+        rewrite_input_text_for_comparison(
+            &dict,
+            word_info.headword(dict.lexicon()),
+            &mut entry_buffer,
+        )?;
+        if entry_buffer.current() == query {
             result.push(SingleMorpheme::from_word_id(dict.clone(), word_id, subset)?);
         }
     }

--- a/sudachi/src/dic/dictionary_access.rs
+++ b/sudachi/src/dic/dictionary_access.rs
@@ -103,7 +103,7 @@ where
 }
 
 /// Build normalized input text by applying dictionary input-text plugins.
-pub fn normalize_input_text<D: DictionaryAccess + ?Sized>(
+pub(crate) fn normalize_input_text<D: DictionaryAccess + ?Sized>(
     dict: &D,
     text: &str,
     buffer: &mut InputBuffer,
@@ -117,7 +117,7 @@ pub fn normalize_input_text<D: DictionaryAccess + ?Sized>(
 }
 
 /// Look up entries by scanning every public dictionary entry.
-pub fn lookup_all_entries<D>(
+pub(crate) fn lookup_all_entries<D>(
     dict: D,
     surface: &str,
     subset: InfoSubset,
@@ -131,6 +131,7 @@ where
     let mut result = Vec::new();
 
     for word_id in dict.lexicon().word_ids() {
+        let word_id = word_id?;
         let word_info = dict
             .lexicon()
             .get_word_info_subset(word_id, InfoSubset::HEADWORD)?;

--- a/sudachi/src/dic/lexicon.rs
+++ b/sudachi/src/dic/lexicon.rs
@@ -24,7 +24,7 @@ use crate::dic::binary_loader::BinaryLexicon;
 use crate::dic::lexicon::strings::CompactedStrings;
 use crate::dic::subset::InfoSubset;
 use crate::dic::word_id::{EntryId, WordId};
-use crate::dic::word_info::{WordInfoRefData, WordInfos};
+use crate::dic::word_info::{WordInfoEntryIdCursor, WordInfoRefData, WordInfos};
 use crate::dic::DictionaryAccess;
 use crate::prelude::*;
 
@@ -84,6 +84,18 @@ impl<'a> Lexicon<'a> {
                 result
             }
         }
+    }
+
+    pub fn entry_ids(&self) -> impl Iterator<Item = EntryId> + '_ {
+        self.word_infos.entry_ids(self.num_total_entries)
+    }
+
+    pub fn entry_id_cursor(&self) -> WordInfoEntryIdCursor {
+        WordInfos::entry_id_cursor(self.num_total_entries)
+    }
+
+    pub fn next_entry_id(&self, cursor: &mut WordInfoEntryIdCursor) -> Option<EntryId> {
+        self.word_infos.next_entry_id(cursor)
     }
 
     /// Assign lexicon id to the current Lexicon

--- a/sudachi/src/dic/lexicon.rs
+++ b/sudachi/src/dic/lexicon.rs
@@ -86,15 +86,15 @@ impl<'a> Lexicon<'a> {
         }
     }
 
-    pub fn entry_ids(&self) -> impl Iterator<Item = SudachiResult<EntryId>> + '_ {
+    pub(crate) fn entry_ids(&self) -> impl Iterator<Item = SudachiResult<EntryId>> + '_ {
         self.word_infos.entry_ids(self.num_total_entries)
     }
 
-    pub fn entry_id_cursor(&self) -> WordInfoEntryIdCursor {
+    pub(crate) fn entry_id_cursor(&self) -> WordInfoEntryIdCursor {
         WordInfos::entry_id_cursor(self.num_total_entries)
     }
 
-    pub fn next_entry_id(
+    pub(crate) fn next_entry_id(
         &self,
         cursor: &mut WordInfoEntryIdCursor,
     ) -> SudachiResult<Option<EntryId>> {

--- a/sudachi/src/dic/lexicon.rs
+++ b/sudachi/src/dic/lexicon.rs
@@ -86,7 +86,7 @@ impl<'a> Lexicon<'a> {
         }
     }
 
-    pub fn entry_ids(&self) -> impl Iterator<Item = EntryId> + '_ {
+    pub fn entry_ids(&self) -> impl Iterator<Item = SudachiResult<EntryId>> + '_ {
         self.word_infos.entry_ids(self.num_total_entries)
     }
 
@@ -94,7 +94,10 @@ impl<'a> Lexicon<'a> {
         WordInfos::entry_id_cursor(self.num_total_entries)
     }
 
-    pub fn next_entry_id(&self, cursor: &mut WordInfoEntryIdCursor) -> Option<EntryId> {
+    pub fn next_entry_id(
+        &self,
+        cursor: &mut WordInfoEntryIdCursor,
+    ) -> SudachiResult<Option<EntryId>> {
         self.word_infos.next_entry_id(cursor)
     }
 

--- a/sudachi/src/dic/lexicon_set.rs
+++ b/sudachi/src/dic/lexicon_set.rs
@@ -177,11 +177,11 @@ impl LexiconSet<'_> {
         self.lexicons.iter().fold(0, |acc, lex| acc + lex.size())
     }
 
-    pub fn word_ids(&self) -> impl Iterator<Item = WordId> + '_ {
+    pub fn word_ids(&self) -> impl Iterator<Item = SudachiResult<WordId>> + '_ {
         self.lexicons.iter().enumerate().flat_map(|(dict_id, lex)| {
             let dict_id = DictId::new(dict_id as u8);
             lex.entry_ids()
-                .map(move |entry| WordId::from_parts(dict_id, entry))
+                .map(move |entry| entry.map(|entry| WordId::from_parts(dict_id, entry)))
         })
     }
 
@@ -192,13 +192,17 @@ impl LexiconSet<'_> {
         }
     }
 
-    pub fn next_word_id(&self, cursor: &mut WordIdCursor) -> Option<WordId> {
+    pub fn next_word_id(&self, cursor: &mut WordIdCursor) -> SudachiResult<Option<WordId>> {
         loop {
-            let lexicon = self.lexicons.get(cursor.lexicon_index)?;
-            let entry_cursor = cursor.entry_cursor.as_mut()?;
-            if let Some(entry) = lexicon.next_entry_id(entry_cursor) {
+            let Some(lexicon) = self.lexicons.get(cursor.lexicon_index) else {
+                return Ok(None);
+            };
+            let Some(entry_cursor) = cursor.entry_cursor.as_mut() else {
+                return Ok(None);
+            };
+            if let Some(entry) = lexicon.next_entry_id(entry_cursor)? {
                 let dict_id = DictId::new(cursor.lexicon_index as u8);
-                return Some(WordId::from_parts(dict_id, entry));
+                return Ok(Some(WordId::from_parts(dict_id, entry)));
             }
 
             cursor.lexicon_index += 1;

--- a/sudachi/src/dic/lexicon_set.rs
+++ b/sudachi/src/dic/lexicon_set.rs
@@ -51,6 +51,7 @@ pub struct LexiconSet<'a> {
     num_system_pos: usize,
 }
 
+#[doc(hidden)]
 pub struct WordIdCursor {
     lexicon_index: usize,
     entry_cursor: Option<WordInfoEntryIdCursor>,
@@ -185,6 +186,7 @@ impl LexiconSet<'_> {
         })
     }
 
+    #[doc(hidden)]
     pub fn word_id_cursor(&self) -> WordIdCursor {
         WordIdCursor {
             lexicon_index: 0,
@@ -192,6 +194,7 @@ impl LexiconSet<'_> {
         }
     }
 
+    #[doc(hidden)]
     pub fn next_word_id(&self, cursor: &mut WordIdCursor) -> SudachiResult<Option<WordId>> {
         loop {
             let Some(lexicon) = self.lexicons.get(cursor.lexicon_index) else {

--- a/sudachi/src/dic/lexicon_set.rs
+++ b/sudachi/src/dic/lexicon_set.rs
@@ -21,7 +21,7 @@ use crate::dic::lexicon::strings::StringPointer;
 use crate::dic::lexicon::{Lexicon, LexiconEntry, MAX_DICTIONARIES};
 use crate::dic::subset::InfoSubset;
 use crate::dic::word_id::{DictId, WordId};
-use crate::dic::word_info::WordInfo;
+use crate::dic::word_info::{WordInfo, WordInfoEntryIdCursor};
 use crate::dic::LexiconAccess;
 use crate::prelude::*;
 
@@ -49,6 +49,11 @@ pub struct LexiconSet<'a> {
     lexicons: Vec<Lexicon<'a>>,
     pos_offsets: Vec<usize>,
     num_system_pos: usize,
+}
+
+pub struct WordIdCursor {
+    lexicon_index: usize,
+    entry_cursor: Option<WordInfoEntryIdCursor>,
 }
 
 impl LexiconAccess for LexiconSet<'_> {
@@ -170,6 +175,38 @@ impl LexiconSet<'_> {
 
     pub fn size(&self) -> u32 {
         self.lexicons.iter().fold(0, |acc, lex| acc + lex.size())
+    }
+
+    pub fn word_ids(&self) -> impl Iterator<Item = WordId> + '_ {
+        self.lexicons.iter().enumerate().flat_map(|(dict_id, lex)| {
+            let dict_id = DictId::new(dict_id as u8);
+            lex.entry_ids()
+                .map(move |entry| WordId::from_parts(dict_id, entry))
+        })
+    }
+
+    pub fn word_id_cursor(&self) -> WordIdCursor {
+        WordIdCursor {
+            lexicon_index: 0,
+            entry_cursor: self.lexicons.first().map(Lexicon::entry_id_cursor),
+        }
+    }
+
+    pub fn next_word_id(&self, cursor: &mut WordIdCursor) -> Option<WordId> {
+        loop {
+            let lexicon = self.lexicons.get(cursor.lexicon_index)?;
+            let entry_cursor = cursor.entry_cursor.as_mut()?;
+            if let Some(entry) = lexicon.next_entry_id(entry_cursor) {
+                let dict_id = DictId::new(cursor.lexicon_index as u8);
+                return Some(WordId::from_parts(dict_id, entry));
+            }
+
+            cursor.lexicon_index += 1;
+            cursor.entry_cursor = self
+                .lexicons
+                .get(cursor.lexicon_index)
+                .map(Lexicon::entry_id_cursor);
+        }
     }
 
     pub fn system_word_ids_in_order(&self) -> Vec<WordId> {

--- a/sudachi/src/dic/word_info.rs
+++ b/sudachi/src/dic/word_info.rs
@@ -23,7 +23,8 @@ mod raw;
 
 pub(crate) use binary::{parse_i32_array, parse_u32_array, parse_user_data};
 pub use data::*;
-pub use infos::{WordInfoEntryIdCursor, WordInfos};
+pub(crate) use infos::WordInfoEntryIdCursor;
+pub use infos::WordInfos;
 pub(crate) use layout::WordInfoVariableLayout;
 pub use parse::WordInfoParser;
 pub(crate) use raw::WordInfoVariableData;

--- a/sudachi/src/dic/word_info.rs
+++ b/sudachi/src/dic/word_info.rs
@@ -24,7 +24,7 @@ mod raw;
 pub(crate) use binary::{parse_i32_array, parse_u32_array, parse_user_data};
 pub use data::*;
 pub(crate) use infos::WordInfoEntryIdCursor;
-pub use infos::WordInfos;
+pub use infos::{WordInfoError, WordInfos};
 pub(crate) use layout::WordInfoVariableLayout;
 pub use parse::WordInfoParser;
 pub(crate) use raw::WordInfoVariableData;

--- a/sudachi/src/dic/word_info.rs
+++ b/sudachi/src/dic/word_info.rs
@@ -23,7 +23,7 @@ mod raw;
 
 pub(crate) use binary::{parse_i32_array, parse_u32_array, parse_user_data};
 pub use data::*;
-pub use infos::WordInfos;
+pub use infos::{WordInfoEntryIdCursor, WordInfos};
 pub(crate) use layout::WordInfoVariableLayout;
 pub use parse::WordInfoParser;
 pub(crate) use raw::WordInfoVariableData;

--- a/sudachi/src/dic/word_info/infos.rs
+++ b/sudachi/src/dic/word_info/infos.rs
@@ -40,32 +40,19 @@ impl<'a> WordInfos<'a> {
     }
 
     pub fn entry_ids_in_order(&self, num_total_entries: u32) -> Option<Vec<EntryId>> {
-        let mut result = Vec::with_capacity(num_total_entries as usize);
-        let mut offset = Self::ENTRIES_INITIAL_OFFSET;
-
-        while result.len() < num_total_entries as usize {
-            if offset % Self::WORD_INFO_OFFSET_ALIGNMENT != 0 {
-                return None;
-            }
-
-            let entry_id = EntryId::new((offset >> Self::WORD_ID_ALIGNMENT_BITS) as u32);
-            result.push(entry_id);
-
-            let size = self.entry_size_at(offset)?;
-            offset = offset.checked_add(size)?;
-        }
-
-        Some(result)
+        self.entry_ids(num_total_entries)
+            .collect::<SudachiResult<Vec<_>>>()
+            .ok()
     }
 
-    pub fn entry_ids(&self, num_total_entries: u32) -> WordInfoEntryIdIter<'_, '_> {
+    pub(crate) fn entry_ids(&self, num_total_entries: u32) -> WordInfoEntryIdIter<'_, '_> {
         WordInfoEntryIdIter {
             infos: self,
             cursor: Self::entry_id_cursor(num_total_entries),
         }
     }
 
-    pub fn entry_id_cursor(num_total_entries: u32) -> WordInfoEntryIdCursor {
+    pub(crate) fn entry_id_cursor(num_total_entries: u32) -> WordInfoEntryIdCursor {
         WordInfoEntryIdCursor {
             remaining: num_total_entries,
             offset: Self::ENTRIES_INITIAL_OFFSET,
@@ -78,7 +65,7 @@ impl<'a> WordInfos<'a> {
         Ok(())
     }
 
-    pub fn next_entry_id(
+    pub(crate) fn next_entry_id(
         &self,
         cursor: &mut WordInfoEntryIdCursor,
     ) -> SudachiResult<Option<EntryId>> {
@@ -172,12 +159,12 @@ fn invalid_entry_block(offset: usize, reason: &str) -> SudachiError {
     )
 }
 
-pub struct WordInfoEntryIdCursor {
+pub(crate) struct WordInfoEntryIdCursor {
     remaining: u32,
     offset: usize,
 }
 
-pub struct WordInfoEntryIdIter<'a, 'b> {
+pub(crate) struct WordInfoEntryIdIter<'a, 'b> {
     infos: &'a WordInfos<'b>,
     cursor: WordInfoEntryIdCursor,
 }

--- a/sudachi/src/dic/word_info/infos.rs
+++ b/sudachi/src/dic/word_info/infos.rs
@@ -69,42 +69,51 @@ impl<'a> WordInfos<'a> {
         WordInfoEntryIdCursor {
             remaining: num_total_entries,
             offset: Self::ENTRIES_INITIAL_OFFSET,
-            invalid: false,
         }
     }
 
-    pub fn next_entry_id(&self, cursor: &mut WordInfoEntryIdCursor) -> Option<EntryId> {
-        if cursor.remaining == 0 || cursor.invalid {
-            return None;
+    pub fn validate_entry_boundaries(&self, num_total_entries: u32) -> SudachiResult<()> {
+        let mut cursor = Self::entry_id_cursor(num_total_entries);
+        while self.next_entry_id(&mut cursor)?.is_some() {}
+        Ok(())
+    }
+
+    pub fn next_entry_id(
+        &self,
+        cursor: &mut WordInfoEntryIdCursor,
+    ) -> SudachiResult<Option<EntryId>> {
+        if cursor.remaining == 0 {
+            return Ok(None);
         }
 
         if cursor.offset % Self::WORD_INFO_OFFSET_ALIGNMENT != 0 {
-            cursor.invalid = true;
-            return None;
+            return Err(invalid_entry_block(
+                cursor.offset,
+                "word info entry offset is not aligned",
+            ));
         }
 
         let entry_id = EntryId::new((cursor.offset >> Self::WORD_ID_ALIGNMENT_BITS) as u32);
-        let size = match self.entry_size_at(cursor.offset) {
-            Some(size) => size,
-            None => {
-                cursor.invalid = true;
-                return None;
-            }
-        };
+        let size = self.entry_size_at(cursor.offset).ok_or_else(|| {
+            invalid_entry_block(cursor.offset, "failed to read word info entry size")
+        })?;
 
         cursor.offset = match cursor.offset.checked_add(size) {
             Some(offset) => offset,
             None => {
-                cursor.invalid = true;
-                return None;
+                return Err(invalid_entry_block(
+                    cursor.offset,
+                    "word info entry overflows",
+                ))
             }
         };
         cursor.remaining -= 1;
-        Some(entry_id)
+        Ok(Some(entry_id))
     }
 
     fn entry_size_at(&self, offset: usize) -> Option<usize> {
-        let fixed = WordInfoFixedData::from_entry_bytes(&self.bytes[offset..])?;
+        let entry_bytes = self.bytes.get(offset..)?;
+        let fixed = WordInfoFixedData::from_entry_bytes(entry_bytes)?;
 
         if !layout::is_valid_user_data_flag(fixed.user_data_flag) {
             return None;
@@ -156,10 +165,16 @@ impl<'a> WordInfos<'a> {
     }
 }
 
+fn invalid_entry_block(offset: usize, reason: &str) -> SudachiError {
+    SudachiError::InvalidDataFormat(
+        0,
+        format!("invalid word info entry block at byte offset {offset}: {reason}"),
+    )
+}
+
 pub struct WordInfoEntryIdCursor {
     remaining: u32,
     offset: usize,
-    invalid: bool,
 }
 
 pub struct WordInfoEntryIdIter<'a, 'b> {
@@ -168,18 +183,21 @@ pub struct WordInfoEntryIdIter<'a, 'b> {
 }
 
 impl Iterator for WordInfoEntryIdIter<'_, '_> {
-    type Item = EntryId;
+    type Item = SudachiResult<EntryId>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.infos.next_entry_id(&mut self.cursor)
+        match self.infos.next_entry_id(&mut self.cursor) {
+            Ok(Some(entry_id)) => Some(Ok(entry_id)),
+            Ok(None) => None,
+            Err(error) => {
+                self.cursor.remaining = 0;
+                Some(Err(error))
+            }
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = if self.cursor.invalid {
-            0
-        } else {
-            self.cursor.remaining as usize
-        };
+        let remaining = self.cursor.remaining as usize;
         (0, Some(remaining))
     }
 }
@@ -319,5 +337,39 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[test]
+    fn validate_entry_boundaries_rejects_malformed_entries() {
+        let mut bytes = make_entry(&sample_fixed());
+        bytes.truncate(bytes.len() - 1);
+        let infos = WordInfos::from_bytes(&bytes);
+
+        let err = infos.validate_entry_boundaries(1).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("invalid word info entry block at byte offset"));
+    }
+
+    #[test]
+    fn validate_entry_boundaries_rejects_short_entry_block() {
+        let bytes = vec![0; layout::ENTRY_INITIAL_OFFSET - 1];
+        let infos = WordInfos::from_bytes(&bytes);
+
+        let err = infos.validate_entry_boundaries(1).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("failed to read word info entry size"));
+    }
+
+    #[test]
+    fn entry_id_iterator_reports_malformed_entries() {
+        let mut bytes = make_entry(&sample_fixed());
+        bytes.truncate(bytes.len() - 1);
+        let infos = WordInfos::from_bytes(&bytes);
+        let mut entries = infos.entry_ids(1);
+
+        assert!(entries.next().unwrap().is_err());
+        assert!(entries.next().is_none());
     }
 }

--- a/sudachi/src/dic/word_info/infos.rs
+++ b/sudachi/src/dic/word_info/infos.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use std::iter::FusedIterator;
+
 use crate::dic::subset::InfoSubset;
 use crate::dic::word_id::EntryId;
 use crate::dic::word_info::layout;
@@ -54,6 +56,51 @@ impl<'a> WordInfos<'a> {
         }
 
         Some(result)
+    }
+
+    pub fn entry_ids(&self, num_total_entries: u32) -> WordInfoEntryIdIter<'_, '_> {
+        WordInfoEntryIdIter {
+            infos: self,
+            cursor: Self::entry_id_cursor(num_total_entries),
+        }
+    }
+
+    pub fn entry_id_cursor(num_total_entries: u32) -> WordInfoEntryIdCursor {
+        WordInfoEntryIdCursor {
+            remaining: num_total_entries,
+            offset: Self::ENTRIES_INITIAL_OFFSET,
+            invalid: false,
+        }
+    }
+
+    pub fn next_entry_id(&self, cursor: &mut WordInfoEntryIdCursor) -> Option<EntryId> {
+        if cursor.remaining == 0 || cursor.invalid {
+            return None;
+        }
+
+        if cursor.offset % Self::WORD_INFO_OFFSET_ALIGNMENT != 0 {
+            cursor.invalid = true;
+            return None;
+        }
+
+        let entry_id = EntryId::new((cursor.offset >> Self::WORD_ID_ALIGNMENT_BITS) as u32);
+        let size = match self.entry_size_at(cursor.offset) {
+            Some(size) => size,
+            None => {
+                cursor.invalid = true;
+                return None;
+            }
+        };
+
+        cursor.offset = match cursor.offset.checked_add(size) {
+            Some(offset) => offset,
+            None => {
+                cursor.invalid = true;
+                return None;
+            }
+        };
+        cursor.remaining -= 1;
+        Some(entry_id)
     }
 
     fn entry_size_at(&self, offset: usize) -> Option<usize> {
@@ -108,6 +155,36 @@ impl<'a> WordInfos<'a> {
         Ok(WordInfoRefData::from_raw(word_info))
     }
 }
+
+pub struct WordInfoEntryIdCursor {
+    remaining: u32,
+    offset: usize,
+    invalid: bool,
+}
+
+pub struct WordInfoEntryIdIter<'a, 'b> {
+    infos: &'a WordInfos<'b>,
+    cursor: WordInfoEntryIdCursor,
+}
+
+impl Iterator for WordInfoEntryIdIter<'_, '_> {
+    type Item = EntryId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.infos.next_entry_id(&mut self.cursor)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = if self.cursor.invalid {
+            0
+        } else {
+            self.cursor.remaining as usize
+        };
+        (0, Some(remaining))
+    }
+}
+
+impl FusedIterator for WordInfoEntryIdIter<'_, '_> {}
 
 #[cfg(test)]
 mod tests {

--- a/sudachi/src/dic/word_info/infos.rs
+++ b/sudachi/src/dic/word_info/infos.rs
@@ -21,6 +21,24 @@ use crate::dic::word_id::EntryId;
 use crate::dic::word_info::layout;
 use crate::dic::word_info::{WordInfoFixedData, WordInfoParser, WordInfoRefData};
 use crate::prelude::*;
+use thiserror::Error;
+
+/// Errors returned while scanning binary WordInfo entry boundaries.
+#[derive(Error, Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum WordInfoError {
+    /// WordInfo entry offsets must be aligned because entry ids are derived from them.
+    #[error("word info entry id at byte offset {0} is not aligned")]
+    EntryIdNotAligned(usize),
+
+    /// The scanner could not determine a complete, valid entry size at the offset.
+    #[error("failed to load word info entry size at byte offset {0}")]
+    FailedToLoadEntrySize(usize),
+
+    /// The entry offset cannot be represented as a valid Sudachi entry id.
+    #[error("word info entry id at byte offset {0} is too large")]
+    EntryIdTooLarge(usize),
+}
 
 pub struct WordInfos<'a> {
     bytes: &'a [u8],
@@ -59,6 +77,10 @@ impl<'a> WordInfos<'a> {
         }
     }
 
+    /// Validate that all WordInfo entries can be scanned from their binary boundaries.
+    ///
+    /// Returns [`WordInfoError`] through [`SudachiError`] when an entry id cannot be
+    /// derived or an entry size cannot be read.
     pub fn validate_entry_boundaries(&self, num_total_entries: u32) -> SudachiResult<()> {
         let mut cursor = Self::entry_id_cursor(num_total_entries);
         while self.next_entry_id(&mut cursor)?.is_some() {}
@@ -73,29 +95,30 @@ impl<'a> WordInfos<'a> {
             return Ok(None);
         }
 
-        if cursor.offset % Self::WORD_INFO_OFFSET_ALIGNMENT != 0 {
-            return Err(invalid_entry_block(
-                cursor.offset,
-                "word info entry offset is not aligned",
-            ));
-        }
-
-        let entry_id = EntryId::new((cursor.offset >> Self::WORD_ID_ALIGNMENT_BITS) as u32);
-        let size = self.entry_size_at(cursor.offset).ok_or_else(|| {
-            invalid_entry_block(cursor.offset, "failed to read word info entry size")
-        })?;
+        let entry_id = Self::entry_id_from_offset(cursor.offset)?;
+        let size = self
+            .entry_size_at(cursor.offset)
+            .ok_or_else(|| WordInfoError::FailedToLoadEntrySize(cursor.offset))?;
 
         cursor.offset = match cursor.offset.checked_add(size) {
             Some(offset) => offset,
-            None => {
-                return Err(invalid_entry_block(
-                    cursor.offset,
-                    "word info entry overflows",
-                ))
-            }
+            None => return Err(WordInfoError::EntryIdTooLarge(cursor.offset).into()),
         };
         cursor.remaining -= 1;
         Ok(Some(entry_id))
+    }
+
+    fn entry_id_from_offset(offset: usize) -> SudachiResult<EntryId> {
+        if offset % Self::WORD_INFO_OFFSET_ALIGNMENT != 0 {
+            return Err(WordInfoError::EntryIdNotAligned(offset).into());
+        }
+
+        let raw = offset >> Self::WORD_ID_ALIGNMENT_BITS;
+        if raw > EntryId::MAX as usize {
+            return Err(WordInfoError::EntryIdTooLarge(offset).into());
+        }
+
+        Ok(EntryId::new(raw as u32))
     }
 
     fn entry_size_at(&self, offset: usize) -> Option<usize> {
@@ -108,16 +131,16 @@ impl<'a> WordInfos<'a> {
 
         let mut user_data_units = None;
         if fixed.has_user_data() {
-            let user_data_offset = offset
-                + layout::unaligned_size_from_lengths(
-                    fixed.c_unit_split_length,
-                    fixed.b_unit_split_length,
-                    fixed.a_unit_split_length,
-                    fixed.word_structure_length,
-                    fixed.synonym_group_ids_length,
-                    None,
-                )?;
-            let user_len_bytes = self.bytes.get(user_data_offset..user_data_offset + 2)?;
+            let user_data_offset = offset.checked_add(layout::unaligned_size_from_lengths(
+                fixed.c_unit_split_length,
+                fixed.b_unit_split_length,
+                fixed.a_unit_split_length,
+                fixed.word_structure_length,
+                fixed.synonym_group_ids_length,
+                None,
+            )?)?;
+            let user_data_len_end = user_data_offset.checked_add(2)?;
+            let user_len_bytes = self.bytes.get(user_data_offset..user_data_len_end)?;
             let user_len = i16::from_le_bytes([user_len_bytes[0], user_len_bytes[1]]);
             user_data_units = Some(user_len);
         }
@@ -130,7 +153,8 @@ impl<'a> WordInfos<'a> {
             fixed.synonym_group_ids_length,
             user_data_units,
         )?;
-        self.bytes.get(offset..offset + aligned)?;
+        let end = offset.checked_add(aligned)?;
+        self.bytes.get(offset..end)?;
         Some(aligned)
     }
 
@@ -150,13 +174,6 @@ impl<'a> WordInfos<'a> {
         let word_info = parser.parse(bytes)?;
         Ok(WordInfoRefData::from_raw(word_info))
     }
-}
-
-fn invalid_entry_block(offset: usize, reason: &str) -> SudachiError {
-    SudachiError::InvalidDataFormat(
-        0,
-        format!("invalid word info entry block at byte offset {offset}: {reason}"),
-    )
 }
 
 pub(crate) struct WordInfoEntryIdCursor {
@@ -197,6 +214,13 @@ mod tests {
     use crate::dic::lexicon::strings::StringPointer;
     use crate::dic::word_id::DictId;
     use crate::dic::word_info::WordInfoVariableData;
+
+    fn assert_word_info_error(error: SudachiError, expected: WordInfoError) {
+        match error {
+            SudachiError::WordInfo(actual) => assert_eq!(actual, expected),
+            other => panic!("expected word info error {expected:?}, got {other:?}"),
+        }
+    }
 
     fn sample_fixed() -> WordInfoFixedData {
         WordInfoFixedData {
@@ -333,9 +357,10 @@ mod tests {
         let infos = WordInfos::from_bytes(&bytes);
 
         let err = infos.validate_entry_boundaries(1).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("invalid word info entry block at byte offset"));
+        assert_word_info_error(
+            err,
+            WordInfoError::FailedToLoadEntrySize(layout::ENTRY_INITIAL_OFFSET),
+        );
     }
 
     #[test]
@@ -344,9 +369,40 @@ mod tests {
         let infos = WordInfos::from_bytes(&bytes);
 
         let err = infos.validate_entry_boundaries(1).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("failed to read word info entry size"));
+        assert_word_info_error(
+            err,
+            WordInfoError::FailedToLoadEntrySize(layout::ENTRY_INITIAL_OFFSET),
+        );
+    }
+
+    #[test]
+    fn next_entry_id_rejects_misaligned_entry_offset() {
+        let bytes = make_entry(&sample_fixed());
+        let infos = WordInfos::from_bytes(&bytes);
+        let mut cursor = WordInfoEntryIdCursor {
+            remaining: 1,
+            offset: layout::ENTRY_INITIAL_OFFSET + 1,
+        };
+
+        let err = infos.next_entry_id(&mut cursor).unwrap_err();
+        assert_word_info_error(
+            err,
+            WordInfoError::EntryIdNotAligned(layout::ENTRY_INITIAL_OFFSET + 1),
+        );
+    }
+
+    #[test]
+    fn next_entry_id_rejects_too_large_entry_id() {
+        let bytes = make_entry(&sample_fixed());
+        let infos = WordInfos::from_bytes(&bytes);
+        let too_large_offset = ((EntryId::MAX as usize) + 1) << WordInfos::WORD_ID_ALIGNMENT_BITS;
+        let mut cursor = WordInfoEntryIdCursor {
+            remaining: 1,
+            offset: too_large_offset,
+        };
+
+        let err = infos.next_entry_id(&mut cursor).unwrap_err();
+        assert_word_info_error(err, WordInfoError::EntryIdTooLarge(too_large_offset));
     }
 
     #[test]

--- a/sudachi/src/error.rs
+++ b/sudachi/src/error.rs
@@ -27,6 +27,7 @@ use crate::dic::header::HeaderError;
 use crate::dic::lexicon_set::LexiconSetError;
 use crate::dic::read::error::SudachiNomError;
 use crate::dic::word_id::WordId;
+use crate::dic::word_info::WordInfoError;
 use crate::plugin::PluginError;
 
 pub type SudachiResult<T> = Result<T, SudachiError>;
@@ -91,6 +92,9 @@ pub enum SudachiError {
 
     #[error("Invalid data format: {1} at line {0}")]
     InvalidDataFormat(usize, String),
+
+    #[error(transparent)]
+    WordInfo(#[from] WordInfoError),
 
     #[error("Invalid grammar")]
     InvalidDictionaryGrammar,

--- a/sudachi/tests/dictionary.rs
+++ b/sudachi/tests/dictionary.rs
@@ -27,7 +27,7 @@ use sudachi::dic::error::DictionaryCompatibilityError;
 use sudachi::dic::storage::{Storage, SudachiDicData};
 use sudachi::error::SudachiError;
 
-const HIDDEN_ENTRY_LEXICON: &[u8] = concat!(
+const NON_INDEXED_ENTRY_LEXICON: &[u8] = concat!(
     "index_form,left_id,right_id,cost,pos1,pos2,pos3,pos4,pos5,pos6,reading_form,normalized_form,dictionary_form,mode,split_a,split_b,word_structure\n",
     "京都,6,6,5293,名詞,固有名詞,地名,一般,*,*,キョウト,,,A,,,\n",
     "隠し,-1,-1,5293,名詞,普通名詞,一般,*,*,*,カクシ,,,A,,,\n",
@@ -35,7 +35,7 @@ const HIDDEN_ENTRY_LEXICON: &[u8] = concat!(
 )
 .as_bytes();
 
-const HIDDEN_ENTRY_CONFIG: &str = r#"
+const NON_INDEXED_ENTRY_CONFIG: &str = r#"
 {
     "path" : "tests/resources/",
     "characterDefinitionFile" : "char.def",
@@ -158,8 +158,8 @@ fn reject_incompatible_user_dictionary() {
 
 #[test]
 fn entries_include_non_indexed_entries_and_exclude_phantoms() {
-    let tok = common::TestStatefulTokenizer::builder(HIDDEN_ENTRY_LEXICON)
-        .config(HIDDEN_ENTRY_CONFIG.as_bytes())
+    let tok = common::TestStatefulTokenizer::builder(NON_INDEXED_ENTRY_LEXICON)
+        .config(NON_INDEXED_ENTRY_CONFIG.as_bytes())
         .build();
 
     let entries = tok
@@ -176,8 +176,8 @@ fn entries_include_non_indexed_entries_and_exclude_phantoms() {
 
 #[test]
 fn lookup_all_entries_scans_non_indexed_entries_only_public_rows() {
-    let mut tok = common::TestStatefulTokenizer::builder(HIDDEN_ENTRY_LEXICON)
-        .config(HIDDEN_ENTRY_CONFIG.as_bytes())
+    let mut tok = common::TestStatefulTokenizer::builder(NON_INDEXED_ENTRY_LEXICON)
+        .config(NON_INDEXED_ENTRY_CONFIG.as_bytes())
         .build();
 
     let indexed = tok.dict().lookup_all_entries("京都").unwrap();
@@ -235,7 +235,7 @@ fn lookup_all_entries_normalizes_query_and_searches_user_dictionaries() {
 
 #[test]
 fn lookup_all_entries_and_lookup_apply_input_text_plugins() {
-    let mut tok = common::TestStatefulTokenizer::builder(HIDDEN_ENTRY_LEXICON)
+    let mut tok = common::TestStatefulTokenizer::builder(NON_INDEXED_ENTRY_LEXICON)
         .config(YOMIGANA_CONFIG.as_bytes())
         .build();
 

--- a/sudachi/tests/dictionary.rs
+++ b/sudachi/tests/dictionary.rs
@@ -16,6 +16,7 @@
 
 extern crate lazy_static;
 
+use std::ops::Deref;
 use std::time::{Duration, UNIX_EPOCH};
 
 mod common;
@@ -43,6 +44,28 @@ const HIDDEN_ENTRY_CONFIG: &str = r#"
     ],
     "oovProviderPlugin" : [
         { "class" : "$exe/simple_oov",
+          "oovPOS" : [ "名詞", "普通名詞", "一般", "*", "*", "*" ],
+          "leftId" : 8,
+          "rightId" : 8,
+          "cost" : 6000 }
+    ],
+    "pathRewritePlugin" : []
+}
+"#;
+
+const YOMIGANA_CONFIG: &str = r#"
+{
+    "path" : "tests/resources/",
+    "characterDefinitionFile" : "char.def",
+    "inputTextPlugin" : [
+        { "class" : "com.worksap.nlp.sudachi.DefaultInputTextPlugin" },
+        { "class" : "com.worksap.nlp.sudachi.IgnoreYomiganaPlugin",
+          "leftBrackets": ["(", "（"],
+          "rightBrackets": [")", "）"],
+          "maxYomiganaLength": 4 }
+    ],
+    "oovProviderPlugin" : [
+        { "class" : "com.worksap.nlp.sudachi.SimpleOovPlugin",
           "oovPOS" : [ "名詞", "普通名詞", "一般", "*", "*", "*" ],
           "leftId" : 8,
           "rightId" : 8,
@@ -161,9 +184,9 @@ fn lookup_all_entries_scans_non_indexed_entries_only_public_rows() {
     assert_eq!(indexed.len(), 1);
     assert_eq!(indexed[0].reading_form(), "キョウト");
 
-    let hidden = tok.dict().lookup_all_entries("隠し").unwrap();
-    assert_eq!(hidden.len(), 1);
-    assert_eq!(hidden[0].surface(), "隠し");
+    let non_indexed = tok.dict().lookup_all_entries("隠し").unwrap();
+    assert_eq!(non_indexed.len(), 1);
+    assert_eq!(non_indexed[0].surface(), "隠し");
 
     tok.result.clear();
     assert_eq!(
@@ -175,6 +198,19 @@ fn lookup_all_entries_scans_non_indexed_entries_only_public_rows() {
 
     let phantom = tok.dict().lookup_all_entries("舞台芸術").unwrap();
     assert!(phantom.is_empty());
+}
+
+#[test]
+fn indexed_lookup_normalizes_query() {
+    let mut tok = common::TestStatefulTokenizer::new_built(sudachi::analysis::Mode::C);
+
+    assert_eq!(
+        tok.result
+            .lookup("特A", sudachi::dic::subset::InfoSubset::all())
+            .unwrap(),
+        1
+    );
+    assert_eq!(tok.result.get(0).reading_form(), "トクエー");
 }
 
 #[test]
@@ -195,6 +231,31 @@ fn lookup_all_entries_normalizes_query_and_searches_user_dictionaries() {
         .lookup_all_entries("存在しない語")
         .unwrap()
         .is_empty());
+}
+
+#[test]
+fn lookup_all_entries_and_lookup_apply_input_text_plugins() {
+    let mut tok = common::TestStatefulTokenizer::builder(HIDDEN_ENTRY_LEXICON)
+        .config(YOMIGANA_CONFIG.as_bytes())
+        .build();
+
+    let entries = tok.dict().lookup_all_entries("京都（キョウト）").unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].surface(), "京都");
+    assert_eq!(entries[0].normalized_form(), "京都");
+
+    tok.result.clear();
+    assert_eq!(
+        tok.result
+            .lookup("京都（キョウト）", sudachi::dic::subset::InfoSubset::all())
+            .unwrap(),
+        1
+    );
+    assert_eq!(tok.result.get(0).reading_form(), "キョウト");
+    assert_eq!(tok.result.get(0).surface().deref(), "京都");
+    assert_eq!(tok.result.get(0).begin(), 0);
+    assert_eq!(tok.result.get(0).end(), "京都".len());
+    assert_eq!(tok.result.get(0).end_c(), 2);
 }
 
 // fn creat_with_merging_settings

--- a/sudachi/tests/dictionary.rs
+++ b/sudachi/tests/dictionary.rs
@@ -26,6 +26,32 @@ use sudachi::dic::error::DictionaryCompatibilityError;
 use sudachi::dic::storage::{Storage, SudachiDicData};
 use sudachi::error::SudachiError;
 
+const HIDDEN_ENTRY_LEXICON: &[u8] = concat!(
+    "index_form,left_id,right_id,cost,pos1,pos2,pos3,pos4,pos5,pos6,reading_form,normalized_form,dictionary_form,mode,split_a,split_b,word_structure\n",
+    "京都,6,6,5293,名詞,固有名詞,地名,一般,*,*,キョウト,,,A,,,\n",
+    "隠し,-1,-1,5293,名詞,普通名詞,一般,*,*,*,カクシ,,,A,,,\n",
+    "舞台藝術,1,1,2816,名詞,普通名詞,一般,*,*,*,ブタイゲイジュツ,舞台芸術,,A,,,\n",
+)
+.as_bytes();
+
+const HIDDEN_ENTRY_CONFIG: &str = r#"
+{
+    "path" : "tests/resources/",
+    "characterDefinitionFile" : "char.def",
+    "inputTextPlugin" : [
+        { "class" : "$exe/default_input_text" }
+    ],
+    "oovProviderPlugin" : [
+        { "class" : "$exe/simple_oov",
+          "oovPOS" : [ "名詞", "普通名詞", "一般", "*", "*", "*" ],
+          "leftId" : 8,
+          "rightId" : 8,
+          "cost" : 6000 }
+    ],
+    "pathRewritePlugin" : []
+}
+"#;
+
 #[test]
 fn get_part_of_speech_size() {
     // pos from system test dict
@@ -105,6 +131,70 @@ fn reject_incompatible_user_dictionary() {
         }
         Err(err) => panic!("unexpected error: {err}"),
     }
+}
+
+#[test]
+fn entries_include_non_indexed_entries_and_exclude_phantoms() {
+    let tok = common::TestStatefulTokenizer::builder(HIDDEN_ENTRY_LEXICON)
+        .config(HIDDEN_ENTRY_CONFIG.as_bytes())
+        .build();
+
+    let entries = tok
+        .dict()
+        .entries()
+        .map(|entry| entry.unwrap().surface().to_owned())
+        .collect::<Vec<_>>();
+
+    assert_eq!(entries.len(), 3);
+    assert!(entries.contains(&"京都".to_string()));
+    assert!(entries.contains(&"隠し".to_string()));
+    assert!(entries.contains(&"舞台藝術".to_string()));
+}
+
+#[test]
+fn lookup_all_entries_scans_non_indexed_entries_only_public_rows() {
+    let mut tok = common::TestStatefulTokenizer::builder(HIDDEN_ENTRY_LEXICON)
+        .config(HIDDEN_ENTRY_CONFIG.as_bytes())
+        .build();
+
+    let indexed = tok.dict().lookup_all_entries("京都").unwrap();
+    assert_eq!(indexed.len(), 1);
+    assert_eq!(indexed[0].reading_form(), "キョウト");
+
+    let hidden = tok.dict().lookup_all_entries("隠し").unwrap();
+    assert_eq!(hidden.len(), 1);
+    assert_eq!(hidden[0].surface(), "隠し");
+
+    tok.result.clear();
+    assert_eq!(
+        tok.result
+            .lookup("隠し", sudachi::dic::subset::InfoSubset::all())
+            .unwrap(),
+        0
+    );
+
+    let phantom = tok.dict().lookup_all_entries("舞台芸術").unwrap();
+    assert!(phantom.is_empty());
+}
+
+#[test]
+fn lookup_all_entries_normalizes_query_and_searches_user_dictionaries() {
+    let tok = TestTokenizer::new();
+
+    let normalized = tok.dict().lookup_all_entries("特A").unwrap();
+    assert_eq!(normalized.len(), 1);
+    assert_eq!(normalized[0].surface(), "特A");
+
+    let user_entry = tok.dict().lookup_all_entries("すだち").unwrap();
+    assert_eq!(user_entry.len(), 1);
+    assert_eq!(user_entry[0].dictionary_id(), 1);
+    assert_eq!(user_entry[0].user_data(), "徳島県産");
+
+    assert!(tok
+        .dict()
+        .lookup_all_entries("存在しない語")
+        .unwrap()
+        .is_empty());
 }
 
 // fn creat_with_merging_settings


### PR DESCRIPTION
## Summary

Adds dictionary-entry iteration and full-entry lookup APIs for Rust and Python, following Java `develop-v0.8` behavior for `Dictionary.entries()` and `lookupAllEntries()`.

- `entries()` iterates public lexicon entries as standalone morphemes, including entries referred from other entries such as split/constituent units even when they are not indexed for normal lookup.
- Internal entries automatically generated for literal normalized forms are not exposed.
- `lookup_all_entries()` normalizes the query with dictionary input-text plugins, scans public lexicon entries, and returns entries whose normalized surface matches.
- Indexed `lookup()` also normalizes the query before trie lookup and now materializes results over the normalized input text, matching Java behavior for cases such as `IgnoreYomigana`.

## Review notes

- WordInfo entry scanning is now fallible, and dictionary load validates entry boundaries. Malformed or truncated entry blocks no longer silently truncate `entries()` / `lookup_all_entries()`.
- Entry-scan helpers stay crate-internal; the public API surface is the dictionary methods and the Python binding methods.
- The iteration order is intentionally not part of the public contract.

## Validation

- `cargo fmt --all --check`
- `cargo test -p sudachi dic::word_info::infos --offline`
- `cargo test -p sudachi --test dictionary --offline`
- `cargo test -p sudachipy --lib --offline`
- `python setup.py build_rust --inplace && python -m unittest tests.test_dictionary`
- `git diff --check`

## Benchmark note

Checked on SudachiDict full 20260428, built as a V1 dictionary from raw CSV. Java comparison used `WorksApplications/Sudachi` `develop-v0.8` at `9a2f4c3`. Queries: `東京都`, `京都`, `京都（キョウト）`, `外国人参政権`, `存在しない語`. Rust and Python were measured with release builds; RSS was measured with `/usr/bin/time -l`.

All engines matched for `entries()`, indexed `lookup()`, and `lookup_all_entries()` digests. `entries()` count was `2,883,177` with checksum `sum=0x79401354812f1721`, `xor=0xc66f60b830cc6537`.

| Engine | `entries()` | indexed `lookup` | `lookup_all_entries` | peak RSS |
|---|---:|---:|---:|---:|
| Rust | 1.533 s | 1.061 us/call | 1.304 s/call | 172 MB |
| Java | 1.456 s | 7.475 us/call | 0.471 s/call | 5012 MB |
| Python | 27.644 s | 1.248 us/call | 1.273 s/call | 191 MB |

`lookup_all_entries("京都")` and `lookup_all_entries("京都（キョウト）")` both returned 2 entries, while indexed `lookup(...)` returned 1 entry for each. The Python `entries()` timing includes Python-level iteration and method-call overhead over 2.88M morphemes; the core scan path is exercised by Rust and by Python `lookup_all_entries()`.

Closes #320
