### PR TITLE
Rework config (rust side)

### DIFF
--- a/python/src/build.rs
+++ b/python/src/build.rs
@@ -21,12 +21,11 @@ use std::path::Path;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyList, PyString, PyType};
 
-use sudachi::config::Config;
+use sudachi::config::{Config, PathResolver};
 use sudachi::dic::build::{DataSource, DictBuilder};
 use sudachi::dic::dictionary::JapaneseDictionary;
 use sudachi::dic::{DictionaryAccess, ReferenceIdAccess};
 
-use crate::dictionary::get_default_resource_dir;
 use crate::errors;
 
 pub fn register_functions(m: &Bound<PyModule>) -> PyResult<()> {
@@ -133,8 +132,7 @@ fn build_user_dic<'py>(
     let system_path = resolve_as_pypathstr(py, system)?;
     let system_dic = match as_data_source(system_path.as_ref(), system)? {
         DataSource::File(f) => {
-            let resource_path = get_default_resource_dir(py)?;
-            let cfg = Config::minimal_at(resource_path).with_system_dic(f);
+            let cfg = Config::minimal_at(PathResolver::from_embedded()).with_system_dic(f);
             errors::wrap_ctx(JapaneseDictionary::from_cfg(&cfg), f)?
         }
         DataSource::Data(_) => {

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -196,6 +196,12 @@ impl PyDictionary {
     /// If both config.systemDict and dict are given, dict is used.
     /// If dict is an absolute path to a file, it is used as a dictionary.
     ///
+    /// Resolution precedence is:
+    /// 1. `resource_dir` (if given).
+    /// 2. `path` field in the `config_file` (if set).
+    /// 3. The parent directory of the `config_file` (if given).
+    /// 4. The default resources.
+    ///
     /// :param config_path: path to the configuration JSON file, config json as a string, or a [sudachipy.Config] object.
     /// :param config: alias to config_path, only one of them can be specified at the same time.
     /// :param resource_dir: path to the resource directory folder.

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -225,22 +225,16 @@ impl PyDictionary {
             return errors::wrap(Err("Both config and config_path options were specified at the same time, use one of them"));
         }
 
-        let default_config = read_default_config(py)?;
+        let mut builder = read_default_config(py)?;
 
-        let config_builder = match config.or(config_path) {
-            None => default_config,
-            Some(v) => read_config(v)?.fallback(&default_config),
-        };
+        if let Some(v) = config.or(config_path) {
+            builder = read_config(v)?.fallback_data(&builder);
+        }
 
-        let resource_dir = match resource_dir {
-            None => Some(get_default_resource_dir(py)?),
-            Some(v) => Some(v),
-        };
-
-        let dict_path = match dict.or(dict_type) {
-            None => None,
-            Some(dt) => Some(locate_system_dict(py, Path::new(dt))?),
-        };
+        if let Some(p) = resource_dir {
+            builder = builder.prepend_resolver_root(p);
+        }
+        builder = builder.push_resolver_root(get_default_resource_dir(py)?);
 
         if dict_type.is_some() {
             errors::warn_deprecation(
@@ -248,18 +242,12 @@ impl PyDictionary {
                 c_str!("Parameter dict_type of Dictionary() is deprecated, use dict instead"),
             )?
         }
-
-        let config_builder = match resource_dir {
-            Some(p) => config_builder.resource_path(p),
-            None => config_builder,
+        if let Some(dt) = dict.or(dict_type) {
+            let dict_path = locate_system_dict(py, Path::new(dt))?;
+            builder = builder.system_dict(dict_path)
         };
 
-        let config_builder = match dict_path {
-            Some(p) => config_builder.system_dict(p),
-            None => config_builder,
-        };
-
-        let mut config = config_builder.build();
+        let mut config = builder.build();
 
         // Load a dictionary from `sudachidict_core` as the default one.
         // For this behavior, the value of `systemDict` key in the default setting file must be

--- a/python/tests/test_dictionary.py
+++ b/python/tests/test_dictionary.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import tempfile
 import unittest
@@ -168,6 +169,45 @@ class TestDictionary(unittest.TestCase):
 
                 phantom = dictionary.lookup_all_entries("舞台芸術")
                 self.assertFalse(phantom)
+            finally:
+                dictionary.close()
+
+    def test_resource_dir_precedes_config_parent(self):
+        resource_dir = Path(__file__).parent / "resources"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            config_path = temp_path / "sudachi.json"
+            # If the config directory is searched first, dictionary creation will try to
+            # open this directory as `char.def` and fail before reaching `resource_dir`.
+            (temp_path / "char.def").mkdir()
+            config_path.write_text(json.dumps({
+                "systemDict": str(resource_dir / "system.dic.test"),
+                "userDict": [str(resource_dir / "user.dic.test")],
+                "characterDefinitionFile": "char.def",
+                "inputTextPlugin": [
+                    {"class": "com.worksap.nlp.sudachi.DefaultInputTextPlugin"}
+                ],
+                "oovProviderPlugin": [
+                    {"class": "com.worksap.nlp.sudachi.SimpleOovPlugin",
+                     "oovPOS": ["名詞", "普通名詞", "一般", "*", "*", "*"],
+                     "leftId": 8,
+                     "rightId": 8,
+                     "cost": 6000}
+                ],
+                "pathRewritePlugin": [
+                    {"class": "com.worksap.nlp.sudachi.JoinNumericPlugin",
+                     "enableNormalize": True},
+                    {"class": "com.worksap.nlp.sudachi.JoinKatakanaOovPlugin",
+                     "oovPOS": ["名詞", "普通名詞", "一般", "*", "*", "*"],
+                     "minLength": 3}
+                ]
+            }), encoding="utf-8")
+
+            dictionary = Dictionary(str(config_path), resource_dir=str(resource_dir))
+            try:
+                morphemes = dictionary.lookup("東京都")
+                self.assertEqual(1, len(morphemes))
+                self.assertEqual("トウキョウト", morphemes[0].reading_form())
             finally:
                 dictionary.close()
 

--- a/sudachi/src/config.rs
+++ b/sudachi/src/config.rs
@@ -17,7 +17,7 @@
 use std::convert::TryFrom;
 use std::env::current_exe;
 use std::fs::File;
-use std::io::BufReader;
+use std::io::{BufRead, BufReader, Cursor};
 use std::path::{Path, PathBuf};
 
 use crate::dic::subset::InfoSubset;
@@ -27,10 +27,14 @@ use serde::Deserialize;
 use serde_json::Value;
 use thiserror::Error;
 
-const DEFAULT_RESOURCE_DIR: &str = "resources";
 const DEFAULT_SETTING_FILE: &str = "sudachi.json";
 const DEFAULT_SETTING_BYTES: &[u8] = include_bytes!("../../resources/sudachi.json");
-const DEFAULT_CHAR_DEF_FILE: &str = "char.def";
+pub(crate) const DEFAULT_CHAR_DEF_FILE: &str = "char.def";
+pub(crate) const DEFAULT_CHAR_DEF_BYTES: &[u8] = include_bytes!("../../resources/char.def");
+pub(crate) const DEFAULT_UNK_DEF_FILE: &str = "unk.def";
+const DEFAULT_UNK_DEF_BYTES: &[u8] = include_bytes!("../../resources/unk.def");
+pub(crate) const DEFAULT_REWRITE_DEF_FILE: &str = "rewrite.def";
+const DEFAULT_REWRITE_DEF_BYTES: &[u8] = include_bytes!("../../resources/rewrite.def");
 
 /// Sudachi Error
 #[derive(Error, Debug)]
@@ -50,13 +54,100 @@ pub enum ConfigError {
     #[error("Argument {0} is missing")]
     MissingArgument(String),
 
+    #[error("{0} is only available as an embedded resource")]
+    EmbeddedResourcePath(String),
+
     #[error("Failed to resolve relative path {0}, tried: {1:?}")]
     PathResolution(String, Vec<String>),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EmbeddedResource {
+    Config,
+    CharDef,
+    UnkDef,
+    RewriteDef,
+}
+
+impl EmbeddedResource {
+    fn name(self) -> &'static str {
+        match self {
+            EmbeddedResource::Config => DEFAULT_SETTING_FILE,
+            EmbeddedResource::CharDef => DEFAULT_CHAR_DEF_FILE,
+            EmbeddedResource::UnkDef => DEFAULT_UNK_DEF_FILE,
+            EmbeddedResource::RewriteDef => DEFAULT_REWRITE_DEF_FILE,
+        }
+    }
+
+    fn bytes(self) -> &'static [u8] {
+        match self {
+            EmbeddedResource::Config => DEFAULT_SETTING_BYTES,
+            EmbeddedResource::CharDef => DEFAULT_CHAR_DEF_BYTES,
+            EmbeddedResource::UnkDef => DEFAULT_UNK_DEF_BYTES,
+            EmbeddedResource::RewriteDef => DEFAULT_REWRITE_DEF_BYTES,
+        }
+    }
+
+    fn from_path<P: AsRef<Path>>(path: P) -> Option<Self> {
+        let path = path.as_ref();
+        if path.is_absolute() || path.components().count() != 1 {
+            return None;
+        }
+        match path.to_str()? {
+            DEFAULT_SETTING_FILE => Some(EmbeddedResource::Config),
+            DEFAULT_CHAR_DEF_FILE => Some(EmbeddedResource::CharDef),
+            DEFAULT_UNK_DEF_FILE => Some(EmbeddedResource::UnkDef),
+            DEFAULT_REWRITE_DEF_FILE => Some(EmbeddedResource::RewriteDef),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ResolvedResource {
+    Path(PathBuf),
+    Embedded(EmbeddedResource),
+}
+
+impl ResolvedResource {
+    pub fn read_bytes(self) -> Result<Vec<u8>, ConfigError> {
+        match self {
+            ResolvedResource::Path(path) => std::fs::read(path).map_err(ConfigError::from),
+            ResolvedResource::Embedded(resource) => Ok(resource.bytes().to_vec()),
+        }
+    }
+
+    pub fn reader(self) -> Result<Box<dyn BufRead>, ConfigError> {
+        match self {
+            ResolvedResource::Path(path) => {
+                let file = File::open(path)?;
+                Ok(Box::new(BufReader::new(file)))
+            }
+            ResolvedResource::Embedded(resource) => {
+                Ok(Box::new(BufReader::new(Cursor::new(resource.bytes()))))
+            }
+        }
+    }
+
+    pub fn into_path(self) -> Result<PathBuf, ConfigError> {
+        match self {
+            ResolvedResource::Path(path) => Ok(path),
+            ResolvedResource::Embedded(resource) => Err(ConfigError::EmbeddedResourcePath(
+                resource.name().to_owned(),
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ResolverRoot {
+    Filesystem(PathBuf),
+    Embedded,
+}
+
 #[derive(Default, Debug, Clone)]
 struct PathResolver {
-    roots: Vec<PathBuf>,
+    roots: Vec<ResolverRoot>,
 }
 
 impl PathResolver {
@@ -67,23 +158,41 @@ impl PathResolver {
     }
 
     fn add<P: Into<PathBuf>>(&mut self, path: P) {
-        self.roots.push(path.into())
+        self.roots.push(ResolverRoot::Filesystem(path.into()))
+    }
+
+    fn add_embedded(&mut self) {
+        self.roots.push(ResolverRoot::Embedded)
     }
 
     fn contains<P: AsRef<Path>>(&self, path: P) -> bool {
         let query = path.as_ref();
-        self.roots.iter().any(|p| p.as_path() == query)
+        self.roots.iter().any(|p| match p {
+            ResolverRoot::Filesystem(root) => root.as_path() == query,
+            ResolverRoot::Embedded => false,
+        })
     }
 
-    pub fn first_existing<P: AsRef<Path> + Clone>(&self, path: P) -> Option<PathBuf> {
-        self.all_candidates(path).find(|p| p.exists())
+    fn contains_embedded(&self) -> bool {
+        self.roots.contains(&ResolverRoot::Embedded)
+    }
+
+    pub fn first_existing<P: AsRef<Path> + Clone>(&self, path: P) -> Option<ResolvedResource> {
+        self.roots.iter().find_map(|root| match root {
+            ResolverRoot::Filesystem(base) => {
+                let candidate = base.join(path.clone());
+                candidate
+                    .exists()
+                    .then_some(ResolvedResource::Path(candidate))
+            }
+            ResolverRoot::Embedded => {
+                EmbeddedResource::from_path(path.clone()).map(ResolvedResource::Embedded)
+            }
+        })
     }
 
     pub fn resolution_failure<P: AsRef<Path> + Clone>(&self, path: P) -> ConfigError {
-        let candidates = self
-            .all_candidates(path.clone())
-            .map(|p| p.to_string_lossy().into_owned())
-            .collect();
+        let candidates = self.all_candidates(path.clone()).collect();
 
         ConfigError::PathResolution(path.as_ref().to_string_lossy().into_owned(), candidates)
     }
@@ -91,12 +200,20 @@ impl PathResolver {
     pub fn all_candidates<'a, P: AsRef<Path> + Clone + 'a>(
         &'a self,
         path: P,
-    ) -> impl Iterator<Item = PathBuf> + 'a {
-        self.roots.iter().map(move |root| root.join(path.clone()))
+    ) -> impl Iterator<Item = String> + 'a {
+        self.roots.iter().map(move |root| match root {
+            ResolverRoot::Filesystem(base) => {
+                base.join(path.clone()).to_string_lossy().into_owned()
+            }
+            ResolverRoot::Embedded => format!("<embedded>/{}", path.as_ref().display()),
+        })
     }
 
-    pub fn roots(&self) -> &[PathBuf] {
-        &self.roots
+    pub fn filesystem_roots(&self) -> impl Iterator<Item = &PathBuf> {
+        self.roots.iter().filter_map(|root| match root {
+            ResolverRoot::Filesystem(path) => Some(path),
+            ResolverRoot::Embedded => None,
+        })
     }
 }
 
@@ -168,15 +285,18 @@ pub struct Config {
 #[allow(non_snake_case)]
 #[derive(Deserialize, Debug, Clone)]
 pub struct ConfigBuilder {
-    /// Analogue to Java Implementation path Override    
+    /// Analogue to Java Implementation path Override.
     path: Option<PathBuf>,
-    /// User-passed resourcePath
+    /// User-passed resourcePath.
     #[serde(skip)]
     resourcePath: Option<PathBuf>,
     /// User-passed root directory.
-    /// Is also automatically set on from_file
+    /// Is also automatically set on from_file.
     #[serde(skip)]
     rootDirectory: Option<PathBuf>,
+    /// Use embedded resource data if true.
+    #[serde(skip)]
+    embedded_resources: bool,
     #[serde(alias = "system")]
     systemDict: Option<PathBuf>,
     #[serde(alias = "user")]
@@ -189,21 +309,6 @@ pub struct ConfigBuilder {
     projection: Option<SurfaceProjection>,
 }
 
-pub fn default_resource_dir() -> PathBuf {
-    let mut src_root_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if !src_root_path.pop() {
-        src_root_path.push("..");
-    }
-    src_root_path.push(DEFAULT_RESOURCE_DIR);
-    src_root_path
-}
-
-pub fn default_config_location() -> PathBuf {
-    let mut resdir = default_resource_dir();
-    resdir.push(DEFAULT_SETTING_FILE);
-    resdir
-}
-
 macro_rules! merge_cfg_value {
     ($base: ident, $o: ident, $name: tt) => {
         $base.$name = $base.$name.or_else(|| $o.$name.clone())
@@ -213,10 +318,7 @@ macro_rules! merge_cfg_value {
 impl ConfigBuilder {
     pub fn from_opt_file(config_file: Option<&Path>) -> Result<Self, ConfigError> {
         match config_file {
-            None => {
-                let default_config = default_config_location();
-                Self::from_file(&default_config)
-            }
+            None => Self::from_embedded(),
             Some(cfg) => Self::from_file(cfg),
         }
     }
@@ -234,6 +336,10 @@ impl ConfigBuilder {
 
     pub fn from_bytes(data: &[u8]) -> Result<Self, ConfigError> {
         serde_json::from_slice(data).map_err(|e| e.into())
+    }
+
+    pub fn from_embedded() -> Result<Self, ConfigError> {
+        Self::from_bytes(DEFAULT_SETTING_BYTES)
     }
 
     pub fn empty() -> Self {
@@ -267,10 +373,12 @@ impl ConfigBuilder {
         self
     }
 
-    pub fn build(self) -> Config {
-        let default_resource_dir = default_resource_dir();
-        let resource_dir = self.resourcePath.unwrap_or(default_resource_dir);
+    pub fn embedded_resources(mut self, enabled: bool) -> Self {
+        self.embedded_resources = enabled;
+        self
+    }
 
+    pub fn build(self) -> Config {
         let mut resolver = PathResolver::with_capacity(3);
         let mut add_path = |buf: PathBuf| {
             if !resolver.contains(&buf) {
@@ -278,8 +386,11 @@ impl ConfigBuilder {
             }
         };
         self.path.map(&mut add_path);
-        add_path(resource_dir);
+        self.resourcePath.map(&mut add_path);
         self.rootDirectory.map(&mut add_path);
+        if self.embedded_resources && !resolver.contains_embedded() {
+            resolver.add_embedded();
+        }
 
         let character_definition_file = self
             .characterDefinitionFile
@@ -311,6 +422,7 @@ impl ConfigBuilder {
         merge_cfg_value!(self, other, oovProviderPlugin);
         merge_cfg_value!(self, other, pathRewritePlugin);
         merge_cfg_value!(self, other, projection);
+        self.embedded_resources |= other.embedded_resources;
         self
     }
 }
@@ -326,21 +438,21 @@ impl Config {
 
         // prioritize arg (cli option) > config file
         let raw_config = match resource_dir {
-            None => raw_config,
             Some(p) => raw_config.resource_path(p),
+            None => raw_config,
         };
 
         // prioritize arg (cli option) > config file
         let raw_config = match dictionary_path {
-            None => raw_config,
             Some(p) => raw_config.system_dict(p),
+            None => raw_config,
         };
 
         Ok(raw_config.build())
     }
 
     pub fn new_embedded() -> Result<Self, ConfigError> {
-        let raw_config = ConfigBuilder::from_bytes(DEFAULT_SETTING_BYTES)?;
+        let raw_config = ConfigBuilder::from_embedded()?;
 
         Ok(raw_config.build())
     }
@@ -349,7 +461,7 @@ impl Config {
     pub fn minimal_at(resource_dir: impl Into<PathBuf>) -> Config {
         let mut cfg = Config::default();
         let resource = resource_dir.into();
-        cfg.character_definition_file = resource.join(DEFAULT_CHAR_DEF_FILE);
+        cfg.character_definition_file = PathBuf::from(DEFAULT_CHAR_DEF_FILE);
         let mut resolver = PathResolver::with_capacity(1);
         resolver.add(resource);
         cfg.resolver = resolver;
@@ -379,10 +491,9 @@ impl Config {
         }
 
         if path.starts_with("$cfg/") || path.starts_with("$cfg\\") {
-            let roots = self.resolver.roots();
-            let mut result = Vec::with_capacity(roots.len());
+            let mut result = Vec::new();
             path.replace_range(0..5, "");
-            for root in roots {
+            for root in self.resolver.filesystem_roots() {
                 let subpath = root.join(&path);
                 result.push(subpath.to_string_lossy().into_owned());
             }
@@ -401,10 +512,17 @@ impl Config {
         &self,
         file_path: P,
     ) -> Result<PathBuf, ConfigError> {
+        self.resolve_resource(file_path)?.into_path()
+    }
+
+    pub(crate) fn resolve_resource<P: AsRef<Path> + Into<PathBuf>>(
+        &self,
+        file_path: P,
+    ) -> Result<ResolvedResource, ConfigError> {
         let pref = file_path.as_ref();
         // 1. absolute paths are not normalized
         if pref.is_absolute() {
-            return Ok(file_path.into());
+            return Ok(ResolvedResource::Path(file_path.into()));
         }
 
         // 2. try to resolve paths wrt anchors
@@ -414,7 +532,7 @@ impl Config {
 
         // 3. try to resolve path wrt CWD
         if pref.exists() {
-            return Ok(file_path.into());
+            return Ok(ResolvedResource::Path(file_path.into()));
         }
 
         // Report an error
@@ -473,10 +591,7 @@ mod tests {
     fn resolve_cfg() -> SudachiResult<()> {
         let cfg = Config::new(None, None, None)?;
         let npath = cfg.resolve_paths("$cfg/data".to_owned());
-        let def = default_resource_dir();
-        let path_dir: &str = def.to_str().unwrap();
-        assert_eq!(1, npath.len());
-        assert!(npath[0].starts_with(path_dir));
+        assert!(npath.is_empty());
         Ok(())
     }
 
@@ -487,6 +602,34 @@ mod tests {
         let cfg2 = ConfigBuilder::empty();
         let cfg2 = cfg2.fallback(&cfg);
         assert_eq!(cfg2.path, Some("test".into()));
+    }
+
+    #[test]
+    fn embedded_resources_are_enabled_by_default() -> SudachiResult<()> {
+        let cfg = ConfigBuilder::empty().build();
+        let res = cfg.resolve_resource(DEFAULT_CHAR_DEF_FILE)?;
+        assert!(matches!(
+            res,
+            ResolvedResource::Embedded(EmbeddedResource::CharDef)
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn embedded_resources_can_be_disabled() {
+        let cfg = ConfigBuilder::empty().embedded_resources(false).build();
+        let err = cfg.resolve_resource(DEFAULT_CHAR_DEF_FILE).unwrap_err();
+        assert!(matches!(err, ConfigError::PathResolution(_, _)));
+    }
+
+    #[test]
+    fn embedded_resource_can_not_be_forced_into_path() {
+        let cfg = ConfigBuilder::empty().build();
+        let err = cfg.complete_path(DEFAULT_CHAR_DEF_FILE).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::EmbeddedResourcePath(name) if name == DEFAULT_CHAR_DEF_FILE
+        ));
     }
 
     #[test]

--- a/sudachi/src/config.rs
+++ b/sudachi/src/config.rs
@@ -517,6 +517,16 @@ pub struct Config {
 }
 
 impl Config {
+    /// Creates a config from optional config, resource, and dictionary paths.
+    ///
+    /// Resolution precedence is:
+    /// 1. `resource_dir` (if given).
+    /// 2. The `path` field in the `config_file` (if set).
+    /// 3. The parent directory of the `config_file` (if given).
+    /// 4. The default (embedded) resources.
+    ///
+    /// When `config_file` is `None`, the embedded default `sudachi.json` is used as config
+    /// data.
     pub fn new(
         config_file: Option<PathBuf>,
         resource_dir: Option<PathBuf>,
@@ -527,9 +537,10 @@ impl Config {
 
         // prioritize arg (cli option) > config file
         let raw_config = match resource_dir {
-            Some(p) => raw_config.push_resolver_root(p),
+            Some(p) => raw_config.prepend_resolver_root(p),
             None => raw_config,
-        };
+        }
+        .push_embedded();
 
         // prioritize arg (cli option) > config file
         let raw_config = match dictionary_path {

--- a/sudachi/src/config.rs
+++ b/sudachi/src/config.rs
@@ -155,11 +155,32 @@ impl PathResolver {
         Self::default()
     }
 
+    pub fn from_path<P: Into<PathBuf>>(path: P) -> Self {
+        let mut resolver = Self::new();
+        resolver.push_root(path);
+        resolver
+    }
+
+    pub fn from_embedded() -> Self {
+        let mut resolver = Self::new();
+        resolver.push_embedded();
+        resolver
+    }
+
     pub fn push_root<P: Into<PathBuf>>(&mut self, path: P) {
         let path = path.into();
         if !self.contains(&path) {
             self.roots.push(ResolverRoot::Filesystem(path))
         }
+    }
+
+    pub fn prepend_root<P: Into<PathBuf>>(&mut self, path: P) {
+        let path = path.into();
+        self.roots.retain(|root| match root {
+            ResolverRoot::Filesystem(existing) => existing != &path,
+            ResolverRoot::Embedded => true,
+        });
+        self.roots.insert(0, ResolverRoot::Filesystem(path));
     }
 
     pub fn push_embedded(&mut self) {
@@ -168,11 +189,25 @@ impl PathResolver {
         }
     }
 
+    pub fn prepend_embedded(&mut self) {
+        self.roots.retain(|root| root != &ResolverRoot::Embedded);
+        self.roots.insert(0, ResolverRoot::Embedded);
+    }
+
     pub fn append(&mut self, other: PathResolver) {
         for root in other.roots {
             match root {
                 ResolverRoot::Filesystem(path) => self.push_root(path),
                 ResolverRoot::Embedded => self.push_embedded(),
+            }
+        }
+    }
+
+    pub fn prepend(&mut self, other: PathResolver) {
+        for root in other.roots.into_iter().rev() {
+            match root {
+                ResolverRoot::Filesystem(path) => self.prepend_root(path),
+                ResolverRoot::Embedded => self.prepend_embedded(),
             }
         }
     }
@@ -272,23 +307,6 @@ impl TryFrom<&str> for SurfaceProjection {
             _ => Err(ConfigError::InvalidFormat(format!("unknown projection: {value}")).into()),
         }
     }
-}
-
-/// Setting data loaded from config file
-#[derive(Debug, Default, Clone)]
-pub struct Config {
-    /// Paths will be resolved against these roots, until a file will be found
-    resolver: PathResolver,
-    pub system_dict: Option<PathBuf>,
-    pub user_dicts: Vec<PathBuf>,
-    pub character_definition_file: PathBuf,
-
-    pub connection_cost_plugins: Vec<Value>,
-    pub input_text_plugins: Vec<Value>,
-    pub oov_provider_plugins: Vec<Value>,
-    pub path_rewrite_plugins: Vec<Value>,
-    // this option is Python-only and is ignored in Rust APIs
-    pub projection: SurfaceProjection,
 }
 
 /// Struct corresponds with raw config json file.
@@ -399,6 +417,16 @@ impl ConfigBuilder {
         self
     }
 
+    pub fn character_definition_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.data.characterDefinitionFile = Some(path.into());
+        self
+    }
+
+    pub fn projection(mut self, projection: SurfaceProjection) -> Self {
+        self.data.projection = Some(projection);
+        self
+    }
+
     pub fn with_resolver(mut self, resolver: PathResolver) -> Self {
         self.resolver = resolver;
         self
@@ -409,8 +437,18 @@ impl ConfigBuilder {
         self
     }
 
+    pub fn prepend_resolver(mut self, other: PathResolver) -> Self {
+        self.resolver.prepend(other);
+        self
+    }
+
     pub fn push_resolver_root(mut self, path: impl Into<PathBuf>) -> Self {
         self.resolver.push_root(path);
+        self
+    }
+
+    pub fn prepend_resolver_root(mut self, path: impl Into<PathBuf>) -> Self {
+        self.resolver.prepend_root(path);
         self
     }
 
@@ -461,6 +499,23 @@ impl ConfigBuilder {
     }
 }
 
+/// Setting data loaded from config file
+#[derive(Debug, Default, Clone)]
+pub struct Config {
+    /// Paths will be resolved against these roots, until a file will be found
+    pub resolver: PathResolver,
+    pub system_dict: Option<PathBuf>,
+    pub user_dicts: Vec<PathBuf>,
+    pub character_definition_file: PathBuf,
+
+    pub connection_cost_plugins: Vec<Value>,
+    pub input_text_plugins: Vec<Value>,
+    pub oov_provider_plugins: Vec<Value>,
+    pub path_rewrite_plugins: Vec<Value>,
+    // this option is Python-only and is ignored in Rust APIs
+    pub projection: SurfaceProjection,
+}
+
 impl Config {
     pub fn new(
         config_file: Option<PathBuf>,
@@ -491,15 +546,12 @@ impl Config {
 
     pub fn new_embedded() -> Result<Self, ConfigError> {
         let raw_config = ConfigBuilder::from_embedded()?.push_embedded();
-
         Ok(raw_config.build())
     }
 
-    /// Creates a minimal config with the provided resource directory
-    pub fn minimal_at(resource_dir: impl Into<PathBuf>) -> Config {
-        let mut cfg = ConfigBuilder::empty()
-            .push_resolver_root(resource_dir)
-            .build();
+    /// Creates a minimal config with the provided path resolver
+    pub fn minimal_at(resolver: PathResolver) -> Config {
+        let mut cfg = ConfigBuilder::empty().append_resolver(resolver).build();
         cfg.oov_provider_plugins = vec![serde_json::json!(
             { "class" : "com.worksap.nlp.sudachi.SimpleOovPlugin",
               "oovPOS" : [ "名詞", "普通名詞", "一般", "*", "*", "*" ],
@@ -679,10 +731,38 @@ mod tests {
     }
 
     #[test]
+    fn prepend_resolver_root_takes_priority() {
+        let cfg = ConfigBuilder::from_bytes(br#"{ "path": "config-root" }"#)
+            .unwrap()
+            .prepend_resolver_root("resource-root");
+        let roots: Vec<_> = cfg.resolver.filesystem_roots().cloned().collect();
+        assert_eq!(
+            roots,
+            vec![PathBuf::from("resource-root"), PathBuf::from("config-root")]
+        );
+    }
+
+    #[test]
     fn surface_projection_tryfrom() {
         assert_eq!(
             SurfaceProjection::Surface,
             SurfaceProjection::try_from("surface").unwrap()
         );
+    }
+
+    #[test]
+    fn config_builder_sets_character_definition_file() {
+        let cfg = ConfigBuilder::empty()
+            .character_definition_file("custom.def")
+            .build();
+        assert_eq!(cfg.character_definition_file, PathBuf::from("custom.def"));
+    }
+
+    #[test]
+    fn config_builder_sets_projection() {
+        let cfg = ConfigBuilder::empty()
+            .projection(SurfaceProjection::Reading)
+            .build();
+        assert_eq!(cfg.projection, SurfaceProjection::Reading);
     }
 }

--- a/sudachi/src/config.rs
+++ b/sudachi/src/config.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 use crate::dic::subset::InfoSubset;
 use crate::error::SudachiError;
 use lazy_static::lazy_static;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 
@@ -146,23 +146,35 @@ enum ResolverRoot {
 }
 
 #[derive(Default, Debug, Clone)]
-struct PathResolver {
+pub struct PathResolver {
     roots: Vec<ResolverRoot>,
 }
 
 impl PathResolver {
-    fn with_capacity(capacity: usize) -> PathResolver {
-        PathResolver {
-            roots: Vec::with_capacity(capacity),
+    pub fn new() -> PathResolver {
+        Self::default()
+    }
+
+    pub fn push_root<P: Into<PathBuf>>(&mut self, path: P) {
+        let path = path.into();
+        if !self.contains(&path) {
+            self.roots.push(ResolverRoot::Filesystem(path))
         }
     }
 
-    fn add<P: Into<PathBuf>>(&mut self, path: P) {
-        self.roots.push(ResolverRoot::Filesystem(path.into()))
+    pub fn push_embedded(&mut self) {
+        if !self.contains_embedded() {
+            self.roots.push(ResolverRoot::Embedded)
+        }
     }
 
-    fn add_embedded(&mut self) {
-        self.roots.push(ResolverRoot::Embedded)
+    pub fn append(&mut self, other: PathResolver) {
+        for root in other.roots {
+            match root {
+                ResolverRoot::Filesystem(path) => self.push_root(path),
+                ResolverRoot::Embedded => self.push_embedded(),
+            }
+        }
     }
 
     fn contains<P: AsRef<Path>>(&self, path: P) -> bool {
@@ -177,7 +189,7 @@ impl PathResolver {
         self.roots.contains(&ResolverRoot::Embedded)
     }
 
-    pub fn first_existing<P: AsRef<Path> + Clone>(&self, path: P) -> Option<ResolvedResource> {
+    fn first_existing<P: AsRef<Path> + Clone>(&self, path: P) -> Option<ResolvedResource> {
         self.roots.iter().find_map(|root| match root {
             ResolverRoot::Filesystem(base) => {
                 let candidate = base.join(path.clone());
@@ -191,13 +203,13 @@ impl PathResolver {
         })
     }
 
-    pub fn resolution_failure<P: AsRef<Path> + Clone>(&self, path: P) -> ConfigError {
+    fn resolution_failure<P: AsRef<Path> + Clone>(&self, path: P) -> ConfigError {
         let candidates = self.all_candidates(path.clone()).collect();
 
         ConfigError::PathResolution(path.as_ref().to_string_lossy().into_owned(), candidates)
     }
 
-    pub fn all_candidates<'a, P: AsRef<Path> + Clone + 'a>(
+    fn all_candidates<'a, P: AsRef<Path> + Clone + 'a>(
         &'a self,
         path: P,
     ) -> impl Iterator<Item = String> + 'a {
@@ -209,7 +221,7 @@ impl PathResolver {
         })
     }
 
-    pub fn filesystem_roots(&self) -> impl Iterator<Item = &PathBuf> {
+    fn filesystem_roots(&self) -> impl Iterator<Item = &PathBuf> {
         self.roots.iter().filter_map(|root| match root {
             ResolverRoot::Filesystem(path) => Some(path),
             ResolverRoot::Embedded => None,
@@ -217,7 +229,7 @@ impl PathResolver {
     }
 }
 
-#[derive(Deserialize, Clone, Copy, Debug, Eq, PartialEq, Default)]
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, Eq, PartialEq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum SurfaceProjection {
     #[default]
@@ -283,20 +295,10 @@ pub struct Config {
 /// You must use filed names defined here as json object key.
 /// For plugins, refer to each plugin.
 #[allow(non_snake_case)]
-#[derive(Deserialize, Debug, Clone)]
-pub struct ConfigBuilder {
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+pub struct RawConfig {
     /// Analogue to Java Implementation path Override.
     path: Option<PathBuf>,
-    /// User-passed resourcePath.
-    #[serde(skip)]
-    resourcePath: Option<PathBuf>,
-    /// User-passed root directory.
-    /// Is also automatically set on from_file.
-    #[serde(skip)]
-    rootDirectory: Option<PathBuf>,
-    /// Use embedded resource data if true.
-    #[serde(skip)]
-    embedded_resources: bool,
     #[serde(alias = "system")]
     systemDict: Option<PathBuf>,
     #[serde(alias = "user")]
@@ -309,13 +311,33 @@ pub struct ConfigBuilder {
     projection: Option<SurfaceProjection>,
 }
 
+#[derive(Debug, Clone, Default)]
+/// Editable configuration source consisting of normalized config data and
+/// explicit resource-resolution state.
+pub struct ConfigBuilder {
+    data: RawConfig,
+    resolver: PathResolver,
+}
+
 macro_rules! merge_cfg_value {
-    ($base: ident, $o: ident, $name: tt) => {
+    ($base: expr, $o: expr, $name: tt) => {
         $base.$name = $base.$name.or_else(|| $o.$name.clone())
     };
 }
 
 impl ConfigBuilder {
+    /// Creates a builder from already-deserialized config data.
+    ///
+    /// If the raw config contains `path`, it is immediately appended to the
+    /// resolver so runtime resolution state is explicit from construction time.
+    fn from_data(data: RawConfig) -> Self {
+        let mut resolver = PathResolver::new();
+        if let Some(path) = data.path.clone() {
+            resolver.push_root(path);
+        }
+        Self { data, resolver }
+    }
+
     pub fn from_opt_file(config_file: Option<&Path>) -> Result<Self, ConfigError> {
         match config_file {
             None => Self::from_embedded(),
@@ -323,39 +345,53 @@ impl ConfigBuilder {
         }
     }
 
+    /// Loads config JSON from a file.
+    ///
+    /// The resulting builder contains the deserialized config data, appends the
+    /// config's `path` field to the resolver if present, and then appends the
+    /// parent directory of `config_file` as an additional filesystem root.
     pub fn from_file(config_file: &Path) -> Result<Self, ConfigError> {
         let file = File::open(config_file)?;
         let reader = BufReader::new(file);
-        serde_json::from_reader(reader)
-            .map_err(|e| e.into())
-            .map(|cfg: ConfigBuilder| match config_file.parent() {
-                Some(p) => cfg.root_directory(p),
-                None => cfg,
-            })
+        let data: RawConfig = serde_json::from_reader(reader).map_err(ConfigError::from)?;
+        let mut cfg = Self::from_data(data);
+        if let Some(parent) = config_file.parent() {
+            cfg.resolver.push_root(parent);
+        }
+        Ok(cfg)
     }
 
+    /// Loads config JSON from raw bytes.
+    ///
+    /// The resulting builder contains the deserialized config data and appends
+    /// the config's `path` field to the resolver if present.
     pub fn from_bytes(data: &[u8]) -> Result<Self, ConfigError> {
-        serde_json::from_slice(data).map_err(|e| e.into())
+        let data = serde_json::from_slice(data).map_err(ConfigError::from)?;
+        Ok(Self::from_data(data))
     }
 
+    /// Loads the bundled default config JSON.
+    ///
+    /// This only loads the embedded JSON contents; embedded resources
+    /// themselves are not enabled unless `push_embedded()` is called.
     pub fn from_embedded() -> Result<Self, ConfigError> {
         Self::from_bytes(DEFAULT_SETTING_BYTES)
     }
 
     pub fn empty() -> Self {
-        serde_json::from_slice(b"{}").unwrap()
+        Self::default()
     }
 
     pub fn system_dict(mut self, dict: impl Into<PathBuf>) -> Self {
-        self.systemDict = Some(dict.into());
+        self.data.systemDict = Some(dict.into());
         self
     }
 
     pub fn user_dict(mut self, dict: impl Into<PathBuf>) -> Self {
-        let dicts = match self.userDict.as_mut() {
+        let dicts = match self.data.userDict.as_mut() {
             None => {
-                self.userDict = Some(Default::default());
-                self.userDict.as_mut().unwrap()
+                self.data.userDict = Some(Default::default());
+                self.data.userDict.as_mut().unwrap()
             }
             Some(dicts) => dicts,
         };
@@ -363,67 +399,65 @@ impl ConfigBuilder {
         self
     }
 
-    pub fn resource_path(mut self, path: impl Into<PathBuf>) -> Self {
-        self.resourcePath = Some(path.into());
+    pub fn with_resolver(mut self, resolver: PathResolver) -> Self {
+        self.resolver = resolver;
         self
     }
 
-    pub fn root_directory(mut self, path: impl Into<PathBuf>) -> Self {
-        self.rootDirectory = Some(path.into());
+    pub fn append_resolver(mut self, other: PathResolver) -> Self {
+        self.resolver.append(other);
         self
     }
 
-    pub fn embedded_resources(mut self, enabled: bool) -> Self {
-        self.embedded_resources = enabled;
+    pub fn push_resolver_root(mut self, path: impl Into<PathBuf>) -> Self {
+        self.resolver.push_root(path);
         self
+    }
+
+    pub fn push_embedded(mut self) -> Self {
+        self.resolver.push_embedded();
+        self
+    }
+
+    pub fn fallback_data(mut self, other: &ConfigBuilder) -> ConfigBuilder {
+        merge_cfg_value!(self.data, other.data, path);
+        merge_cfg_value!(self.data, other.data, systemDict);
+        merge_cfg_value!(self.data, other.data, userDict);
+        merge_cfg_value!(self.data, other.data, characterDefinitionFile);
+        merge_cfg_value!(self.data, other.data, connectionCostPlugin);
+        merge_cfg_value!(self.data, other.data, inputTextPlugin);
+        merge_cfg_value!(self.data, other.data, oovProviderPlugin);
+        merge_cfg_value!(self.data, other.data, pathRewritePlugin);
+        merge_cfg_value!(self.data, other.data, projection);
+        self
+    }
+
+    pub fn raw_config(&self) -> &RawConfig {
+        &self.data
+    }
+
+    pub fn into_raw_config(self) -> RawConfig {
+        self.data
     }
 
     pub fn build(self) -> Config {
-        let mut resolver = PathResolver::with_capacity(3);
-        let mut add_path = |buf: PathBuf| {
-            if !resolver.contains(&buf) {
-                resolver.add(buf);
-            }
-        };
-        self.path.map(&mut add_path);
-        self.resourcePath.map(&mut add_path);
-        self.rootDirectory.map(&mut add_path);
-        if self.embedded_resources && !resolver.contains_embedded() {
-            resolver.add_embedded();
-        }
-
         let character_definition_file = self
+            .data
             .characterDefinitionFile
             .unwrap_or(PathBuf::from(DEFAULT_CHAR_DEF_FILE));
 
         Config {
-            resolver,
-            system_dict: self.systemDict,
-            user_dicts: self.userDict.unwrap_or_default(),
+            resolver: self.resolver,
+            system_dict: self.data.systemDict,
+            user_dicts: self.data.userDict.unwrap_or_default(),
             character_definition_file,
 
-            connection_cost_plugins: self.connectionCostPlugin.unwrap_or_default(),
-            input_text_plugins: self.inputTextPlugin.unwrap_or_default(),
-            oov_provider_plugins: self.oovProviderPlugin.unwrap_or_default(),
-            path_rewrite_plugins: self.pathRewritePlugin.unwrap_or_default(),
-            projection: self.projection.unwrap_or(SurfaceProjection::Surface),
+            connection_cost_plugins: self.data.connectionCostPlugin.unwrap_or_default(),
+            input_text_plugins: self.data.inputTextPlugin.unwrap_or_default(),
+            oov_provider_plugins: self.data.oovProviderPlugin.unwrap_or_default(),
+            path_rewrite_plugins: self.data.pathRewritePlugin.unwrap_or_default(),
+            projection: self.data.projection.unwrap_or(SurfaceProjection::Surface),
         }
-    }
-
-    pub fn fallback(mut self, other: &ConfigBuilder) -> ConfigBuilder {
-        merge_cfg_value!(self, other, path);
-        merge_cfg_value!(self, other, resourcePath);
-        merge_cfg_value!(self, other, rootDirectory);
-        merge_cfg_value!(self, other, systemDict);
-        merge_cfg_value!(self, other, userDict);
-        merge_cfg_value!(self, other, characterDefinitionFile);
-        merge_cfg_value!(self, other, connectionCostPlugin);
-        merge_cfg_value!(self, other, inputTextPlugin);
-        merge_cfg_value!(self, other, oovProviderPlugin);
-        merge_cfg_value!(self, other, pathRewritePlugin);
-        merge_cfg_value!(self, other, projection);
-        self.embedded_resources |= other.embedded_resources;
-        self
     }
 }
 
@@ -438,7 +472,7 @@ impl Config {
 
         // prioritize arg (cli option) > config file
         let raw_config = match resource_dir {
-            Some(p) => raw_config.resource_path(p),
+            Some(p) => raw_config.push_resolver_root(p),
             None => raw_config,
         };
 
@@ -451,20 +485,21 @@ impl Config {
         Ok(raw_config.build())
     }
 
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
     pub fn new_embedded() -> Result<Self, ConfigError> {
-        let raw_config = ConfigBuilder::from_embedded()?;
+        let raw_config = ConfigBuilder::from_embedded()?.push_embedded();
 
         Ok(raw_config.build())
     }
 
     /// Creates a minimal config with the provided resource directory
     pub fn minimal_at(resource_dir: impl Into<PathBuf>) -> Config {
-        let mut cfg = Config::default();
-        let resource = resource_dir.into();
-        cfg.character_definition_file = PathBuf::from(DEFAULT_CHAR_DEF_FILE);
-        let mut resolver = PathResolver::with_capacity(1);
-        resolver.add(resource);
-        cfg.resolver = resolver;
+        let mut cfg = ConfigBuilder::empty()
+            .push_resolver_root(resource_dir)
+            .build();
         cfg.oov_provider_plugins = vec![serde_json::json!(
             { "class" : "com.worksap.nlp.sudachi.SimpleOovPlugin",
               "oovPOS" : [ "名詞", "普通名詞", "一般", "*", "*", "*" ],
@@ -597,16 +632,15 @@ mod tests {
 
     #[test]
     fn config_builder_fallback() {
-        let mut cfg = ConfigBuilder::empty();
-        cfg.path = Some("test".into());
+        let cfg = ConfigBuilder::from_bytes(br#"{ "path": "test" }"#).unwrap();
         let cfg2 = ConfigBuilder::empty();
-        let cfg2 = cfg2.fallback(&cfg);
-        assert_eq!(cfg2.path, Some("test".into()));
+        let cfg2 = cfg2.fallback_data(&cfg);
+        assert_eq!(cfg2.raw_config().path, Some("test".into()));
     }
 
     #[test]
-    fn embedded_resources_are_enabled_by_default() -> SudachiResult<()> {
-        let cfg = ConfigBuilder::empty().build();
+    fn embedded_resources_can_be_enabled_explicitly() -> SudachiResult<()> {
+        let cfg = ConfigBuilder::empty().push_embedded().build();
         let res = cfg.resolve_resource(DEFAULT_CHAR_DEF_FILE)?;
         assert!(matches!(
             res,
@@ -616,20 +650,32 @@ mod tests {
     }
 
     #[test]
-    fn embedded_resources_can_be_disabled() {
-        let cfg = ConfigBuilder::empty().embedded_resources(false).build();
+    fn embedded_resources_are_disabled_by_default() {
+        let cfg = ConfigBuilder::empty().build();
         let err = cfg.resolve_resource(DEFAULT_CHAR_DEF_FILE).unwrap_err();
         assert!(matches!(err, ConfigError::PathResolution(_, _)));
     }
 
     #[test]
     fn embedded_resource_can_not_be_forced_into_path() {
-        let cfg = ConfigBuilder::empty().build();
+        let cfg = ConfigBuilder::empty().push_embedded().build();
         let err = cfg.complete_path(DEFAULT_CHAR_DEF_FILE).unwrap_err();
         assert!(matches!(
             err,
             ConfigError::EmbeddedResourcePath(name) if name == DEFAULT_CHAR_DEF_FILE
         ));
+    }
+
+    #[test]
+    fn from_file_sets_path_before_parent() -> SudachiResult<()> {
+        let cfg_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/resources/sudachi.json");
+        let cfg = ConfigBuilder::from_file(&cfg_path)?;
+        let roots: Vec<_> = cfg.raw_config().path.iter().cloned().collect();
+        assert_eq!(roots, vec![PathBuf::from("tests/resources/")]);
+        let npath = cfg.build().resolve_paths("$cfg/data".to_owned());
+        assert_eq!(npath[0], "tests/resources/data");
+        assert!(npath[1].ends_with("sudachi/tests/resources/data"));
+        Ok(())
     }
 
     #[test]

--- a/sudachi/src/dic/build/test/test_config_template.json
+++ b/sudachi/src/dic/build/test/test_config_template.json
@@ -1,5 +1,5 @@
 {
-  "resourcePath" : "tests/resources/",
+  "path" : "tests/resources/",
   "systemDict" : "$system_dict",
   "userDict" : "$user_dict",
   "characterDefinitionFile" : "char.def",

--- a/sudachi/src/dic/character_category.rs
+++ b/sudachi/src/dic/character_category.rs
@@ -23,10 +23,9 @@ use std::path::Path;
 
 use thiserror::Error;
 
+use crate::config::DEFAULT_CHAR_DEF_BYTES;
 use crate::dic::category_type::CategoryType;
 use crate::prelude::*;
-
-const DEFAULT_CHAR_DEF_BYTES: &[u8] = include_bytes!("../../../resources/char.def");
 
 /// Sudachi error
 #[derive(Error, Debug, Eq, PartialEq)]

--- a/sudachi/src/dic/dictionary.rs
+++ b/sudachi/src/dic/dictionary.rs
@@ -90,6 +90,31 @@ impl JapaneseDictionary {
         Self::from_cfg_storage_chardef(cfg, sb, chardef)
     }
 
+    /// Creates a dictionary from the specified configuration and storage
+    pub fn from_cfg_storage(
+        cfg: &Config,
+        storage: SudachiDicData,
+    ) -> SudachiResult<JapaneseDictionary> {
+        let chardef = CharacterCategory::from_bytes(
+            &cfg.resolve_resource(&cfg.character_definition_file)?
+                .read_bytes()?,
+        )?;
+        Self::from_cfg_storage_chardef(cfg, storage, chardef)
+    }
+
+    #[deprecated(
+        since = "0.7.0",
+        note = "embedded resources are now resolved through Config; use from_cfg_storage instead"
+    )]
+    /// Creates a dictionary from the specified configuration and storage, with embedded character definition
+    pub fn from_cfg_storage_with_embedded_chardef(
+        cfg: &Config,
+        storage: SudachiDicData,
+    ) -> SudachiResult<JapaneseDictionary> {
+        let chardef = CharacterCategory::from_embedded();
+        Self::from_cfg_storage_chardef(cfg, storage, chardef)
+    }
+
     pub fn from_cfg_storage_chardef(
         cfg: &Config,
         storage: SudachiDicData,
@@ -138,27 +163,6 @@ impl JapaneseDictionary {
         }
 
         Ok(dic)
-    }
-
-    /// Creates a dictionary from the specified configuration and storage
-    pub fn from_cfg_storage(
-        cfg: &Config,
-        storage: SudachiDicData,
-    ) -> SudachiResult<JapaneseDictionary> {
-        let chardef = CharacterCategory::from_bytes(
-            &cfg.resolve_resource(&cfg.character_definition_file)?
-                .read_bytes()?,
-        )?;
-        Self::from_cfg_storage_chardef(cfg, storage, chardef)
-    }
-
-    /// Creates a dictionary from the specified configuration and storage, with embedded character definition
-    pub fn from_cfg_storage_with_embedded_chardef(
-        cfg: &Config,
-        storage: SudachiDicData,
-    ) -> SudachiResult<JapaneseDictionary> {
-        let chardef = CharacterCategory::from_embedded();
-        Self::from_cfg_storage_chardef(cfg, storage, chardef)
     }
 
     /// Returns grammar with the correct lifetime

--- a/sudachi/src/dic/dictionary.rs
+++ b/sudachi/src/dic/dictionary.rs
@@ -82,8 +82,10 @@ impl JapaneseDictionary {
             )
         }
 
-        let chardef_path = cfg.complete_path(&cfg.character_definition_file)?;
-        let chardef = CharacterCategory::from_file(chardef_path.as_path())?;
+        let chardef = CharacterCategory::from_bytes(
+            &cfg.resolve_resource(&cfg.character_definition_file)?
+                .read_bytes()?,
+        )?;
 
         Self::from_cfg_storage_chardef(cfg, sb, chardef)
     }
@@ -143,8 +145,10 @@ impl JapaneseDictionary {
         cfg: &Config,
         storage: SudachiDicData,
     ) -> SudachiResult<JapaneseDictionary> {
-        let chardef_path = cfg.complete_path(&cfg.character_definition_file)?;
-        let chardef = CharacterCategory::from_file(chardef_path.as_path())?;
+        let chardef = CharacterCategory::from_bytes(
+            &cfg.resolve_resource(&cfg.character_definition_file)?
+                .read_bytes()?,
+        )?;
         Self::from_cfg_storage_chardef(cfg, storage, chardef)
     }
 

--- a/sudachi/src/plugin/input_text/default_input_text.rs
+++ b/sudachi/src/plugin/input_text/default_input_text.rs
@@ -15,8 +15,7 @@
  */
 
 use std::collections::{HashMap, HashSet};
-use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::BufRead;
 use std::path::PathBuf;
 
 use aho_corasick::{
@@ -26,7 +25,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use unicode_normalization::{is_nfkc_quick, IsNormalized, UnicodeNormalization};
 
-use crate::config::Config;
+use crate::config::{Config, DEFAULT_REWRITE_DEF_FILE};
 use crate::dic::grammar::Grammar;
 use crate::hash::RoMu;
 use crate::input_text::{InputBuffer, InputEditor};
@@ -36,9 +35,6 @@ use crate::prelude::*;
 
 #[cfg(test)]
 mod tests;
-
-const DEFAULT_REWRITE_DEF_FILE: &str = "rewrite.def";
-const DEFAULT_REWRITE_DEF_BYTES: &[u8] = include_bytes!("../../../../resources/rewrite.def");
 
 /// Provides basic normalization of the input text
 #[derive(Default)]
@@ -263,19 +259,12 @@ impl InputTextPlugin for DefaultInputTextPlugin {
         let settings: PluginSettings =
             serde_json::from_value(settings.clone()).map_err(PluginError::from)?;
 
-        let rewrite_file_path = config.complete_path(
+        let rewrite_def = config.resolve_resource(
             settings
                 .rewriteDef
                 .unwrap_or_else(|| DEFAULT_REWRITE_DEF_FILE.into()),
-        );
-
-        if rewrite_file_path.is_ok() {
-            let reader = BufReader::new(fs::File::open(rewrite_file_path?)?);
-            self.read_rewrite_lists(reader)?;
-        } else {
-            let reader = BufReader::new(DEFAULT_REWRITE_DEF_BYTES);
-            self.read_rewrite_lists(reader)?;
-        }
+        )?;
+        self.read_rewrite_lists(rewrite_def.reader()?)?;
 
         Ok(())
     }

--- a/sudachi/src/plugin/oov/mecab_oov.rs
+++ b/sudachi/src/plugin/oov/mecab_oov.rs
@@ -19,12 +19,11 @@ use crate::util::user_pos::{UserPosMode, UserPosSupport};
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::BufRead;
 use std::path::PathBuf;
 
 use crate::analysis::Node;
-use crate::config::Config;
+use crate::config::{Config, DEFAULT_CHAR_DEF_FILE, DEFAULT_UNK_DEF_FILE};
 use crate::dic::category_type::CategoryType;
 use crate::dic::character_category::Error as CharacterCategoryError;
 use crate::dic::grammar::Grammar;
@@ -38,11 +37,6 @@ use crate::prelude::*;
 
 #[cfg(test)]
 mod test;
-
-const DEFAULT_CHAR_DEF_FILE: &str = "char.def";
-const DEFAULT_CHAR_DEF_BYTES: &[u8] = include_bytes!("../../../../resources/char.def");
-const DEFAULT_UNK_DEF_FILE: &str = "unk.def";
-const DEFAULT_UNK_DEF_BYTES: &[u8] = include_bytes!("../../../../resources/unk.def");
 
 /// provides MeCab oov nodes
 #[derive(Default)]
@@ -268,33 +262,20 @@ impl OovProviderPlugin for MeCabOovPlugin {
         let settings: PluginSettings =
             serde_json::from_value(settings.clone()).map_err(PluginError::from)?;
 
-        let char_def_path = config.complete_path(
+        let char_def = config.resolve_resource(
             settings
                 .charDef
                 .unwrap_or_else(|| PathBuf::from(DEFAULT_CHAR_DEF_FILE)),
-        );
+        )?;
+        let categories = MeCabOovPlugin::read_character_property(char_def.reader()?)?;
 
-        let categories = if char_def_path.is_ok() {
-            let reader = BufReader::new(fs::File::open(char_def_path?)?);
-            MeCabOovPlugin::read_character_property(reader)?
-        } else {
-            let reader = BufReader::new(DEFAULT_CHAR_DEF_BYTES);
-            MeCabOovPlugin::read_character_property(reader)?
-        };
-
-        let unk_def_path = config.complete_path(
+        let unk_def = config.resolve_resource(
             settings
                 .unkDef
                 .unwrap_or_else(|| PathBuf::from(DEFAULT_UNK_DEF_FILE)),
-        );
-
-        let oov_list = if unk_def_path.is_ok() {
-            let reader = BufReader::new(fs::File::open(unk_def_path?)?);
-            MeCabOovPlugin::read_oov(reader, &categories, grammar, settings.userPOS)?
-        } else {
-            let reader = BufReader::new(DEFAULT_UNK_DEF_BYTES);
-            MeCabOovPlugin::read_oov(reader, &categories, grammar, settings.userPOS)?
-        };
+        )?;
+        let oov_list =
+            MeCabOovPlugin::read_oov(unk_def.reader()?, &categories, grammar, settings.userPOS)?;
 
         self.categories = categories;
         self.oov_list = oov_list;

--- a/sudachi/src/plugin/oov/mecab_oov/test.rs
+++ b/sudachi/src/plugin/oov/mecab_oov/test.rs
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-use std::io::{Cursor, Write};
+use std::io::{BufReader, Cursor, Write};
 
 use crate::analysis::node::LatticeNode;
 use crate::plugin::PluginError;

--- a/sudachi/src/plugin/oov/regex_oov/test.rs
+++ b/sudachi/src/plugin/oov/regex_oov/test.rs
@@ -57,7 +57,7 @@ fn plugin(
 ) -> RegexOovProvider {
     let mut plugin = RegexOovProvider::default();
     let mut grammar = zero_grammar();
-    let cfg = Config::minimal_at("");
+    let cfg = Config::empty();
     let jval = json!({
         "leftId": 0,
         "rightId": 0,

--- a/sudachi/src/text_normalizer.rs
+++ b/sudachi/src/text_normalizer.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::config::Config;
+use crate::config::ConfigBuilder;
 use crate::dic::grammar::Grammar;
 use crate::input_text::InputBuffer;
 use crate::plugin::input_text::default_input_text::DefaultInputTextPlugin;
@@ -29,7 +29,7 @@ pub struct TextNormalizer {
 impl TextNormalizer {
     pub fn new(grammar: &Grammar) -> SudachiResult<Self> {
         let mut plugin = DefaultInputTextPlugin::default();
-        let cfg = Config::minimal_at(crate::config::default_resource_dir());
+        let cfg = ConfigBuilder::empty().push_embedded().build();
         plugin.set_up(
             &serde_json::Value::Object(serde_json::Map::default()),
             &cfg,

--- a/sudachi/tests/common.rs
+++ b/sudachi/tests/common.rs
@@ -39,6 +39,8 @@ use sudachi::dic::subset::InfoSubset;
 use sudachi::dic::{grammar::Grammar, lexicon::Lexicon};
 use sudachi::prelude::*;
 
+// used in lazy_static
+#[allow(unused)]
 pub fn dictionary_bytes_from_path<P: AsRef<Path>>(dictionary_path: P) -> SudachiResult<Vec<u8>> {
     let dictionary_path = dictionary_path.as_ref();
     let dictionary_stat = fs::metadata(dictionary_path)?;


### PR DESCRIPTION
implement #286 (rust side)

- embed resource files (char.def, unk.def, rewrite.def, and sudachi.json)
- add pathresolver for embedded resources
- reduce path related fields in ConfigBuilder into a single PathResolver.

breaking behavior changes:
- Embedded resources are not automatically loaded now. User need to explicitly add embedded path-resolver to the config.
- The order of path resolution changed for `Config::new` and python `Dictionary.create`:
  - previous: `path` defined in the config > default or given resource dir > parent of config_file > default resouces
  - now: given resource dir > `path` defined in the config > parent of config_file > default resouces
