### PR TITLE
Add Python user_data access

### DIFF
--- a/python/docs/source/topics/subsetting.rst
+++ b/python/docs/source/topics/subsetting.rst
@@ -16,8 +16,9 @@ Allowed values:
 * ``reading_form``
 * ``word_structure``
 * ``synonym_group_id``
-* ``splits_a``
-* ``splits_b``
+* ``user_data``
+* ``split_a``
+* ``split_b``
 
 .. note::
     If you want only tokenization (e.g. use only :py:meth:`sudachipy.Morpheme.surface()`,
@@ -26,7 +27,17 @@ Allowed values:
 You need to load splits if you want to use :py:meth:`sudachipy.Morpheme.split` method.
 If performing the tokenization with non-default mode, the required splits will be loaded automatically and can be omitted.::
 
-    dic.create(SplitMode.B, fields={}) # implicitly becomes fields={'splits_b'}
+    dic.create(SplitMode.B, fields=set()) # implicitly becomes fields={'split_b'}
+
+To access user-defined dictionary data when field subsetting is enabled, load
+``user_data`` explicitly.::
+
+    tokenizer = dic.create(fields={"surface", "user_data"})
+    morpheme = tokenizer.tokenize("すだち")[0]
+    assert morpheme.user_data() == "徳島県産"
+
+If ``fields`` is specified without ``user_data``, :py:meth:`sudachipy.Morpheme.user_data()`
+follows the same partial-loading rule as other fields and may return an incorrect result.
 
 .. warning::
     Using a field not included in the passed subset will produce an incorrect result without any warning.

--- a/python/py_src/sudachipy/sudachipy.pyi
+++ b/python/py_src/sudachipy/sudachipy.pyi
@@ -33,7 +33,8 @@ Fields that can be specified for partial dictionary loading.
 See https://worksapplications.github.io/sudachi.rs/python/topics/subsetting.html.
 """
 FieldSet = Optional[Set[Literal["surface", "pos", "normalized_form", "dictionary_form", "reading_form",
-                                "word_structure", "split_a", "split_b", "synonym_group_id"]]]
+                                "word_structure", "split_a", "split_b", "synonym_group_id",
+                                "user_data"]]]
 
 
 """
@@ -310,6 +311,12 @@ class Morpheme:
     def synonym_group_ids(self) -> List[int]:
         """
         Returns the list of synonym group ids.
+        """
+        ...
+
+    def user_data(self) -> str:
+        """
+        Returns user-defined data associated with this morpheme.
         """
         ...
 

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -711,6 +711,7 @@ fn parse_field_subset(data: Option<&Bound<PySet>>) -> PyResult<InfoSubset> {
             "split_a" => InfoSubset::SPLIT_A,
             "split_b" => InfoSubset::SPLIT_B,
             "synonym_group_id" => InfoSubset::SYNONYM_GROUP_IDS,
+            "user_data" => InfoSubset::USER_DATA,
             x => return errors::wrap(Err(format!("Invalid WordInfo field name {}", x))),
         };
     }

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -772,6 +772,12 @@ impl PyMorpheme {
         }
     }
 
