### PR TITLE
Fix clippy warnings

### DIFF
--- a/python/src/morpheme.rs
+++ b/python/src/morpheme.rs
@@ -178,7 +178,7 @@ impl PyMorphemeListWrapper {
     fn __getitem__(slf: Bound<PyMorphemeListWrapper>, mut idx: isize) -> PyResult<PyMorpheme> {
         enum Item {
             List(usize),
-            Single(SingleMorpheme<Arc<PyDicData>>, PyProjector),
+            Single(Box<SingleMorpheme<Arc<PyDicData>>>, PyProjector),
         }
 
         let item = {
@@ -201,7 +201,7 @@ impl PyMorphemeListWrapper {
             match &list.inner {
                 PyMorphemeListBacking::List(_) => Item::List(idx),
                 PyMorphemeListBacking::Singles(items) => {
-                    Item::Single(items[idx].clone(), list.projection.clone())
+                    Item::Single(Box::new(items[idx].clone()), list.projection.clone())
                 }
             }
         };
@@ -212,7 +212,7 @@ impl PyMorphemeListWrapper {
                 Ok(PyMorpheme::list_backed(py_list, idx))
             }
             Item::Single(morpheme, projection) => {
-                Ok(PyMorpheme::single_backed(morpheme, projection))
+                Ok(PyMorpheme::single_backed_boxed(morpheme, projection))
             }
         }
     }
@@ -283,7 +283,7 @@ impl PyMorphemeIter {
     fn __next__(&mut self, py: Python) -> Option<PyMorpheme> {
         enum Item {
             List(usize),
-            Single(SingleMorpheme<Arc<PyDicData>>, PyProjector),
+            Single(Box<SingleMorpheme<Arc<PyDicData>>>, PyProjector),
         }
 
         let item = {
@@ -295,7 +295,7 @@ impl PyMorphemeIter {
             match &list.inner {
                 PyMorphemeListBacking::List(_) => Item::List(self.index),
                 PyMorphemeListBacking::Singles(items) => {
-                    Item::Single(items[self.index].clone(), list.projection.clone())
+                    Item::Single(Box::new(items[self.index].clone()), list.projection.clone())
                 }
             }
         };
@@ -304,7 +304,7 @@ impl PyMorphemeIter {
         match item {
             Item::List(index) => Some(PyMorpheme::list_backed(self.list.clone_ref(py), index)),
             Item::Single(morpheme, projection) => {
-                Some(PyMorpheme::single_backed(morpheme, projection))
+                Some(PyMorpheme::single_backed_boxed(morpheme, projection))
             }
         }
     }
@@ -332,7 +332,7 @@ enum PyMorphemeBacking {
         index: usize,
     },
     Single {
-        morpheme: SingleMorpheme<Arc<PyDicData>>,
+        morpheme: Box<SingleMorpheme<Arc<PyDicData>>>,
         projection: PyProjector,
     },
 }
@@ -358,6 +358,13 @@ impl PyMorpheme {
 
     pub(crate) fn single_backed(
         morpheme: SingleMorpheme<Arc<PyDicData>>,
+        projection: PyProjector,
+    ) -> Self {
+        Self::single_backed_boxed(Box::new(morpheme), projection)
+    }
+
+    pub(crate) fn single_backed_boxed(
+        morpheme: Box<SingleMorpheme<Arc<PyDicData>>>,
         projection: PyProjector,
     ) -> Self {
         Self {
@@ -423,7 +430,7 @@ impl PyMorpheme {
             PyMorphemeBacking::Single {
                 morpheme,
                 projection,
-            } => PyMorpheme::single_backed(morpheme.clone(), projection.clone()),
+            } => PyMorpheme::single_backed_boxed((*morpheme).clone(), projection.clone()),
         }
     }
 
@@ -437,7 +444,7 @@ impl PyMorpheme {
                 let mrp = Self::borrow_morpheme(list, py, *index)?;
                 Ok(f(mrp.deref()))
             }
-            PyMorphemeBacking::Single { morpheme, .. } => Ok(f(morpheme)),
+            PyMorphemeBacking::Single { morpheme, .. } => Ok(f(morpheme.as_ref())),
         }
     }
 
@@ -586,9 +593,9 @@ impl PyMorpheme {
                 let list = list.borrow(py);
                 Ok(list.as_list()?.dict().pos_of(pos_id).clone_ref(py))
             }
-            PyMorphemeBacking::Single { morpheme, .. } => {
-                Ok(MorphemeView::dict(morpheme).pos_of(pos_id).clone_ref(py))
-            }
+            PyMorphemeBacking::Single { morpheme, .. } => Ok(MorphemeView::dict(morpheme.as_ref())
+                .pos_of(pos_id)
+                .clone_ref(py)),
         }
     }
 }
