### PR TITLE
Optimize sentence detector scanning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +592,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +657,12 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -905,6 +926,7 @@ dependencies = [
  "aho-corasick",
  "bitflags",
  "claim",
+ "criterion",
  "csv",
  "default_input_text",
  "fancy-regex",
@@ -913,6 +935,7 @@ dependencies = [
  "join_katakana_oov",
  "join_numeric",
  "lazy_static",
+ "libc",
  "libloading",
  "memmap2",
  "nom",
@@ -932,8 +955,10 @@ version = "0.6.11-a1"
 dependencies = [
  "cfg-if",
  "clap",
+ "csv",
  "memmap2",
  "sudachi",
+ "time",
 ]
 
 [[package]]
@@ -1013,6 +1038,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/sudachi/Cargo.toml
+++ b/sudachi/Cargo.toml
@@ -31,6 +31,7 @@ yada = "0.5" # MIT/Apache 2.0
 
 [dev-dependencies]
 claim = "0.5" # MIT/Apache 2.0
+criterion = "0.5" # MIT/Apache 2.0
 tempfile = "3" # MIT/Apache 2.0
 
 # Plugins for tests
@@ -41,3 +42,7 @@ join_katakana_oov = { path = "../plugin/path_rewrite/join_katakana_oov" }
 
 [lib]
 crate-type = ["rlib"]
+
+[[bench]]
+name = "sentence_detector"
+harness = false

--- a/sudachi/benches/sentence_detector.rs
+++ b/sudachi/benches/sentence_detector.rs
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::path::PathBuf;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use sudachi::analysis::stateful_tokenizer::StatefulTokenizer;
+use sudachi::analysis::Mode;
+use sudachi::config::Config;
+use sudachi::dic::dictionary::JapaneseDictionary;
+use sudachi::prelude::MorphemeList;
+use sudachi::sentence_splitter::{SentenceSplitter, SplitSentences};
+
+fn load_dictionary() -> JapaneseDictionary {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let config = Config::new(
+        Some(manifest_dir.join("tests/resources/sudachi.json")),
+        None,
+        None,
+    )
+    .expect("test config should load");
+    JapaneseDictionary::from_cfg(&config).expect("test dictionary should load")
+}
+
+fn prose_corpus_repeated(repeats: usize) -> String {
+    [
+        "吾輩は猫である。名前はまだ無い。",
+        "どこで生れたかとんと見当がつかぬ。",
+        "何でも薄暗いじめじめした所でニャーニャー泣いていた事だけは記憶している。",
+        "この文章は、括弧（たとえば「引用。まだ続く」）を含む。",
+    ]
+    .join("")
+    .repeat(repeats)
+}
+
+fn prose_corpus() -> String {
+    prose_corpus_repeated(512)
+}
+
+fn punctuation_heavy_corpus() -> String {
+    [
+        "え？！本当に？！",
+        "価格は3.141ではない。四百十.〇も数字として扱う。",
+        "箇条書き1.と2.の途中では切らない。",
+        "「まだ終わらない。引用の内側だ」。ここで終わる。",
+        "あ・・・？！次へ。",
+    ]
+    .join("")
+    .repeat(512)
+}
+
+fn long_line_corpus() -> String {
+    let mut text = "長い文節".repeat(1200);
+    text.push(' ');
+    text.push_str(&"さらに長い文節".repeat(600));
+    text.push('。');
+    text
+}
+
+fn html_corpus() -> String {
+    [
+        "一つ目の段落<br><br>二つ目の段落。",
+        "大文字の区切り<BR><BR>次の段落。",
+        "単独の<br>タグでは切らない。",
+    ]
+    .join("")
+    .repeat(512)
+}
+
+fn corpora() -> Vec<(&'static str, String)> {
+    vec![
+        ("prose", prose_corpus()),
+        ("punctuation_heavy", punctuation_heavy_corpus()),
+        ("long_line", long_line_corpus()),
+        ("html", html_corpus()),
+    ]
+}
+
+fn bench_split_only(c: &mut Criterion) {
+    let dict = load_dictionary();
+    let splitter = SentenceSplitter::new().with_checker(dict.lexicon());
+
+    let mut group = c.benchmark_group("sentence_splitter_only");
+    for (name, corpus) in corpora() {
+        group.throughput(Throughput::Bytes(corpus.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(name), &corpus, |b, input| {
+            b.iter(|| {
+                let total_len = splitter
+                    .split(black_box(input))
+                    .map(|(_, sentence)| sentence.len())
+                    .sum::<usize>();
+                black_box(total_len)
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_end_to_end(c: &mut Criterion) {
+    let dict = load_dictionary();
+    let splitter = SentenceSplitter::new().with_checker(dict.lexicon());
+    let mut tokenizer = StatefulTokenizer::create(&dict, false, Mode::C);
+    let mut morphemes = MorphemeList::empty(&dict);
+    let input = prose_corpus_repeated(128);
+
+    let mut group = c.benchmark_group("sentence_splitter_end_to_end");
+    group.throughput(Throughput::Bytes(input.len() as u64));
+
+    group.bench_function("split_sentences_yes", |b| {
+        b.iter(|| {
+            let mut total = 0;
+            for (_, sentence) in splitter.split(black_box(&input)) {
+                tokenizer.reset().push_str(sentence);
+                tokenizer
+                    .do_tokenize()
+                    .expect("tokenization should succeed");
+                morphemes
+                    .collect_results(&mut tokenizer)
+                    .expect("collection should succeed");
+                total += morphemes.len();
+            }
+            black_box(total)
+        })
+    });
+
+    group.bench_function("split_sentences_none", |b| {
+        b.iter(|| {
+            tokenizer.reset().push_str(black_box(&input));
+            tokenizer
+                .do_tokenize()
+                .expect("tokenization should succeed");
+            morphemes
+                .collect_results(&mut tokenizer)
+                .expect("collection should succeed");
+            black_box(morphemes.len())
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_split_only, bench_end_to_end);
+criterion_main!(benches);

--- a/sudachi/src/dic/lexicon.rs
+++ b/sudachi/src/dic/lexicon.rs
@@ -129,6 +129,18 @@ impl<'a> Lexicon<'a> {
             })
     }
 
+    /// Returns end offsets of trie prefixes that match given input.
+    #[inline]
+    pub(crate) fn lookup_prefix_ends(
+        &'a self,
+        input: &'a [u8],
+        offset: usize,
+    ) -> impl Iterator<Item = usize> + 'a {
+        self.trie
+            .common_prefix_iterator(input, offset)
+            .map(|entry| entry.end)
+    }
+
     /// Returns WordInfo for given word_id
     ///
     /// WordInfo will contain only fields included in InfoSubset

--- a/sudachi/src/dic/lexicon_set.rs
+++ b/sudachi/src/dic/lexicon_set.rs
@@ -128,6 +128,28 @@ impl LexiconSet<'_> {
             .flat_map(move |l| l.lookup(input, offset))
     }
 
+    /// Checks prefix end offsets in the same dictionary order as lookup(), but
+    /// without expanding trie leaves into word IDs.
+    #[inline]
+    pub(crate) fn check_prefix_ends<F>(
+        &self,
+        input: &[u8],
+        offset: usize,
+        mut check: F,
+    ) -> Option<bool>
+    where
+        F: FnMut(usize) -> Option<bool>,
+    {
+        for lexicon in self.lexicons.iter().rev() {
+            for end in lexicon.lookup_prefix_ends(input, offset) {
+                if let Some(result) = check(end) {
+                    return Some(result);
+                }
+            }
+        }
+        None
+    }
+
     /// Returns WordInfo for given WordId
     pub fn get_word_info(&self, id: WordId) -> SudachiResult<WordInfo> {
         self.get_word_info_subset(id, InfoSubset::all())
@@ -225,5 +247,56 @@ impl LexiconSet<'_> {
             .into_iter()
             .map(|entry| WordId::from_parts(DictId::SYSTEM, entry))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dic::binary_loader::LoadedDictionary;
+
+    const TEST_SYSTEM_DIC: &[u8] = include_bytes!("../../tests/resources/system.dic.test");
+
+    #[test]
+    fn check_prefix_ends_matches_lookup_end_order() {
+        let dictionary = LoadedDictionary::load_system(TEST_SYSTEM_DIC).unwrap();
+        let lexicon_set = &dictionary.lexicon_set;
+        let inputs = [
+            "ばな。なです。",
+            "東京都に行く",
+            "京都",
+            "あいうえお",
+            "1.と2.が。",
+        ];
+
+        for input in inputs {
+            let bytes = input.as_bytes();
+            for (offset, _) in input.char_indices() {
+                let mut checked_ends = Vec::new();
+                let decision = lexicon_set.check_prefix_ends(bytes, offset, |end| {
+                    checked_ends.push(end);
+                    None::<bool>
+                });
+
+                assert_eq!(decision, None);
+
+                let mut expected_ends = Vec::new();
+                for lexicon in lexicon_set.lexicons.iter().rev() {
+                    let mut lookup_ends = Vec::new();
+                    for entry in lexicon.lookup(bytes, offset) {
+                        if lookup_ends.last() != Some(&entry.end) {
+                            lookup_ends.push(entry.end);
+                        }
+                    }
+
+                    let prefix_ends = lexicon
+                        .lookup_prefix_ends(bytes, offset)
+                        .collect::<Vec<_>>();
+                    assert_eq!(lookup_ends, prefix_ends);
+                    expected_ends.extend(prefix_ends);
+                }
+
+                assert_eq!(checked_ends, expected_ends);
+            }
+        }
     }
 }

--- a/sudachi/src/sentence_detector.rs
+++ b/sudachi/src/sentence_detector.rs
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-use fancy_regex::Regex;
-use lazy_static::lazy_static;
 use std::cmp::Ordering;
 
 use crate::dic::lexicon_set::LexiconSet;
@@ -38,10 +36,19 @@ impl NonBreakChecker<'_> {
     fn has_non_break_word(&self, input: &str, length: usize) -> bool {
         // assume that SentenceDetector::get_eos called with self.input[self.bos..]
         let eos_byte = self.bos + length;
+        if eos_byte > input.len() || !input.is_char_boundary(eos_byte) {
+            return false;
+        }
+
         let input_bytes = input.as_bytes();
         const LOOKUP_BYTE_LENGTH: usize = 10 * 3; // 10 Japanese characters in UTF-8
-        let lookup_start = std::cmp::max(LOOKUP_BYTE_LENGTH, eos_byte) - LOOKUP_BYTE_LENGTH;
-        for i in lookup_start..eos_byte {
+        let mut lookup_start = eos_byte.saturating_sub(LOOKUP_BYTE_LENGTH);
+        while lookup_start < eos_byte && !input.is_char_boundary(lookup_start) {
+            lookup_start += 1;
+        }
+
+        for (relative, _) in input[lookup_start..eos_byte].char_indices() {
+            let i = lookup_start + relative;
             for entry in self.lexicon.lookup(input_bytes, i) {
                 let end_byte = entry.end;
                 // handling cases like モーニング娘。
@@ -50,7 +57,7 @@ impl NonBreakChecker<'_> {
                     Ordering::Greater => return true,
                     // end is on boundary candidate,
                     // check that there are more than one character in the matched word
-                    Ordering::Equal => return input[i..].chars().take(2).count() > 1,
+                    Ordering::Equal => return input[i..].chars().nth(1).is_some(),
                     _ => {}
                 }
             }
@@ -58,15 +65,6 @@ impl NonBreakChecker<'_> {
         false
     }
 }
-
-const PERIODS: &str = "。？！♪…\\?\\!";
-const DOT: &str = "\\.．";
-const CDOTS: &str = "・{3,}";
-const COMMA: &str = ",，、";
-const BR_TAG: &str = "(<br>|<BR>){2,}";
-const ALPHABET_OR_NUMBER: &str = "a-zA-Z0-9ａ-ｚＡ-Ｚ０-９〇一二三四五六七八九十百千万億兆";
-const OPEN_PARENTHESIS: &str = "\\(\\{｛\\[（「【『［≪〔“";
-const CLOSE_PARENTHESIS: &str = "\\)\\}\\]）」｝】』］〕≫”";
 
 const DEFAULT_LIMIT: usize = 4096;
 
@@ -113,58 +111,16 @@ impl SentenceDetector {
             return Ok(0);
         }
 
-        // handle at most self.limit chars at once
-        let s: String = input.chars().take(self.limit).collect();
-        let input_exceeds_limit = s.len() < input.len();
+        let (s, input_exceeds_limit) = limited_prefix(input, self.limit);
 
-        lazy_static! {
-            static ref SENTENCE_BREAKER: Regex = Regex::new(&format!(
-                "([{}]|{}+|(?<![{}])[{}](?![{}{}]))[{}{}]*|{}",
-                PERIODS,
-                CDOTS,
-                ALPHABET_OR_NUMBER,
-                DOT,
-                ALPHABET_OR_NUMBER,
-                COMMA,
-                DOT,
-                PERIODS,
-                BR_TAG
-            ))
-            .unwrap();
-            static ref ITEMIZE_HEADER: Regex =
-                Regex::new(&format!("^([{}])([{}])$", ALPHABET_OR_NUMBER, DOT)).unwrap();
-        }
-
-        for mat in SENTENCE_BREAKER.find_iter(&s) {
-            // check if we can split at the match
-            let mut eos = mat?.end();
-            if parenthesis_level(&s[..eos])? > 0 {
-                continue;
-            }
-            if eos < s.len() {
-                eos += prohibited_bos(&s[eos..])?;
-            }
-            if ITEMIZE_HEADER.is_match(&s)? {
-                continue;
-            }
-            if eos < s.len() && is_continuous_phrase(&s, eos)? {
-                continue;
-            }
-            if let Some(ck) = checker {
-                if ck.has_non_break_word(input, eos) {
-                    continue;
-                }
-            }
+        if let Some(eos) = find_sentence_boundary(s, input, checker) {
             return Ok(eos as isize);
         }
 
         if input_exceeds_limit {
             // search the final whitespace as a provisional split.
-            lazy_static! {
-                static ref SPACES: Regex = Regex::new(".+\\s+").unwrap();
-            }
-            if let Some(mat) = SPACES.find(&s)? {
-                return Ok(-(mat.end() as isize));
+            if let Some(end) = last_whitespace_end(s) {
+                return Ok(-(end as isize));
             }
         }
 
@@ -172,67 +128,288 @@ impl SentenceDetector {
     }
 }
 
-/// Returns the count of non-closed open parentheses remaining at the end of input.
-fn parenthesis_level(s: &str) -> SudachiResult<usize> {
-    lazy_static! {
-        static ref PARENTHESIS: Regex = Regex::new(&format!(
-            "([{}])|([{}])",
-            OPEN_PARENTHESIS, CLOSE_PARENTHESIS
-        ))
-        .unwrap();
+#[inline]
+fn limited_prefix(input: &str, limit: usize) -> (&str, bool) {
+    if input.len() <= limit {
+        return (input, false);
     }
-    let mut level: usize = 0;
-    for caps in PARENTHESIS.captures_iter(s) {
-        if caps?.get(1).is_some() {
-            // open
-            level += 1;
-        } else {
-            level = level.saturating_sub(1);
-        }
+
+    match input.char_indices().nth(limit) {
+        Some((idx, _)) => (&input[..idx], true),
+        None => (input, false),
     }
-    Ok(level)
 }
 
-/// Returns a byte length of chars at the beggining of str, which cannot be a bos
-fn prohibited_bos(s: &str) -> SudachiResult<usize> {
-    lazy_static! {
-        static ref PROHIBITED_BOS: Regex = Regex::new(&format!(
-            "\\A([{}{}{}])+",
-            CLOSE_PARENTHESIS, COMMA, PERIODS
-        ))
-        .unwrap();
+fn find_sentence_boundary(
+    limited: &str,
+    original: &str,
+    checker: Option<&NonBreakChecker>,
+) -> Option<usize> {
+    let mut index = 0;
+    let mut previous = None;
+    let mut parenthesis_level = 0usize;
+
+    while index < limited.len() {
+        let c = limited[index..]
+            .chars()
+            .next()
+            .expect("valid char boundary");
+        let next_index = index + c.len_utf8();
+
+        if is_open_parenthesis(c) {
+            parenthesis_level += 1;
+            previous = Some(c);
+            index = next_index;
+            continue;
+        }
+
+        if is_close_parenthesis(c) {
+            parenthesis_level = parenthesis_level.saturating_sub(1);
+            previous = Some(c);
+            index = next_index;
+            continue;
+        }
+
+        if let Some(candidate_end) = sentence_candidate_end(limited, index, c, previous) {
+            if parenthesis_level == 0 {
+                let mut eos = candidate_end;
+                if eos < limited.len() {
+                    eos += prohibited_bos_len(&limited[eos..]);
+                }
+
+                if !is_itemize_header(limited) && !continues_phrase(limited, eos) {
+                    if let Some(ck) = checker {
+                        if ck.has_non_break_word(original, eos) {
+                            previous = limited[..candidate_end].chars().next_back();
+                            index = candidate_end;
+                            continue;
+                        }
+                    }
+                    return Some(eos);
+                }
+            }
+
+            previous = limited[..candidate_end].chars().next_back();
+            index = candidate_end;
+            continue;
+        }
+
+        previous = Some(c);
+        index = next_index;
     }
 
-    if let Some(mat) = PROHIBITED_BOS.find(s)? {
-        Ok(mat.end())
+    None
+}
+
+fn sentence_candidate_end(s: &str, index: usize, c: char, previous: Option<char>) -> Option<usize> {
+    if is_sentence_period(c) {
+        return Some(consume_trailing_break_chars(s, index + c.len_utf8()));
+    }
+
+    if c == '・' {
+        return cdots_candidate_end(s, index);
+    }
+
+    if is_dot(c) {
+        let next_index = index + c.len_utf8();
+        let previous_blocks = previous.map(is_alphabet_or_number).unwrap_or(false);
+        let next_blocks = s[next_index..]
+            .chars()
+            .next()
+            .map(|next| is_alphabet_or_number(next) || is_comma(next))
+            .unwrap_or(false);
+
+        if !previous_blocks && !next_blocks {
+            return Some(consume_trailing_break_chars(s, next_index));
+        }
+    }
+
+    if c == '<' {
+        return br_sequence_end(s, index);
+    }
+
+    None
+}
+
+fn cdots_candidate_end(s: &str, index: usize) -> Option<usize> {
+    let mut count = 0;
+    let mut end = index;
+    while let Some(c) = s[end..].chars().next() {
+        if c != '・' {
+            break;
+        }
+        count += 1;
+        end += c.len_utf8();
+    }
+
+    if count >= 3 {
+        Some(consume_trailing_break_chars(s, end))
     } else {
-        Ok(0)
+        None
     }
 }
 
-// Returns if eos is the middle of phrase
-fn is_continuous_phrase(s: &str, eos: usize) -> SudachiResult<bool> {
-    lazy_static! {
-        static ref QUOTE_MARKER: Regex = Regex::new(&format!(
-            "(！|？|\\!|\\?|[{}])(と|っ|です)",
-            CLOSE_PARENTHESIS
-        ))
-        .unwrap();
-        static ref EOS_ITEMIZE_HEADER: Regex =
-            Regex::new(&format!("([{}])([{}])\\z", ALPHABET_OR_NUMBER, DOT)).unwrap();
+fn br_sequence_end(s: &str, index: usize) -> Option<usize> {
+    let mut count = 0;
+    let mut end = index;
+    while let Some(len) = br_tag_len(&s[end..]) {
+        count += 1;
+        end += len;
     }
 
-    // we can safely unwrap since eos > 0
-    let last_char_len = s[..eos].chars().last().unwrap().to_string().len();
-    if let Some(mat) = QUOTE_MARKER.find(&s[(eos - last_char_len)..])? {
-        if mat.start() == 0 {
-            return Ok(true);
+    if count >= 2 {
+        Some(end)
+    } else {
+        None
+    }
+}
+
+#[inline]
+fn br_tag_len(s: &str) -> Option<usize> {
+    if s.starts_with("<br>") || s.starts_with("<BR>") {
+        Some(4)
+    } else {
+        None
+    }
+}
+
+fn consume_trailing_break_chars(s: &str, mut index: usize) -> usize {
+    while let Some(c) = s[index..].chars().next() {
+        if !is_dot(c) && !is_sentence_period(c) {
+            break;
         }
+        index += c.len_utf8();
+    }
+    index
+}
+
+/// Returns a byte length of chars at the beginning of str, which cannot be a bos.
+fn prohibited_bos_len(s: &str) -> usize {
+    let mut end = 0;
+    for (index, c) in s.char_indices() {
+        if !is_close_parenthesis(c) && !is_comma(c) && !is_sentence_period(c) {
+            break;
+        }
+        end = index + c.len_utf8();
+    }
+    end
+}
+
+fn continues_phrase(s: &str, eos: usize) -> bool {
+    if eos >= s.len() {
+        return false;
     }
 
-    // we can safely unwrap since eos < s.len()
-    let c = s[eos..].chars().next().unwrap();
-    Ok((c == 'と' || c == 'や' || c == 'の') && EOS_ITEMIZE_HEADER.is_match(&s[..eos])?)
+    let last = s[..eos]
+        .chars()
+        .next_back()
+        .expect("eos is after a boundary candidate");
+    let rest = &s[eos..];
+    if is_quote_marker(last)
+        && (rest.starts_with("と") || rest.starts_with("っ") || rest.starts_with("です"))
+    {
+        return true;
+    }
+
+    let next = rest.chars().next().expect("eos is a valid char boundary");
+    (next == 'と' || next == 'や' || next == 'の') && ends_with_itemize_header(&s[..eos])
+}
+
+fn is_itemize_header(s: &str) -> bool {
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    let Some(second) = chars.next() else {
+        return false;
+    };
+    chars.next().is_none() && is_alphabet_or_number(first) && is_dot(second)
+}
+
+fn ends_with_itemize_header(s: &str) -> bool {
+    let mut chars = s.chars().rev();
+    let Some(last) = chars.next() else {
+        return false;
+    };
+    let Some(previous) = chars.next() else {
+        return false;
+    };
+    is_dot(last) && is_alphabet_or_number(previous)
+}
+
+fn last_whitespace_end(s: &str) -> Option<usize> {
+    let mut previous = None;
+    let mut last_end = None;
+    for (index, c) in s.char_indices() {
+        if c.is_whitespace() && previous.map(|p| p != '\n').unwrap_or(false) {
+            last_end = Some(index + c.len_utf8());
+        }
+        previous = Some(c);
+    }
+    last_end
+}
+
+#[inline]
+fn is_sentence_period(c: char) -> bool {
+    matches!(c, '。' | '？' | '！' | '♪' | '…' | '?' | '!')
+}
+
+#[inline]
+fn is_dot(c: char) -> bool {
+    matches!(c, '.' | '．')
+}
+
+#[inline]
+fn is_comma(c: char) -> bool {
+    matches!(c, ',' | '，' | '、')
+}
+
+#[inline]
+fn is_alphabet_or_number(c: char) -> bool {
+    c.is_ascii_alphanumeric()
+        || matches!(
+            c,
+            'ａ'..='ｚ'
+                | 'Ａ'..='Ｚ'
+                | '０'..='９'
+                | '〇'
+                | '一'
+                | '二'
+                | '三'
+                | '四'
+                | '五'
+                | '六'
+                | '七'
+                | '八'
+                | '九'
+                | '十'
+                | '百'
+                | '千'
+                | '万'
+                | '億'
+                | '兆'
+        )
+}
+
+#[inline]
+fn is_open_parenthesis(c: char) -> bool {
+    matches!(
+        c,
+        '(' | '{' | '｛' | '[' | '（' | '「' | '【' | '『' | '［' | '≪' | '〔' | '“'
+    )
+}
+
+#[inline]
+fn is_close_parenthesis(c: char) -> bool {
+    matches!(
+        c,
+        ')' | '}' | ']' | '）' | '」' | '｝' | '】' | '』' | '］' | '〕' | '≫' | '”'
+    )
+}
+
+#[inline]
+fn is_quote_marker(c: char) -> bool {
+    matches!(c, '！' | '？' | '!' | '?') || is_close_parenthesis(c)
 }
 
 #[cfg(test)]
@@ -262,6 +439,14 @@ mod tests {
     }
 
     #[test]
+    fn get_eos_with_multibyte_limit_boundary() {
+        let sd = SentenceDetector::with_limit(4);
+        assert_eq!(sd.get_eos("あいう。", None).unwrap(), 12);
+        assert_eq!(sd.get_eos("あいうえ。", None).unwrap(), -12);
+        assert_eq!(sd.get_eos("あい うえ。", None).unwrap(), -7);
+    }
+
+    #[test]
     fn get_eos_with_period() {
         let sd = SentenceDetector::new();
         assert_eq!(sd.get_eos("あいう.えお", None).unwrap(), 10);
@@ -273,6 +458,23 @@ mod tests {
     fn get_eos_with_many_periods() {
         let sd = SentenceDetector::new();
         assert_eq!(sd.get_eos("あいうえお!??", None).unwrap(), 18);
+    }
+
+    #[test]
+    fn get_eos_with_cdots() {
+        let sd = SentenceDetector::new();
+        assert_eq!(sd.get_eos("あ・・・い", None).unwrap(), 12);
+        assert_eq!(sd.get_eos("あ・・い", None).unwrap(), -12);
+        assert_eq!(sd.get_eos("あ・・・?!い", None).unwrap(), 14);
+    }
+
+    #[test]
+    fn get_eos_with_br_tags() {
+        let sd = SentenceDetector::new();
+        assert_eq!(sd.get_eos("あ<br><br>い", None).unwrap(), 11);
+        assert_eq!(sd.get_eos("あ<BR><BR>い", None).unwrap(), 11);
+        assert_eq!(sd.get_eos("あ<br><BR>い", None).unwrap(), 11);
+        assert_eq!(sd.get_eos("あ<br>い", None).unwrap(), -10);
     }
 
     #[test]

--- a/sudachi/src/sentence_detector.rs
+++ b/sudachi/src/sentence_detector.rs
@@ -15,6 +15,7 @@
  */
 
 use std::cmp::Ordering;
+use std::sync::OnceLock;
 
 use crate::dic::lexicon_set::LexiconSet;
 use crate::prelude::*;
@@ -119,7 +120,7 @@ impl SentenceDetector {
 
         if input_exceeds_limit {
             // search the final whitespace as a provisional split.
-            if let Some(end) = last_whitespace_end(s) {
+            if let Some(end) = legacy_whitespace_end(s) {
                 return Ok(-(end as isize));
             }
         }
@@ -337,16 +338,12 @@ fn ends_with_itemize_header(s: &str) -> bool {
     is_dot(last) && is_alphabet_or_number(previous)
 }
 
-fn last_whitespace_end(s: &str) -> Option<usize> {
-    let mut previous = None;
-    let mut last_end = None;
-    for (index, c) in s.char_indices() {
-        if c.is_whitespace() && previous.map(|p| p != '\n').unwrap_or(false) {
-            last_end = Some(index + c.len_utf8());
-        }
-        previous = Some(c);
-    }
-    last_end
+fn legacy_whitespace_end(s: &str) -> Option<usize> {
+    static SPACES: OnceLock<regex::Regex> = OnceLock::new();
+    SPACES
+        .get_or_init(|| regex::Regex::new(r".+\s+").unwrap())
+        .find(s)
+        .map(|mat| mat.end())
 }
 
 #[inline]
@@ -395,7 +392,7 @@ fn is_alphabet_or_number(c: char) -> bool {
 fn is_open_parenthesis(c: char) -> bool {
     matches!(
         c,
-        '(' | '{' | '｛' | '[' | '（' | '「' | '【' | '『' | '［' | '≪' | '〔' | '“'
+        '(' | '{' | '｛' | '[' | '（' | '「' | '【' | '『' | '［' | '≪' | '〔' | '“' | '"'
     )
 }
 
@@ -403,7 +400,7 @@ fn is_open_parenthesis(c: char) -> bool {
 fn is_close_parenthesis(c: char) -> bool {
     matches!(
         c,
-        ')' | '}' | ']' | '）' | '」' | '｝' | '】' | '』' | '］' | '〕' | '≫' | '”'
+        ')' | '}' | ']' | '）' | '」' | '｝' | '】' | '』' | '］' | '〕' | '≫' | '”' | '"'
     )
 }
 
@@ -447,6 +444,12 @@ mod tests {
     }
 
     #[test]
+    fn get_eos_with_limit_multiline_whitespace_legacy_behavior() {
+        let sd = SentenceDetector::with_limit(5);
+        assert_eq!(sd.get_eos("a\n b c d", None).unwrap(), -3);
+    }
+
+    #[test]
     fn get_eos_with_period() {
         let sd = SentenceDetector::new();
         assert_eq!(sd.get_eos("あいう.えお", None).unwrap(), 10);
@@ -483,6 +486,14 @@ mod tests {
         assert_eq!(sd.get_eos("あ（いう。え）お", None).unwrap(), -24);
         assert_eq!(sd.get_eos("（あ（いう）。え）お", None).unwrap(), -30);
         assert_eq!(sd.get_eos("あ（いう）。えお", None).unwrap(), 18);
+    }
+
+    #[test]
+    fn get_eos_with_ascii_quote_legacy_behavior() {
+        let sd = SentenceDetector::new();
+        assert_eq!(sd.get_eos("\"あ。\"", None).unwrap(), -8);
+        assert_eq!(sd.get_eos("あ。\"です。", None).unwrap(), -16);
+        assert_eq!(sd.get_eos("あ。\")え。", None).unwrap(), 8);
     }
 
     #[test]

--- a/sudachi/src/sentence_detector.rs
+++ b/sudachi/src/sentence_detector.rs
@@ -50,17 +50,18 @@ impl NonBreakChecker<'_> {
 
         for (relative, _) in input[lookup_start..eos_byte].char_indices() {
             let i = lookup_start + relative;
-            for entry in self.lexicon.lookup(input_bytes, i) {
-                let end_byte = entry.end;
+            if let Some(result) = self.lexicon.check_prefix_ends(input_bytes, i, |end_byte| {
                 // handling cases like モーニング娘。
                 match end_byte.cmp(&eos_byte) {
                     // end is after than boundary candidate, this boundary is bad
-                    Ordering::Greater => return true,
+                    Ordering::Greater => Some(true),
                     // end is on boundary candidate,
                     // check that there are more than one character in the matched word
-                    Ordering::Equal => return input[i..].chars().nth(1).is_some(),
-                    _ => {}
+                    Ordering::Equal => Some(input[i..].chars().nth(1).is_some()),
+                    _ => None,
                 }
+            }) {
+                return result;
             }
         }
         false


### PR DESCRIPTION
Closes #164.

This draft replaces the regex-heavy sentence detector path with a zero-copy single-pass scanner while preserving legacy boundary behavior for edge cases such as ASCII `"` and the old long-input whitespace fallback. It also makes `NonBreakChecker` validate boundaries from trie prefix end offsets directly, avoiding `WordIdTable` expansion where only the prefix end byte offset is needed.

Local ARM64 disassembly of the previous checker path showed repeated calls through `core::iter::adapters::flatten::and_then_or_clear` and `sudachi::dic::read::varint::varint64` inside `SentenceDetector::get_eos`; the prefix-end path removes those calls from this hot block.

## Full-dictionary CLI benchmark

Command shape: `sudachi -r resources/sudachi.json --split-sentences <mode> -o /dev/null kftt-ja-100k.txt`

Environment: Apple M4 Max, macOS Darwin 25.5.0, rustc 1.95.0. Dictionaries: SudachiDict raw `20260428` compiled with this branch's `sudachi build` into the new dictionary format. Input: KFTT `data/orig/kyoto-train.ja`, first 100000 lines, 11.09 MB. Each row is 1 warmup + 5 measured process runs, including dictionary load and output to `/dev/null`; lower is better.

### small dictionary

| Split mode | Before mean ± stdev | After mean ± stdev | Speedup | Delta |
| --- | ---: | ---: | ---: | ---: |
| `yes` | 2.395s ± 0.100s | 1.814s ± 0.073s | 1.32x | -24.3% |
| `default` | 2.342s ± 0.033s | 1.774s ± 0.040s | 1.32x | -24.3% |
| `no` | 1.835s ± 0.080s | 1.758s ± 0.023s | 1.04x | -4.2% |
| `none` | 1.793s ± 0.042s | 1.770s ± 0.047s | 1.01x | -1.3% |
| `only` | 0.545s ± 0.005s | 0.050s ± 0.000s | 10.90x | -90.8% |

### core dictionary

| Split mode | Before mean ± stdev | After mean ± stdev | Speedup | Delta |
| --- | ---: | ---: | ---: | ---: |
| `yes` | 2.479s ± 0.070s | 1.856s ± 0.028s | 1.34x | -25.1% |
| `default` | 2.449s ± 0.040s | 1.868s ± 0.016s | 1.31x | -23.7% |
| `no` | 1.876s ± 0.035s | 1.828s ± 0.020s | 1.03x | -2.6% |
| `none` | 1.877s ± 0.047s | 1.852s ± 0.050s | 1.01x | -1.3% |
| `only` | 0.530s ± 0.008s | 0.060s ± 0.000s | 8.83x | -88.7% |

### full dictionary

| Split mode | Before mean ± stdev | After mean ± stdev | Speedup | Delta |
| --- | ---: | ---: | ---: | ---: |
| `yes` | 2.536s ± 0.055s | 1.930s ± 0.027s | 1.31x | -23.9% |
| `default` | 2.570s ± 0.057s | 1.926s ± 0.038s | 1.33x | -25.1% |
| `no` | 1.918s ± 0.016s | 1.926s ± 0.034s | 1.00x | +0.4% |
| `none` | 1.995s ± 0.071s | 1.910s ± 0.027s | 1.04x | -4.3% |
| `only` | 0.554s ± 0.007s | 0.072s ± 0.004s | 7.69x | -87.0% |

`yes/default` are the real end-to-end sentence-splitting paths. `only` isolates the splitter-heavy CLI path. `no/none` are included as controls and should be read as run-to-run noise rather than a sentence detector effect.

## Criterion regression benchmark

Command: `cargo bench -p sudachi --bench sentence_detector -- --warm-up-time 1 --measurement-time 2 --sample-size 10`

Environment: Apple M4 Max, macOS Darwin 25.5.0, rustc 1.95.0. Dictionary: repository test dictionary. Times are local Criterion point estimates; lower is better.

| Benchmark | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `sentence_splitter_only/prose` | 60.092 ms | 23.698 ms | 2.54x |
| `sentence_splitter_only/punctuation_heavy` | 94.893 ms | 39.822 ms | 2.38x |
| `sentence_splitter_only/long_line` | 349.57 us | 38.639 us | 9.05x |
| `sentence_splitter_only/html` | 32.168 ms | 17.402 ms | 1.85x |
| `sentence_splitter_end_to_end/split_sentences_yes` | 15.993 ms | 7.778 ms | 2.06x |
| `sentence_splitter_end_to_end/split_sentences_none` | 6.647 ms | 6.547 ms | 1.02x |

The Criterion end-to-end benchmark is a regression benchmark over a smaller repeated corpus, so the full-dictionary CLI tables above are the better estimate for production-shaped end-to-end impact.

Validation:
- `cargo fmt --all --check`
- `cargo test -p sudachi check_prefix_ends_matches_lookup_end_order --lib`
- `cargo test -p sudachi sentence_detector --tests --lib`
- `cargo test --workspace`
- `cargo bench -p sudachi --bench sentence_detector -- --warm-up-time 1 --measurement-time 2 --sample-size 10`
- Output diff check: `--split-sentences only` on KFTT 100k is identical before/after the prefix-end checker optimization.