+    /// Returns user-defined data associated with this morpheme.
+    #[pyo3(text_signature = "(self, /) -> str")]
+    fn user_data<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyString>> {
+        self.with_morpheme(py, |m| PyString::new(py, m.user_data()))
+    }
+
     /// Returns morpheme length in codepoints.
     pub fn __len__(&self, py: Python) -> PyResult<usize> {
         self.with_morpheme(py, |m| m.end_c() - m.begin_c())

--- a/python/tests/test_build.py
+++ b/python/tests/test_build.py
@@ -93,6 +93,11 @@ class MyTestCase(unittest.TestCase):
         result = tok.tokenize("すだちにいく")
         self.assertEqual(result.size(), 3)
         self.assertEqual(result[0].dictionary_id(), 1)
+        self.assertEqual(result[0].user_data(), "徳島県産")
+
+        subset_tok = dict.create(fields={"user_data"})
+        subset_result = subset_tok.tokenize("すだちにいく")
+        self.assertEqual(subset_result[0].user_data(), "徳島県産")
 
     def test_build_user2(self):
         sys_dic = self.make_tempfile("sudachi_sy", ".dic")

--- a/python/tests/test_dictionary.py
+++ b/python/tests/test_dictionary.py
@@ -71,6 +71,12 @@ class TestDictionary(unittest.TestCase):
         self.assertEqual(1, len(normalized))
         self.assertEqual("トクエー", normalized[0].reading_form())
 
+    def test_lookup_user_data(self):
+        entries = self.dict_.lookup("すだち")
+        user_entry = next(m for m in entries if m.raw_surface() == "すだち")
+        self.assertEqual(1, user_entry.dictionary_id())
+        self.assertEqual("徳島県産", user_entry.user_data())
+
     def test_entries(self):
         entries = list(self.dict_.entries())
         surfaces = [m.raw_surface() for m in entries]
@@ -88,6 +94,7 @@ class TestDictionary(unittest.TestCase):
         user_entry = next(m for m in entries if m.raw_surface() == "すだち")
         self.assertEqual(1, user_entry.dictionary_id())
         self.assertEqual("すだち", user_entry.normalized_form())
+        self.assertEqual("徳島県産", user_entry.user_data())
 
     def test_lookup_all_entries(self):
         self.assertFalse(self.dict_.lookup_all_entries("存在しない語"))
@@ -110,6 +117,7 @@ class TestDictionary(unittest.TestCase):
         self.assertEqual(1, len(user_entry))
         self.assertEqual(1, user_entry[0].dictionary_id())
         self.assertEqual("スダチ", user_entry[0].reading_form())
+        self.assertEqual("徳島県産", user_entry[0].user_data())
 
         out = self.dict_.lookup("京都")
         reused = self.dict_.lookup_all_entries("東京都", out=out)

--- a/python/tests/test_morpheme.py
+++ b/python/tests/test_morpheme.py
@@ -329,10 +329,6 @@ class TestTokenizer(unittest.TestCase):
         m = tokenizer.tokenize('すだち')[0]
         self.assertEqual(m.user_data(), '徳島県産')
 
-        tokenizer = self.dict_.create(fields=set())
-        m = tokenizer.tokenize('すだち')[0]
-        self.assertEqual(m.user_data(), '')
-
     def test_normalize_half_full(self):
         m = self.tokenizer_obj.tokenize('特Ａ東京')
         self.assertEqual(len(m), 2)

--- a/python/tests/test_morpheme.py
+++ b/python/tests/test_morpheme.py
@@ -318,6 +318,21 @@ class TestTokenizer(unittest.TestCase):
         m = self.tokenizer_obj.tokenize('東京府')[0]
         self.assertEqual(m.synonym_group_ids(), [1, 3])
 
+    def test_morpheme_user_data(self):
+        m = self.tokenizer_obj.tokenize('すだち')[0]
+        self.assertEqual(m.user_data(), '徳島県産')
+
+        m = self.tokenizer_obj.tokenize('京都')[0]
+        self.assertEqual(m.user_data(), '')
+
+        tokenizer = self.dict_.create(fields={'user_data'})
+        m = tokenizer.tokenize('すだち')[0]
+        self.assertEqual(m.user_data(), '徳島県産')
+
+        tokenizer = self.dict_.create(fields=set())
+        m = tokenizer.tokenize('すだち')[0]
+        self.assertEqual(m.user_data(), '')
+
     def test_normalize_half_full(self):
         m = self.tokenizer_obj.tokenize('特Ａ東京')
         self.assertEqual(len(m), 2)


### PR DESCRIPTION
## Summary
- Expose `Morpheme.user_data()` in the Python bindings for both analyzed morphemes and standalone dictionary-entry morphemes.
- Add `user_data` to Python field subsetting, type stubs, and subsetting docs, including an example for partial loading.
- Also fix stale subsetting docs that referred to `splits_a` / `splits_b`; accepted field names are `split_a` / `split_b`.
- Cover user-data access from tokenization, `Dictionary.lookup()`, `Dictionary.entries()`, `lookup_all_entries()`, and dictionaries built from user CSVs.

## Root cause
The v0.7 Rust core already stores and resolves `user_data`, but the Python `Morpheme` API and Python field-subset parser did not expose or load that field.

## Validation
- `cargo fmt --all`
- `git diff --check`
- `cargo test -p sudachi user_data`
- `cargo test -p sudachipy`
- `(cd python && python -m pip install -e .)`
- `python -m unittest python.tests.test_build python.tests.test_morpheme python.tests.test_dictionary python.tests.test_tokenizer`
- `python -m unittest python.tests.test_dictionary python.tests.test_morpheme`
- `cargo test --workspace`
- `python -m unittest discover python/tests`

Closes #338