@@ -631,7 +638,7 @@ impl PyMorpheme {
                 projection,
             } => match projection {
                 None => Ok(PyString::new(py, morpheme.surface())),
-                Some(proj) => Ok(proj.project(morpheme, py)),
+                Some(proj) => Ok(proj.project(morpheme.as_ref(), py)),
             },
         }
     }

--- a/sudachi-cli/src/analysis.rs
+++ b/sudachi-cli/src/analysis.rs
@@ -25,6 +25,7 @@ use sudachi::sentence_splitter::{SentenceSplitter, SplitSentences};
 
 pub trait Analysis {
     fn analyze(&mut self, input: &str, writer: &mut Writer);
+    #[allow(unused)]
     fn set_subset(&mut self, subset: InfoSubset);
 }
 

--- a/sudachi-cli/src/build.rs
+++ b/sudachi-cli/src/build.rs
@@ -31,6 +31,7 @@ use sudachi::dic::grammar::Grammar;
 use sudachi::dic::lexicon::Lexicon;
 use sudachi::dic::lexicon_set::LexiconSet;
 use sudachi::dic::word_id::WordId;
+use sudachi::dic::word_info::WordInfo;
 use sudachi::error::SudachiResult;
 use sudachi::text_normalizer::TextNormalizer;
 
@@ -368,7 +369,7 @@ fn dump_word_info<W: Write>(
         (((grammar, lexicon_set), system_reference_ids), None)
     };
 
