### PR TITLE
refactor code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +592,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +657,12 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -913,6 +934,7 @@ dependencies = [
  "join_katakana_oov",
  "join_numeric",
  "lazy_static",
+ "libc",
  "libloading",
  "memmap2",
  "nom",
@@ -932,8 +954,10 @@ version = "0.6.11-a1"
 dependencies = [
  "cfg-if",
  "clap",
+ "csv",
  "memmap2",
  "sudachi",
+ "time",
 ]
 
 [[package]]
@@ -1013,6 +1037,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -375,7 +375,11 @@ impl PyMorpheme {
     ) -> PyResult<MorphemeBorrow<'py>> {
         let list = list.borrow(py);
         // workaround for self-referential structs
-        let morph = unsafe { std::mem::transmute(list.as_list()?.get(index)) };
+        let morph = unsafe {
+            std::mem::transmute::<Morpheme<'_, Arc<PyDicData>>, Morpheme<'_, Arc<PyDicData>>>(
+                list.as_list()?.get(index),
+            )
+        };
         Ok(MorphemeBorrow { list, morph })
     }
 

--- a/sudachi-cli/src/build.rs
+++ b/sudachi-cli/src/build.rs
@@ -516,7 +516,7 @@ fn pos_string(grammar: &Grammar, posid: u16, pos_format: PosDumpFormat) -> Strin
     match pos_format {
         PosDumpFormat::Components => grammar
             .pos_components(posid)
-            .into_iter()
+            .iter()
             .map(|p| csv_field(p))
             .collect::<Vec<_>>()
             .join(","),
@@ -528,7 +528,7 @@ fn pos_string_for_entrykey(grammar: &Grammar, posid: u16, pos_format: PosDumpFor
     match pos_format {
         PosDumpFormat::Components => grammar
             .pos_components(posid)
-            .into_iter()
+            .iter()
             .map(|p| entrykey_ref_escape(p))
             .collect::<Vec<_>>()
             .join(","),

--- a/sudachi/src/analysis/node.rs
+++ b/sudachi/src/analysis/node.rs
@@ -303,16 +303,16 @@ pub fn concat_nodes(
     let mut index_form_length = 0;
 
     for node in path[begin..end].iter() {
-        headword.push_str(node.word_info().headword(&resolver));
-        reading_form.push_str(node.word_info().reading_form(&resolver));
-        dictionary_form.push_str(node.word_info().dictionary_form(&resolver));
+        headword.push_str(node.word_info().headword(resolver));
+        reading_form.push_str(node.word_info().reading_form(resolver));
+        dictionary_form.push_str(node.word_info().dictionary_form(resolver));
         index_form_length += node.word_info().index_form_length();
     }
 
     let normalized_form = normalized_form.unwrap_or_else(|| {
         let mut norm = String::with_capacity(end_bytes - beg_bytes);
         for node in path[begin..end].iter() {
-            norm.push_str(node.word_info().normalized_form(&resolver));
+            norm.push_str(node.word_info().normalized_form(resolver));
         }
         norm
     });
@@ -366,8 +366,8 @@ pub fn concat_oov_nodes(
         return Err(SudachiError::InvalidRange(begin, end));
     }
 
-    let byte_begin = path[begin].begin_bytes as u16;
-    let byte_end = path[end - 1].end_bytes as u16;
+    let byte_begin = path[begin].begin_bytes;
+    let byte_end = path[end - 1].end_bytes;
     let node_begin = path[begin].begin();
     let node_end = path[end - 1].end();
 
@@ -403,7 +403,7 @@ pub fn concat_oov_nodes(
     let mut headword = String::with_capacity(capa);
     let mut index_form_length = 0;
     for node in path[begin..end].iter() {
-        headword.push_str(node.word_info().headword(&resolver));
+        headword.push_str(node.word_info().headword(resolver));
         index_form_length += node.word_info().index_form_length();
     }
 

--- a/sudachi/src/analysis/stateless_tokenizer.rs
+++ b/sudachi/src/analysis/stateless_tokenizer.rs
@@ -45,7 +45,7 @@ where
     <T as Deref>::Target: DictionaryAccess,
 {
     pub fn as_dict(&self) -> &<T as Deref>::Target {
-        return Deref::deref(&self.dict);
+        Deref::deref(&self.dict)
     }
 }
 

--- a/sudachi/src/config.rs
+++ b/sudachi/src/config.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024 Works Applications Co., Ltd.
+ * Copyright (c) 2021-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ impl PathResolver {
 
     fn contains<P: AsRef<Path>>(&self, path: P) -> bool {
         let query = path.as_ref();
-        return self.roots.iter().any(|p| p.as_path() == query);
+        self.roots.iter().any(|p| p.as_path() == query)
     }
 
     pub fn first_existing<P: AsRef<Path> + Clone>(&self, path: P) -> Option<PathBuf> {

--- a/sudachi/src/dic/build/lexicon/layout.rs
+++ b/sudachi/src/dic/build/lexicon/layout.rs
@@ -57,7 +57,7 @@ pub(super) enum Column {
 }
 
 impl Column {
-    const fn legacy_index(self) -> usize {
+    const fn v0_index(self) -> usize {
         self as usize
     }
 
@@ -177,7 +177,7 @@ const REQUIRED_COLUMNS: [Column; 10] = [
 
 #[derive(Copy, Clone)]
 pub(super) enum ColumnLayout {
-    Legacy,
+    V0,
     Header([i16; NUM_COLUMNS]),
 }
 
@@ -187,9 +187,9 @@ impl ColumnLayout {
         ctx: &DicCompilationCtx,
     ) -> SudachiResult<(Self, bool)> {
         if record.len() > 1 {
-            if let Some(left_id) = record.get(Column::LeftId.legacy_index()) {
+            if let Some(left_id) = record.get(Column::LeftId.v0_index()) {
                 if INTEGER_LITERAL.is_match(left_id) {
-                    return Ok((ColumnLayout::Legacy, false));
+                    return Ok((ColumnLayout::V0, false));
                 }
             }
         }
@@ -220,7 +220,7 @@ impl ColumnLayout {
 
     fn index(self, col: Column) -> Option<usize> {
         match self {
-            ColumnLayout::Legacy => Some(col.legacy_index()),
+            ColumnLayout::V0 => Some(col.v0_index()),
             ColumnLayout::Header(mapping) => {
                 let idx = mapping[col.as_usize()];
                 if idx < 0 {
@@ -232,8 +232,8 @@ impl ColumnLayout {
         }
     }
 
-    pub(super) const fn is_legacy(self) -> bool {
-        matches!(self, ColumnLayout::Legacy)
+    pub(super) const fn is_v0(self) -> bool {
+        matches!(self, ColumnLayout::V0)
     }
 }
 

--- a/sudachi/src/dic/build/lexicon/parser.rs
+++ b/sudachi/src/dic/build/lexicon/parser.rs
@@ -24,8 +24,8 @@ use memmap2::Mmap;
 use crate::analysis::Mode;
 use crate::dic::build::error::{BuildFailure, DicWriteResult};
 use crate::dic::build::parse::{
-    it_next, none_if_equal, parse_i16, parse_legacy_line_ref, parse_mode, parse_slash_list,
-    parse_u32_list_with_asterisk, unescape, unescape_cow, WORD_ID_LITERAL,
+    it_next, none_if_equal, parse_i16, parse_mode, parse_slash_list, parse_u32_list_with_asterisk,
+    parse_v0_line_ref, unescape, unescape_cow, LINE_REF_LITERAL,
 };
 use crate::dic::build::pos::read_pos_bytes as read_pos_csv_bytes;
 use crate::dic::build::MAX_POS_IDS;
@@ -73,7 +73,7 @@ impl LexiconReader {
             .trim(Trim::None)
             .flexible(true)
             .from_reader(data);
-        let mut layout = ColumnLayout::Legacy;
+        let mut layout = ColumnLayout::V0;
         let mut first_row = true;
         let mut nread = 0;
         for record in reader.records() {
@@ -130,23 +130,21 @@ impl LexiconReader {
 
         let reading = rec.get_col(layout, Column::ReadingForm, unescape)?;
         let normalized = rec.get_col(layout, Column::NormalizedForm, |s| Ok(s.to_owned()))?;
-        let dic_form_ref = rec.get_col_or(layout, Column::DictionaryForm, "".to_owned(), |s| {
-            Ok(s.to_owned())
-        })?;
+        let dic_form_ref = rec.get_col(layout, Column::DictionaryForm, |s| Ok(s.to_owned()))?;
         let splitting = rec.get_col_or(layout, Column::Mode, Mode::C, parse_mode)?;
-        let allow_word_id_ref = layout.is_legacy();
-        let allow_asterisk = layout.is_legacy();
+        let allow_line_ref = layout.is_v0();
+        let allow_asterisk = layout.is_v0();
         let splits_a = rec.get_col(layout, Column::SplitA, |s| {
-            self.parse_splits_with_asterisk(s, allow_word_id_ref, allow_asterisk)
+            self.parse_splits_with_asterisk(s, allow_line_ref, allow_asterisk)
         })?;
         let splits_b = rec.get_col(layout, Column::SplitB, |s| {
-            self.parse_splits_with_asterisk(s, allow_word_id_ref, allow_asterisk)
+            self.parse_splits_with_asterisk(s, allow_line_ref, allow_asterisk)
         })?;
         let splits_c = rec.get_col_or_default(layout, Column::SplitC, |s| {
-            self.parse_splits_with_asterisk(s, allow_word_id_ref, allow_asterisk)
+            self.parse_splits_with_asterisk(s, allow_line_ref, allow_asterisk)
         })?;
         let word_structure = rec.get_col(layout, Column::WordStructure, |s| {
-            self.parse_splits_with_asterisk(s, allow_word_id_ref, allow_asterisk)
+            self.parse_splits_with_asterisk(s, allow_line_ref, allow_asterisk)
         })?;
         let synonym_groups = rec.get_col_or_default(layout, Column::SynonymGroups, |s| {
             parse_u32_list_with_asterisk(s, allow_asterisk)
@@ -221,14 +219,14 @@ impl LexiconReader {
 
         let dic_form = rec
             .ctx
-            .transform(self.parse_dic_form(&dic_form_ref, allow_word_id_ref))?;
+            .transform(self.parse_dic_form(&dic_form_ref, allow_line_ref))?;
         let norm_form = rec.ctx.transform(self.parse_norm_form(
             &normalized,
             effective_headword.as_ref(),
             pos,
             &reading,
             reference_id.as_deref(),
-            layout.is_legacy(),
+            layout.is_v0(),
         ))?;
 
         if index_form.is_empty() {
@@ -279,15 +277,15 @@ impl LexiconReader {
     pub(super) fn parse_splits(
         &mut self,
         data: &str,
-        allow_word_id_ref: bool,
+        allow_line_ref: bool,
     ) -> DicWriteResult<Vec<WordRef>> {
-        self.parse_splits_with_asterisk(data, allow_word_id_ref, true)
+        self.parse_splits_with_asterisk(data, allow_line_ref, true)
     }
 
     fn parse_splits_with_asterisk(
         &mut self,
         data: &str,
-        allow_word_id_ref: bool,
+        allow_line_ref: bool,
         allow_asterisk: bool,
     ) -> DicWriteResult<Vec<WordRef>> {
         if data.is_empty() || data == "*" {
@@ -297,15 +295,15 @@ impl LexiconReader {
             return Ok(Vec::new());
         }
 
-        parse_slash_list(data, |s| self.parse_split(s, allow_word_id_ref))
+        parse_slash_list(data, |s| self.parse_split(s, allow_line_ref))
     }
 
-    fn parse_split(&mut self, data: &str, allow_word_id_ref: bool) -> DicWriteResult<WordRef> {
-        if WORD_ID_LITERAL.is_match(data) {
-            if !allow_word_id_ref {
+    fn parse_split(&mut self, data: &str, allow_line_ref: bool) -> DicWriteResult<WordRef> {
+        if LINE_REF_LITERAL.is_match(data) {
+            if !allow_line_ref {
                 return Err(BuildFailure::InvalidSplit(data.to_owned()));
             }
-            Ok(WordRef::LineRef(parse_legacy_line_ref(data)?))
+            Ok(WordRef::LineRef(parse_v0_line_ref(data)?))
         } else if matches!(data.matches(',').count(), 2 | 3) {
             let mut iter = data.splitn(4, ',');
             let headword = it_next(data, &mut iter, "(1) headword", unescape)?;
@@ -338,15 +336,15 @@ impl LexiconReader {
         }
     }
 
-    fn parse_dic_form(&mut self, data: &str, allow_word_id_ref: bool) -> DicWriteResult<WordRef> {
-        if data.is_empty() || (allow_word_id_ref && data == "*") {
+    fn parse_dic_form(&mut self, data: &str, allow_line_ref: bool) -> DicWriteResult<WordRef> {
+        if data.is_empty() || (allow_line_ref && data == "*") {
             return Ok(WordRef::SelfRef);
         }
         if data == "*" {
             return Err(BuildFailure::InvalidSplit(data.to_owned()));
         }
 
-        self.parse_split(data, allow_word_id_ref)
+        self.parse_split(data, allow_line_ref)
     }
 
     fn parse_norm_form(

--- a/sudachi/src/dic/build/lexicon/test.rs
+++ b/sudachi/src/dic/build/lexicon/test.rs
@@ -25,7 +25,7 @@ use crate::error::SudachiError;
 use claim::assert_matches;
 use std::fmt::Write;
 
-mod legacy;
+mod v0;
 
 #[test]
 fn parse_split_empty() {

--- a/sudachi/src/dic/build/lexicon/test/v0.rs
+++ b/sudachi/src/dic/build/lexicon/test/v0.rs
@@ -17,7 +17,7 @@
 use super::*;
 
 #[test]
-fn parse_legacy_detection_by_integer_literal_in_legacy_format() {
+fn parse_v0_detection_by_integer_literal_in_v0_format() {
     let mut rdr = LexiconReader::new();
     let data = "京都,40000,6,5293,京都,名詞,固有名詞,地名,一般,*,*,キョウト,京都,*,A,*,*,*,*";
     assert_matches!(

--- a/sudachi/src/dic/build/parse.rs
+++ b/sudachi/src/dic/build/parse.rs
@@ -86,17 +86,17 @@ pub(crate) fn parse_u32(data: &str) -> DicWriteResult<u32> {
 }
 
 #[inline]
-pub(crate) fn parse_legacy_line_ref(data: &str) -> DicWriteResult<WordRef> {
+pub(crate) fn parse_v0_line_ref(data: &str) -> DicWriteResult<WordRef> {
     if let Some(stripped) = data.strip_prefix('U') {
-        let wref = parse_legacy_line_ref_raw(stripped);
+        let wref = parse_v0_line_ref_raw(stripped);
         wref.map(|w| WordRef::new(false, w.entry().as_raw()))
     } else {
-        parse_legacy_line_ref_raw(data)
+        parse_v0_line_ref_raw(data)
     }
 }
 
 #[inline]
-fn parse_legacy_line_ref_raw(data: &str) -> DicWriteResult<WordRef> {
+fn parse_v0_line_ref_raw(data: &str) -> DicWriteResult<WordRef> {
     match u32::from_str(data) {
         Ok(v) => match WordRef::checked(true, v) {
             Ok(wref) => Ok(wref),
@@ -123,7 +123,7 @@ pub(crate) fn parse_u32_list_with_asterisk(
 
 lazy_static! {
     // pattern for an entry reference by line number
-    pub(crate) static ref WORD_ID_LITERAL: Regex = Regex::new(r"^U?\d+$").unwrap();
+    pub(crate) static ref LINE_REF_LITERAL: Regex = Regex::new(r"^U?\d+$").unwrap();
 }
 
 #[inline]

--- a/sudachi/src/dic/build/test.rs
+++ b/sudachi/src/dic/build/test.rs
@@ -16,7 +16,7 @@
 
 use std::time::{Duration, UNIX_EPOCH};
 
-mod legacy;
+mod v0;
 mod with_analysis;
 
 use crate::dic::binary_loader::{BinaryDictionary, LoadedDictionary};

--- a/sudachi/src/dic/build/test/v0.rs
+++ b/sudachi/src/dic/build/test/v0.rs
@@ -17,7 +17,7 @@
 use super::*;
 
 #[test]
-fn split_user_ref_in_legacy_format() {
+fn split_user_ref_in_v0_format() {
     let mut sys = DictBuilder::new_system();
     sys.read_conn(MATRIX_10_10).unwrap();
     sys.read_lexicon(
@@ -71,7 +71,7 @@ fn split_user_ref_in_legacy_format() {
 }
 
 #[test]
-fn split_user_entrykey_ref_system_in_legacy_format() {
+fn split_user_entrykey_ref_system_in_v0_format() {
     let mut sys = DictBuilder::new_system();
     sys.read_conn(MATRIX_10_10).unwrap();
     sys.read_lexicon(
@@ -123,7 +123,7 @@ fn split_user_entrykey_ref_system_in_legacy_format() {
 }
 
 #[test]
-fn split_user_entrykey_ref_user_in_legacy_format() {
+fn split_user_entrykey_ref_user_in_v0_format() {
     let mut sys = DictBuilder::new_system();
     sys.read_conn(MATRIX_10_10).unwrap();
     sys.read_lexicon(
@@ -176,7 +176,7 @@ fn split_user_entrykey_ref_user_in_legacy_format() {
 
 #[test]
 #[ignore = "sudachi.rs currently allows system dictionary_form reference from user lexicon"]
-fn fail_dictionary_form_in_system_in_legacy_format() {
+fn fail_dictionary_form_in_system_in_v0_format() {
     let mut sys = DictBuilder::new_system();
     sys.read_conn(MATRIX_10_10).unwrap();
     sys.read_lexicon(
@@ -204,7 +204,7 @@ fn fail_dictionary_form_in_system_in_legacy_format() {
 }
 
 #[test]
-fn word_id_too_big_dicform_in_legacy_format() {
+fn word_id_too_big_dicform_in_v0_format() {
     let mut bldr = DictBuilder::new_system();
     bldr.read_conn(MATRIX_10_10).unwrap();
     bldr.read_lexicon(
@@ -221,7 +221,7 @@ fn word_id_too_big_dicform_in_legacy_format() {
 }
 
 #[test]
-fn word_id_too_big_split_a_in_legacy_format() {
+fn word_id_too_big_split_a_in_v0_format() {
     let mut bldr = DictBuilder::new_system();
     bldr.read_conn(MATRIX_10_10).unwrap();
     bldr.read_lexicon(
@@ -238,7 +238,7 @@ fn word_id_too_big_split_a_in_legacy_format() {
 }
 
 #[test]
-fn word_id_too_big_split_b_in_legacy_format() {
+fn word_id_too_big_split_b_in_v0_format() {
     let mut bldr = DictBuilder::new_system();
     bldr.read_conn(MATRIX_10_10).unwrap();
     bldr.read_lexicon(
@@ -255,7 +255,7 @@ fn word_id_too_big_split_b_in_legacy_format() {
 }
 
 #[test]
-fn word_id_too_big_word_structure_in_legacy_format() {
+fn word_id_too_big_word_structure_in_v0_format() {
     let mut bldr = DictBuilder::new_system();
     bldr.read_conn(MATRIX_10_10).unwrap();
     bldr.read_lexicon(
@@ -272,7 +272,7 @@ fn word_id_too_big_word_structure_in_legacy_format() {
 }
 
 #[test]
-fn word_id_too_big_dicform_userdic_insystem_in_legacy_format() {
+fn word_id_too_big_dicform_userdic_insystem_in_v0_format() {
     let mut bldr = DictBuilder::new_system();
     bldr.read_conn(MATRIX_10_10).unwrap();
     bldr.read_lexicon(
@@ -296,7 +296,7 @@ fn word_id_too_big_dicform_userdic_insystem_in_legacy_format() {
 }
 
 #[test]
-fn word_id_too_big_dicform_userdic_inuser_in_legacy_format() {
+fn word_id_too_big_dicform_userdic_inuser_in_v0_format() {
     let mut bldr = DictBuilder::new_system();
     bldr.read_conn(MATRIX_10_10).unwrap();
     bldr.read_lexicon(

--- a/sudachi/src/dic/build/util.rs
+++ b/sudachi/src/dic/build/util.rs
@@ -43,8 +43,8 @@ pub fn java_string_hash(data: &str) -> i32 {
 #[cfg(unix)]
 pub fn local_tm(secs: libc::time_t) -> Option<libc::tm> {
     let mut out = std::mem::MaybeUninit::<libc::tm>::uninit();
-    let mut input = secs;
-    let result = unsafe { libc::localtime_r(&mut input, out.as_mut_ptr()) };
+    let input = secs;
+    let result = unsafe { libc::localtime_r(&input, out.as_mut_ptr()) };
     if result.is_null() {
         None
     } else {
@@ -67,8 +67,8 @@ pub fn local_tm(secs: libc::time_t) -> Option<libc::tm> {
 #[cfg(unix)]
 pub fn utc_tm(secs: libc::time_t) -> libc::tm {
     let mut out = std::mem::MaybeUninit::<libc::tm>::uninit();
-    let mut input = secs;
-    let result = unsafe { libc::gmtime_r(&mut input, out.as_mut_ptr()) };
+    let input = secs;
+    let result = unsafe { libc::gmtime_r(&input, out.as_mut_ptr()) };
     if result.is_null() {
         zero_tm()
     } else {

--- a/sudachi/src/dic/description.rs
+++ b/sudachi/src/dic/description.rs
@@ -15,6 +15,7 @@
  */
 
 use nom::number::complete::le_u64;
+use std::fmt::Display;
 use std::time::Duration;
 use thiserror::Error;
 
@@ -76,7 +77,7 @@ pub enum Block {
 impl Block {
     /// return the string representation of the block
     /// This must be same as the name defined in the Java version.
-    fn to_str(&self) -> &str {
+    fn as_string_representation(&self) -> &str {
         match self {
             Block::ConnectionMatrix => "ConnMatrix",
             Block::POSTable => "POS",
@@ -89,9 +90,9 @@ impl Block {
     }
 }
 
-impl ToString for Block {
-    fn to_string(&self) -> String {
-        self.to_str().to_string()
+impl Display for Block {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_string_representation().to_string())
     }
 }
 
@@ -255,7 +256,7 @@ impl Description {
         buf: &'a [u8],
         block: Block,
     ) -> SudachiResult<Option<&'a [u8]>> {
-        let block_name = block.to_str();
+        let block_name = block.as_string_representation();
         match self.blocks.iter().find(|block| block.name() == block_name) {
             Some(block) => {
                 let start = block.start() as usize;

--- a/sudachi/src/dic/description.rs
+++ b/sudachi/src/dic/description.rs
@@ -38,8 +38,8 @@ pub enum DescriptionError {
     #[error("Invalid magic bytes")]
     InvalidMagicBytes,
 
-    #[error("Legacy version")]
-    LegacyVersion,
+    #[error("V0 version")]
+    V0Version,
 
     #[error("Invalid header version {0}")]
     InvalidVersion(u64),
@@ -143,7 +143,7 @@ pub struct Description {
 
 impl Description {
     pub fn load(buf: &[u8]) -> SudachiResult<Self> {
-        Self::check_legacy_format(buf)?;
+        Self::check_v0_format(buf)?;
 
         let rest = Self::check_magic(buf)?;
         let (rest, version) = le_u64(rest)?;
@@ -154,14 +154,14 @@ impl Description {
         }
     }
 
-    /// Check if the dictionary is in legacy (V0) format.
+    /// Check if the dictionary is in V0 format.
     ///
     /// In V0 format, the version is stored as a u64 (long) at the beginning of the binary.
-    fn check_legacy_format(buf: &[u8]) -> SudachiResult<()> {
+    fn check_v0_format(buf: &[u8]) -> SudachiResult<()> {
         let (_rest, version) = le_u64(buf)?;
-        let legacy_version = HeaderVersion::from_u64(version);
-        match legacy_version {
-            Some(_) => Err(DescriptionError::LegacyVersion.into()),
+        let v0_version = HeaderVersion::from_u64(version);
+        match v0_version {
+            Some(_) => Err(DescriptionError::V0Version.into()),
             None => Ok(()),
         }
     }

--- a/sudachi/src/dic/description.rs
+++ b/sudachi/src/dic/description.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Works Applications Co., Ltd.
+ * Copyright (c) 2025-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ use super::read::{
 };
 use crate::error::SudachiResult;
 
-static MAGIC_BYTES: &'static [u8] = b"SudachiBinaryDic";
+static MAGIC_BYTES: &[u8] = b"SudachiBinaryDic";
 
 /// Sudachi error
 #[derive(Error, Debug, Eq, PartialEq)]
@@ -148,9 +148,9 @@ impl Description {
         let rest = Self::check_magic(buf)?;
         let (rest, version) = le_u64(rest)?;
         if version == 1 {
-            return Self::load_v1(rest);
+            Self::load_v1(rest)
         } else {
-            return Err(DescriptionError::InvalidVersion(version).into());
+            Err(DescriptionError::InvalidVersion(version).into())
         }
     }
 
@@ -265,7 +265,7 @@ impl Description {
                 }
                 Ok(Some(&buf[start..end]))
             }
-            None => return Ok(None),
+            None => Ok(None),
         }
     }
 

--- a/sudachi/src/dic/lexicon/strings.rs
+++ b/sudachi/src/dic/lexicon/strings.rs
@@ -46,10 +46,10 @@ pub struct StringPointer {
 
 impl Default for StringPointer {
     fn default() -> Self {
-        return Self {
+        Self {
             length: 0,
             offset: 0,
-        };
+        }
     }
 }
 

--- a/sudachi/src/dic/lexicon/strings.rs
+++ b/sudachi/src/dic/lexicon/strings.rs
@@ -36,21 +36,12 @@ impl<'a> CompactedStrings<'a> {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct StringPointer {
     /// length of the string (in utf16 codepoint)
     pub length: u32,
     /// offset in the CompactedStrings (in utf16 codepoint)
     pub offset: u32,
-}
-
-impl Default for StringPointer {
-    fn default() -> Self {
-        Self {
-            length: 0,
-            offset: 0,
-        }
-    }
 }
 
 impl StringPointer {

--- a/sudachi/src/dic/lexicon/word_id_table.rs
+++ b/sudachi/src/dic/lexicon/word_id_table.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025 Works Applications Co., Ltd.
+ * Copyright (c) 2021-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ impl<'a> WordIdTable<'a> {
 
     pub fn all_entries(&self) -> EntryIdIter<'a> {
         EntryIdIter {
-            inner: DeltaCompressedEntryIdIter::new(&self.bytes),
+            inner: DeltaCompressedEntryIdIter::new(self.bytes),
         }
     }
 }

--- a/sudachi/src/dic/pos.rs
+++ b/sudachi/src/dic/pos.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Works Applications Co., Ltd.
+ * Copyright (c) 2025-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,9 @@ type POS = Vec<String>;
 #[derive(Clone, Debug, Default)]
 pub struct PosList(Vec<POS>);
 
-impl Into<Vec<POS>> for PosList {
-    fn into(self) -> Vec<POS> {
-        self.0
+impl From<PosList> for Vec<POS> {
+    fn from(val: PosList) -> Self {
+        val.0
     }
 }
 

--- a/sudachi/src/dic/read/utf16_string.rs
+++ b/sudachi/src/dic/read/utf16_string.rs
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Works Applications Co., Ltd.
+ *  Copyright (c) 2025-2026 Works Applications Co., Ltd.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ pub fn utf16_string_of_length(input: &[u8], char_length: usize) -> SudachiNomRes
         .split_at_checked(num_bytes)
         .ok_or(nom::Err::Failure(SudachiNomError::Utf16String))?;
 
-    let decoded = string_from_utf16le(data).map_err(|e| nom::Err::Failure(e))?;
+    let decoded = string_from_utf16le(data).map_err(nom::Err::Failure)?;
     Ok((rest, decoded))
 }
 

--- a/sudachi/src/dic/word_info/data.rs
+++ b/sudachi/src/dic/word_info/data.rs
@@ -81,7 +81,7 @@ impl WordInfoRefData {
         WordInfoData::from_resolved(raw)
     }
 
-    fn resolve_ref_vec(refs: &mut Vec<u32>, dict_id: DictId) {
+    fn resolve_ref_vec(refs: &mut [u32], dict_id: DictId) {
         for raw in refs.iter_mut() {
             *raw = WordRef::resolve_raw(*raw, dict_id);
         }

--- a/sudachi/src/dic/word_info/data.rs
+++ b/sudachi/src/dic/word_info/data.rs
@@ -238,7 +238,7 @@ impl WordInfo {
     }
 
     pub fn index_form_length(&self) -> usize {
-        self.data.index_form_length() as usize
+        self.data.index_form_length()
     }
 
     pub fn pos_id(&self) -> u16 {
@@ -264,23 +264,23 @@ impl WordInfo {
     }
 
     pub fn a_unit_split(&self) -> &[WordId] {
-        &self.data.a_unit_split()
+        self.data.a_unit_split()
     }
 
     pub fn b_unit_split(&self) -> &[WordId] {
-        &self.data.b_unit_split()
+        self.data.b_unit_split()
     }
 
     pub fn c_unit_split(&self) -> &[WordId] {
-        &self.data.c_unit_split()
+        self.data.c_unit_split()
     }
 
     pub fn word_structure(&self) -> &[WordId] {
-        &self.data.word_structure()
+        self.data.word_structure()
     }
 
     pub fn synonym_group_ids(&self) -> &[i32] {
-        &self.data.synonym_group_ids()
+        self.data.synonym_group_ids()
     }
 
     pub fn user_data(&self) -> &str {

--- a/sudachi/src/dic/word_info/infos.rs
+++ b/sudachi/src/dic/word_info/infos.rs
@@ -98,7 +98,7 @@ impl<'a> WordInfos<'a> {
         let entry_id = Self::entry_id_from_offset(cursor.offset)?;
         let size = self
             .entry_size_at(cursor.offset)
-            .ok_or_else(|| WordInfoError::FailedToLoadEntrySize(cursor.offset))?;
+            .ok_or(WordInfoError::FailedToLoadEntrySize(cursor.offset))?;
 
         cursor.offset = match cursor.offset.checked_add(size) {
             Some(offset) => offset,

--- a/sudachi/src/input_text/buffer.rs
+++ b/sudachi/src/input_text/buffer.rs
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2024 Works Applications Co., Ltd.
+ *  Copyright (c) 2021-2026 Works Applications Co., Ltd.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -248,7 +248,7 @@ impl InputBuffer {
         // the buffer object itself will be accessible as RO
         let replaces: &'a mut Vec<edit::ReplaceOp<'a>> =
             unsafe { std::mem::transmute(&mut self.replaces) };
-        return InputEditor::new(replaces);
+        InputEditor::new(replaces)
     }
 
     /// Execute a function which can modify the contents of the current buffer

--- a/sudachi/src/sentence_detector.rs
+++ b/sudachi/src/sentence_detector.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024 Works Applications Co., Ltd.
+ * Copyright (c) 2021-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ impl<'a> NonBreakChecker<'a> {
 
 impl NonBreakChecker<'_> {
     /// Returns whether there is a word that crosses the boundary
-
     fn has_non_break_word(&self, input: &str, length: usize) -> bool {
         // assume that SentenceDetector::get_eos called with self.input[self.bos..]
         let eos_byte = self.bos + length;

--- a/sudachi/src/util/cow_array.rs
+++ b/sudachi/src/util/cow_array.rs
@@ -118,7 +118,7 @@ impl<'a, T: ReadLE + Clone> CowArray<'a, T> {
             self.storage = Some(self.slice.to_vec());
             //refresh slice
             let slice: &[T] = self.storage.as_ref().unwrap().as_slice();
-            self.slice = unsafe { std::mem::transmute(slice) };
+            self.slice = unsafe { std::mem::transmute::<&[T], &[T]>(slice) };
         }
         if let Some(s) = self.storage.as_mut() {
             s[offset] = value;

--- a/sudachi/src/util/user_pos.rs
+++ b/sudachi/src/util/user_pos.rs
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021-2024 Works Applications Co., Ltd.
+ *  Copyright (c) 2021-2026 Works Applications Co., Ltd.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ pub trait UserPosSupport {
     ) -> SudachiResult<u16>;
 }
 
-impl<'a> UserPosSupport for &'a mut Grammar<'_> {
+impl UserPosSupport for &mut Grammar<'_> {
     fn handle_user_pos<S: AsRef<str> + ToString + Display>(
         &mut self,
         pos: &[S],


### PR DESCRIPTION
this PR does followings

- change the usage of word "legacy" to "v0" around dictionary format
- change the usage of word "word-id-ref" to "line-ref" around word-reference in the lexicon
- fix some clippy warnings
  - remove unnecessary `mut`/`&`
  - add type annotation
  - change method name following recommendation