-    let ((mut grammar, mut lex), system_reference_ids) = base;
+    let ((mut grammar, mut lexicon), system_reference_ids) = base;
     let mut word_ids = Vec::new();
     let mut user_reference_ids = HashMap::new();
     if let Some(udic) = user {
@@ -377,27 +378,34 @@ fn dump_word_info<W: Write>(
         for entry in user_lex.entry_ids_in_order() {
             word_ids.push(WordId::new(1, entry.as_raw()));
         }
-        lex.append(user_lex, grammar.pos_list.len())?;
+        lexicon.append(user_lex, grammar.pos_list.len())?;
         grammar.merge_binary(udic.grammar);
     } else {
-        for entry in lex.system_word_ids_in_order() {
+        for entry in lexicon.system_word_ids_in_order() {
             word_ids.push(entry);
         }
     }
-
     let normalizer = TextNormalizer::new(&grammar)?;
+    let ctx = WordInfoDumpCtx {
+        grammar,
+        lexicon,
+        system_reference_ids,
+        user_reference_ids,
+        pos_format,
+    };
+
     writeln!(w, "{}", word_info_header(pos_format))?;
     for wid in word_ids {
         if wid.dict().as_raw() != did {
             continue;
         }
-        let (left, right, cost) = lex.get_word_param(wid);
+        let (left, right, cost) = ctx.lexicon.get_word_param(wid);
         // Internally generated phantom entries should not be dumped as source CSV rows.
         if left == -1 && right == -1 && cost == i16::MAX {
             continue;
         }
-        let winfo = lex.get_word_info(wid)?;
-        let headword = winfo.headword(&lex);
+        let winfo = ctx.lexicon.get_word_info(wid)?;
+        let headword = winfo.headword(&ctx.lexicon);
         let index_form = normalizer.normalize(headword)?;
         write!(w, "{},", csv_field(&index_form))?;
         write!(w, "{},{},{},", left, right, cost)?;
@@ -406,76 +414,29 @@ fn dump_word_info<W: Write>(
         } else {
             write!(w, "{},", csv_field(headword))?;
         }
-        write!(w, "{},", pos_string(&grammar, winfo.pos_id(), pos_format))?;
-        let reading = winfo.reading_form(&lex);
+        write!(w, "{},", ctx.pos_string(winfo.pos_id()))?;
+        let reading = winfo.reading_form(&ctx.lexicon);
         write!(w, "{},", csv_field(reading))?;
-        let normalized = winfo.normalized_form(&lex);
+        let normalized = winfo.normalized_form(&ctx.lexicon);
         if normalized == headword {
             write!(w, ",")?;
         } else {
             write!(w, "{},", csv_field(normalized))?;
         }
-        let dict_form = dictionary_form_string(
-            &grammar,
-            &lex,
-            wid,
-            winfo.borrow_data().dictionary_form_word_id(),
-            pos_format,
-            &system_reference_ids,
-            &user_reference_ids,
-        )?;
+        let dict_form =
+            ctx.dictionary_form_string(wid, winfo.borrow_data().dictionary_form_word_id())?;
         write!(w, "{},", dict_form)?;
-        dump_wids(
-            w,
-            &grammar,
-            &lex,
-            winfo.a_unit_split(),
-            pos_format,
-            &system_reference_ids,
-            &user_reference_ids,
-        )?;
+        ctx.dump_wids(w, winfo.a_unit_split())?;
         w.write_all(b",")?;
-        dump_wids(
-            w,
-            &grammar,
-            &lex,
-            winfo.b_unit_split(),
-            pos_format,
-            &system_reference_ids,
-            &user_reference_ids,
-        )?;
+        ctx.dump_wids(w, winfo.b_unit_split())?;
         w.write_all(b",")?;
-        dump_wids(
-            w,
-            &grammar,
-            &lex,
-            winfo.c_unit_split(),
-            pos_format,
-            &system_reference_ids,
-            &user_reference_ids,
-        )?;
+        ctx.dump_wids(w, winfo.c_unit_split())?;
         w.write_all(b",")?;
-        dump_wids(
-            w,
-            &grammar,
-            &lex,
-            winfo.word_structure(),
-            pos_format,
-            &system_reference_ids,
-            &user_reference_ids,
-        )?;
+        ctx.dump_wids(w, winfo.word_structure())?;
         w.write_all(b",")?;
         dump_gids(w, winfo.synonym_group_ids())?;
-        write!(
-            w,
-            ",{},{}",
-            csv_field(winfo.user_data()),
-            csv_field(&reference_id_for_word_id(
-                wid,
-                &system_reference_ids,
-                &user_reference_ids
-            ))
-        )?;
+        write!(w, ",{}", csv_field(winfo.user_data()))?;
+        write!(w, ",{}", csv_field(&ctx.reference_id_for_word_id(wid)))?;
         w.write_all(b"\n")?;
     }
     Ok(())
@@ -512,136 +473,109 @@ fn word_info_header(pos_format: PosDumpFormat) -> &'static str {
     }
 }
 
-fn pos_string(grammar: &Grammar, posid: u16, pos_format: PosDumpFormat) -> String {
-    match pos_format {
-        PosDumpFormat::Components => grammar
-            .pos_components(posid)
-            .iter()
-            .map(|p| csv_field(p))
-            .collect::<Vec<_>>()
-            .join(","),
-        PosDumpFormat::Id => posid.to_string(),
-    }
-}
-
-fn pos_string_for_entrykey(grammar: &Grammar, posid: u16, pos_format: PosDumpFormat) -> String {
-    match pos_format {
-        PosDumpFormat::Components => grammar
-            .pos_components(posid)
-            .iter()
-            .map(|p| entrykey_ref_escape(p))
-            .collect::<Vec<_>>()
-            .join(","),
-        PosDumpFormat::Id => posid.to_string(),
-    }
-}
-
-fn dictionary_form_string(
-    grammar: &Grammar,
-    lex: &LexiconSet,
-    self_wid: WordId,
-    wid: WordId,
+struct WordInfoDumpCtx<'a> {
+    grammar: Grammar<'a>,
+    lexicon: LexiconSet<'a>,
+    system_reference_ids: HashMap<u32, String>,
+    user_reference_ids: HashMap<u32, String>,
     pos_format: PosDumpFormat,
-    system_reference_ids: &HashMap<u32, String>,
-    user_reference_ids: &HashMap<u32, String>,
-) -> SudachiResult<String> {
-    if self_wid == wid {
-        return Ok(String::new());
-    }
-
-    let dict_form_wi = lex.get_word_info(wid)?;
-    Ok(format!(
-        "\"{}\"",
-        entrykey_ref_string(
-            grammar,
-            wid,
-            dict_form_wi.headword(lex),
-            dict_form_wi.pos_id(),
-            dict_form_wi.reading_form(lex),
-            pos_format,
-            system_reference_ids,
-            user_reference_ids,
-        )
-    ))
 }
 
-fn entrykey_ref_string(
-    grammar: &Grammar,
-    wid: WordId,
-    headword: &str,
-    pos_id: u16,
-    reading: &str,
-    pos_format: PosDumpFormat,
-    system_reference_ids: &HashMap<u32, String>,
-    user_reference_ids: &HashMap<u32, String>,
-) -> String {
-    let mut data = format!(
-        "{},{},{}",
-        entrykey_ref_escape(headword),
-        pos_string_for_entrykey(grammar, pos_id, pos_format),
-        entrykey_ref_escape(reading),
-    );
-    let reference_id = reference_id_for_word_id(wid, system_reference_ids, user_reference_ids);
-    if !reference_id.is_empty() {
-        data.push(',');
-        data.push_str(&entrykey_ref_escape(&reference_id));
-    }
-    data
-}
-
-fn dump_wids<W: Write>(
-    w: &mut W,
-    grammar: &Grammar,
-    lex: &LexiconSet,
-    data: &[WordId],
-    pos_format: PosDumpFormat,
-    system_reference_ids: &HashMap<u32, String>,
-    user_reference_ids: &HashMap<u32, String>,
-) -> SudachiResult<()> {
-    if data.is_empty() {
-        return Ok(());
-    }
-
-    let mut refs = Vec::with_capacity(data.len());
-    for wid in data {
-        let wi = lex.get_word_info(*wid)?;
-        refs.push(entrykey_ref_string(
-            grammar,
-            *wid,
-            wi.headword(lex),
-            wi.pos_id(),
-            wi.reading_form(lex),
-            pos_format,
-            system_reference_ids,
-            user_reference_ids,
-        ));
-    }
-    w.write_all(b"\"")?;
-    for (i, r) in refs.iter().enumerate() {
-        write!(w, "{}", r)?;
-        if i + 1 != refs.len() {
-            w.write_all(b"/")?;
+impl<'a> WordInfoDumpCtx<'a> {
+    fn pos_string(&self, posid: u16) -> String {
+        match self.pos_format {
+            PosDumpFormat::Components => self
+                .grammar
+                .pos_components(posid)
+                .iter()
+                .map(|p| csv_field(p))
+                .collect::<Vec<_>>()
+                .join(","),
+            PosDumpFormat::Id => posid.to_string(),
         }
     }
-    w.write_all(b"\"")?;
-    Ok(())
-}
 
-fn reference_id_for_word_id(
-    wid: WordId,
-    system_reference_ids: &HashMap<u32, String>,
-    user_reference_ids: &HashMap<u32, String>,
-) -> String {
-    match wid.dict().as_raw() {
-        0 => system_reference_ids
-            .get(&wid.entry().as_raw())
-            .cloned()
-            .unwrap_or_default(),
-        1 => user_reference_ids
-            .get(&wid.entry().as_raw())
-            .cloned()
-            .unwrap_or_default(),
-        _ => String::new(),
+    fn pos_string_for_entrykey(&self, posid: u16) -> String {
+        match self.pos_format {
+            PosDumpFormat::Components => self
+                .grammar
+                .pos_components(posid)
+                .iter()
+                .map(|p| entrykey_ref_escape(p))
+                .collect::<Vec<_>>()
+                .join(","),
+            PosDumpFormat::Id => posid.to_string(),
+        }
+    }
+
+    fn reference_id_for_word_id(&self, wid: WordId) -> String {
+        match wid.dict().as_raw() {
+            0 => self
+                .system_reference_ids
+                .get(&wid.entry().as_raw())
+                .cloned()
+                .unwrap_or_default(),
+            1 => self
+                .user_reference_ids
+                .get(&wid.entry().as_raw())
+                .cloned()
+                .unwrap_or_default(),
+            _ => String::new(),
+        }
+    }
+
+    fn entrykey_ref_string(&self, word_info: WordInfo, reference_id: &str) -> String {
+        let headword = word_info.headword(&self.lexicon);
+        let pos_id = word_info.pos_id();
+        let reading = word_info.reading_form(&self.lexicon);
+
+        let mut data = format!(
+            "{},{},{}",
+            entrykey_ref_escape(headword),
+            self.pos_string_for_entrykey(pos_id),
+            entrykey_ref_escape(reading),
+        );
+        if !reference_id.is_empty() {
+            data.push(',');
+            data.push_str(&entrykey_ref_escape(reference_id));
+        }
+        data
+    }
+
+    fn dictionary_form_string(&self, self_wid: WordId, wid: WordId) -> SudachiResult<String> {
+        if self_wid == wid {
+            return Ok(String::new());
+        }
+
+        Ok(format!(
+            "\"{}\"",
+            self.entrykey_ref_string(
+                self.lexicon.get_word_info(wid)?,
+                &self.reference_id_for_word_id(wid),
+            )
+        ))
+    }
+
+    fn dump_wids<W: Write>(&self, w: &mut W, data: &[WordId]) -> SudachiResult<()> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let mut refs = Vec::with_capacity(data.len());
+        for wid in data {
+            let wi = self.lexicon.get_word_info(*wid)?;
+            let reference_id = self.reference_id_for_word_id(*wid);
+            refs.push(self.entrykey_ref_string(wi, &reference_id));
+        }
+        w.write_all(b"\"")?;
+        for (i, r) in refs.iter().enumerate() {
+            write!(w, "{}", r)?;
+            if i + 1 != refs.len() {
+                w.write_all(b"/")?;
+            }
+        }
+        w.write_all(b"\"")?;
+        Ok(())
     }
 }
 

--- a/sudachi/src/analysis/morpheme.rs
+++ b/sudachi/src/analysis/morpheme.rs
@@ -147,7 +147,6 @@ pub trait MorphemeView: private::Sealed {
     /// distinct referenced entry, returns a standalone morpheme whose offsets
     /// are `0..surface.len()` in bytes and `0..surface.chars().count()` in
     /// codepoints.
-    #[allow(clippy::result_large_err)]
     fn dictionary_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, Self::Dictionary>>
     where
         Self::Dictionary: Clone,
@@ -177,7 +176,6 @@ pub trait MorphemeView: private::Sealed {
     /// distinct referenced entry, returns a standalone morpheme whose offsets
     /// are `0..surface.len()` in bytes and `0..surface.chars().count()` in
     /// codepoints.
-    #[allow(clippy::result_large_err)]
     fn normalized_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, Self::Dictionary>>
     where
         Self::Dictionary: Clone,
@@ -290,7 +288,6 @@ impl<D> Copy for Morpheme<'_, D> {}
 impl<D: DictionaryAccess + Clone> Morpheme<'_, D> {
     /// Returns new morpheme list splitting the morpheme with given mode.
     #[deprecated(note = "use split_into", since = "0.6.1")]
-    #[allow(clippy::result_large_err)]
     pub fn split(&self, mode: Mode) -> SudachiResult<MorphemeList<D>> {
         #[allow(deprecated)]
         self.list.split(mode, self.index)
@@ -350,7 +347,6 @@ impl<'a, D: DictionaryAccess> Morpheme<'a, D> {
     }
 
     /// Returns the morpheme corresponding to this morpheme's dictionary form.
-    #[allow(clippy::result_large_err)]
     pub fn dictionary_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>>
     where
         D: Clone,
@@ -367,7 +363,6 @@ impl<'a, D: DictionaryAccess> Morpheme<'a, D> {
     }
 
     /// Returns the morpheme corresponding to this morpheme's normalized form.
-    #[allow(clippy::result_large_err)]
     pub fn normalized_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>>
     where
         D: Clone,
@@ -420,7 +415,6 @@ impl<'a, D: DictionaryAccess> Morpheme<'a, D> {
     /// Splits morpheme and writes sub-morphemes into the provided list.
     /// The resulting list is _not_ cleared before that.
     /// Returns true if split has produced any elements.
-    #[allow(clippy::result_large_err)]
     pub fn split_into(&self, mode: Mode, out: &mut MorphemeList<D>) -> SudachiResult<bool> {
         self.list.split_into(mode, self.index, out)
     }
@@ -522,7 +516,6 @@ impl<D: DictionaryAccess> SingleMorpheme<D> {
     /// The entry is resolved by `WordId`, not by surface lookup, so homograph
     /// identity is preserved. `HEADWORD` is always loaded because standalone
     /// offsets and surface are based on the dictionary headword.
-    #[allow(clippy::result_large_err)]
     pub fn from_word_id(dict: D, word_id: WordId, subset: InfoSubset) -> SudachiResult<Self> {
         validate_dictionary_word_id(&dict, word_id)?;
         let subset = (subset | InfoSubset::HEADWORD).normalize();
@@ -634,7 +627,6 @@ impl<D: DictionaryAccess + Clone> SingleMorpheme<D> {
     /// this morpheme. Offsets match Java's standalone morpheme behavior: a
     /// single replacement split preserves this morpheme's span, while
     /// multi-splits advance over each split surface.
-    #[allow(clippy::result_large_err)]
     pub fn split(&self, mode: Mode) -> SudachiResult<Vec<SingleMorpheme<D>>> {
         let split_subset = match mode {
             Mode::A => InfoSubset::SPLIT_A,
@@ -706,7 +698,6 @@ impl<D: DictionaryAccess + Clone> SingleMorpheme<D> {
     }
 
     /// Returns the morpheme corresponding to this morpheme's dictionary form.
-    #[allow(clippy::result_large_err)]
     pub fn dictionary_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>> {
         <Self as MorphemeView>::dictionary_form_morpheme(self)
     }
@@ -717,7 +708,6 @@ impl<D: DictionaryAccess + Clone> SingleMorpheme<D> {
     }
 
     /// Returns the morpheme corresponding to this morpheme's normalized form.
-    #[allow(clippy::result_large_err)]
     pub fn normalized_form_morpheme(&self) -> SudachiResult<MorphemeRef<'_, D>> {
         <Self as MorphemeView>::normalized_form_morpheme(self)
     }

--- a/sudachi/src/dic/build/lexicon/entry.rs
+++ b/sudachi/src/dic/build/lexicon/entry.rs
@@ -213,6 +213,7 @@ impl ResolvedLexiconEntry {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn variable_layout(
     splits_c_len: usize,
     split_b_eq_c: bool,

--- a/sudachi/src/dic/description.rs
+++ b/sudachi/src/dic/description.rs
@@ -92,7 +92,7 @@ impl Block {
 
 impl Display for Block {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_string_representation().to_string())
+        write!(f, "{}", self.as_string_representation())
     }
 }
 

--- a/sudachi/src/dic/dictionary.rs
+++ b/sudachi/src/dic/dictionary.rs
@@ -197,13 +197,11 @@ impl JapaneseDictionary {
     /// This normalizes the query using dictionary input-text plugins and scans
     /// every public lexicon entry. It can find entries that are not indexed for
     /// normal lookup. Use `lookup` for normal indexed lookup.
-    #[allow(clippy::result_large_err)]
     pub fn lookup_all_entries(&self, surface: &str) -> SudachiResult<Vec<SingleMorpheme<&Self>>> {
         self.lookup_all_entries_subset(surface, InfoSubset::all())
     }
 
     /// Looks up all matching dictionary entries, loading only requested fields.
-    #[allow(clippy::result_large_err)]
     pub fn lookup_all_entries_subset(
         &self,
         surface: &str,

--- a/sudachi/src/dic/pos.rs
+++ b/sudachi/src/dic/pos.rs
@@ -25,6 +25,7 @@ pub const POS_DEPTH: usize = 6;
 /// A part of speech
 ///
 /// Its length must be `POS_DEPTH`
+#[allow(clippy::upper_case_acronyms)]
 type POS = Vec<String>;
 
 #[derive(Clone, Debug, Default)]

--- a/sudachi/src/dic/word_info/layout.rs
+++ b/sudachi/src/dic/word_info/layout.rs
@@ -108,6 +108,7 @@ pub(crate) struct WordInfoVariableLayout {
 }
 
 impl WordInfoVariableLayout {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         c_unit_split_len: usize,
         b_unit_split_shared: bool,


### PR DESCRIPTION
Fix some more clippy warnings.

- add boxing to reduce data size
- add Ctx struct to reduce arguments
- suppress some warnings / remove suppression for resolved problems
