### PR TITLE
Issue #117: runtime prefetch-friendly trie lookup (+~9%, format-preserving)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "crawdad"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9742b11612a5e342c05ae62386a7a486c8fcf60bf835914a469d44c545c3b7fe"
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,10 +301,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "3.0.0"
+source = "git+https://github.com/daac-tools/daachorse?tag=v3.0.0#41755e780a41b49f041e76f3d1e81bd0129188c7"
+
+[[package]]
 name = "default_input_text"
 version = "0.6.11-a1"
 dependencies = [
  "sudachi",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -345,6 +365,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "getrandom"
@@ -583,6 +609,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +674,12 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -788,6 +826,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rsmarisa"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb8faa8d19e79a31e62e7856e16cd5c2d8ba71629910ce3ba1db287f968954d"
+dependencies = [
+ "clap",
+ "memmap2",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,18 +953,24 @@ dependencies = [
  "aho-corasick",
  "bitflags",
  "claim",
+ "crawdad",
+ "criterion",
  "csv",
+ "daachorse",
  "default_input_text",
  "fancy-regex",
+ "fst",
  "indexmap",
  "itertools 0.13.0",
  "join_katakana_oov",
  "join_numeric",
  "lazy_static",
+ "libc",
  "libloading",
  "memmap2",
  "nom",
  "regex",
+ "rsmarisa",
  "serde",
  "serde_json",
  "simple_oov",
@@ -932,8 +986,10 @@ version = "0.6.11-a1"
 dependencies = [
  "cfg-if",
  "clap",
+ "csv",
  "memmap2",
  "sudachi",
+ "time",
 ]
 
 [[package]]
@@ -1013,6 +1069,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/docs/issue-117-performance-report.md
+++ b/docs/issue-117-performance-report.md
@@ -1,0 +1,131 @@
+# Issue #117 Trie Layout And Matcher Comparison
+
+Issue #117 asks whether Sudachi can build a `darts-clone`/Yada-compatible trie
+whose node placement is friendlier to speculative cache prefetch. This report
+keeps that scope: trie layout and dictionary matcher candidates only. It does
+not cover tokenizer rewrites, sentence splitting, connection-matrix locality, or
+dictionary format changes.
+
+The production default remains `classic_yada`. Cache-aware Yada is selected only
+with `--trie-layout cache-aware`.
+
+## Benchmark Shape
+
+The maintainer-facing comparison is produced by
+`sudachi/examples/dictionary_matcher_report.rs`.
+
+The measured workload matches Sudachi's dictionary matcher shape:
+
+- `classic_yada` and cache-aware Yada run common-prefix lookup at every UTF-8
+  character start.
+- Daachorse runs one-pass overlapping search over the whole input line and maps
+  matches back to the same per-start buckets.
+- Crawdad, FST, and MARISA-style methods run prefix lookup at every character
+  start through adapters.
+- Every candidate is validated against `classic_yada` as `(start, end, value)`.
+
+The table below uses the same storage strategy for every row:
+`vec_buckets_clear_all`. That keeps the main table focused on matcher/trie
+methods instead of mixing storage experiments into the primary comparison.
+Storage variants can still be enabled with `SUDACHI_COMPARE_STORAGE_VARIANTS=1`.
+
+`serialized_bytes` is the serialized matcher/trie size. For Yada this is the
+serialized trie bytes, not the whole compiled dictionary.
+
+## Reproduce
+
+All numbers below were generated on 2026-05-21 with real SudachiDict tier files
+and the full `matrix.def`:
+
+```bash
+export SUDACHI_TRIE_BENCH_MATRIX=target/bench-lookup/raw/unzipped/matrix/matrix.def
+export SUDACHI_TRIE_BENCH_INPUTS=target/issue-117-corpora/kyoto-leads.txt
+export SUDACHI_COMPARE_INPUT_LIMIT=2048
+export SUDACHI_COMPARE_ROUNDS=20
+
+SUDACHI_TRIE_BENCH_DATA_SET_NAME=small \
+SUDACHI_TRIE_BENCH_LEXICONS=target/bench-lookup/raw/unzipped/small/small_lex.csv \
+cargo run -p sudachi --release --example dictionary_matcher_report --quiet
+
+SUDACHI_TRIE_BENCH_DATA_SET_NAME=core \
+SUDACHI_TRIE_BENCH_LEXICONS=target/bench-lookup/raw/unzipped/small/small_lex.csv:target/bench-lookup/raw/unzipped/core/core_lex.csv \
+cargo run -p sudachi --release --example dictionary_matcher_report --quiet
+
+SUDACHI_TRIE_BENCH_DATA_SET_NAME=full \
+SUDACHI_TRIE_BENCH_LEXICONS=target/bench-lookup/raw/unzipped/small/small_lex.csv:target/bench-lookup/raw/unzipped/core/core_lex.csv:target/bench-lookup/raw/unzipped/notcore/notcore_lex.csv \
+cargo run -p sudachi --release --example dictionary_matcher_report --quiet
+```
+
+Input corpus for each run: 2,048 Kyoto lead lines, 60,840 UTF-8 character starts
+per batch, 20 rounds. All successful rows had `same_order=yes`,
+`same_results=yes`, and `mismatches=0`.
+
+## Results
+
+| Dictionary | Variant | Family | Build ms | Match ns/batch | ns/start | Speed vs current | Total heap | Heap vs current | Serialized bytes | Same results | Mismatches |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|
+| small | `classic_yada` | yada | 5886.369 | 1575754 | 25.90 | 1.00x | 8377792 | 1.00x | 8368128 | yes | 0 |
+| small | `cache_aware_uniform` | yada | 64045.791 | 1496145 | 24.59 | 1.05x | 8744384 | 1.04x | 8734720 | yes | 0 |
+| small | `cache_aware_prefix` | yada | 58393.045 | 1510870 | 24.83 | 1.04x | 8553920 | 1.02x | 8544256 | yes | 0 |
+| small | `cache_aware_external_profile` | yada | 58696.148 | 1574114 | 25.87 | 1.00x | 8556992 | 1.02x | 8547328 | yes | 0 |
+| small | `daachorse_bytewise` | aho-corasick | 227.398 | 1937047 | 31.84 | 0.81x | 25073404 | 2.99x | 25063753 | yes | 0 |
+| small | `daachorse_charwise` | aho-corasick | 1170.017 | 1268062 | 20.84 | 1.24x | 22534340 | 2.69x | 22524697 | yes | 0 |
+| small | `crawdad_trie` | charwise-dat | 1021.840 | 1367814 | 22.48 | 1.15x | 8553352 | 1.02x | 8543700 | yes | 0 |
+| small | `crawdad_mptrie` | charwise-dat | 1531.722 | 1458187 | 23.97 | 1.08x | 9881164 | 1.18x | 9871518 | yes | 0 |
+| small | `fst_map_prefix_scan` | fst | 67.716 | 64928737 | 1067.20 | 0.02x | 2625928 | 0.31x | 2616264 | yes | 0 |
+| small | `rsmarisa_trie` | louds | 104.479 | 14944504 | 245.64 | 0.11x | 1720974 | 0.21x | 1709536 | yes | 0 |
+| core | `classic_yada` | yada | 13707.006 | 1943222 | 31.94 | 1.00x | 27558592 | 1.00x | 27548672 | yes | 0 |
+| core | `cache_aware_uniform` | yada | 206526.321 | 1866585 | 30.68 | 1.04x | 28161728 | 1.02x | 28151808 | yes | 0 |
+| core | `cache_aware_prefix` | yada | 178374.356 | 1929785 | 31.72 | 1.01x | 27852480 | 1.01x | 27842560 | yes | 0 |
+| core | `cache_aware_external_profile` | yada | 177870.293 | 1847137 | 30.36 | 1.05x | 27851456 | 1.01x | 27841536 | yes | 0 |
+| core | `daachorse_bytewise` | aho-corasick | 895.449 | 2954200 | 48.56 | 0.66x | 82576784 | 3.00x | 82566877 | yes | 0 |
+| core | `daachorse_charwise` | aho-corasick | 2365.312 | 1641943 | 26.99 | 1.18x | 58892120 | 2.14x | 58882221 | yes | 0 |
+| core | `crawdad_trie` | charwise-dat | 1074.908 | 1544922 | 25.39 | 1.26x | 21660808 | 0.79x | 21650900 | yes | 0 |
+| core | `crawdad_mptrie` | charwise-dat | 3003.973 | 1619154 | 26.61 | 1.20x | 23907456 | 0.87x | 23897554 | yes | 0 |
+| core | `fst_map_prefix_scan` | fst | 261.432 | 70462727 | 1158.16 | 0.03x | 10728629 | 0.39x | 10718709 | yes | 0 |
+| core | `rsmarisa_trie` | louds | 443.588 | 15884666 | 261.09 | 0.12x | 4987247 | 0.18x | 4975536 | yes | 0 |
+| full | `classic_yada` | yada | 41394.199 | 2250658 | 36.99 | 1.00x | 72173696 | 1.00x | 72163328 | yes | 0 |
+| full | `cache_aware_uniform` | yada | 613334.868 | 2112645 | 34.72 | 1.07x | 73933952 | 1.02x | 73923584 | yes | 0 |
+| full | `cache_aware_prefix` | yada | 561598.820 | 2063293 | 33.91 | 1.09x | 73402496 | 1.02x | 73392128 | yes | 0 |
+| full | `cache_aware_external_profile` | yada | 560395.539 | 2050664 | 33.71 | 1.10x | 73401472 | 1.02x | 73391104 | yes | 0 |
+| full | `daachorse_bytewise` | aho-corasick | 3091.131 | 2849387 | 46.83 | 0.79x | 215297532 | 2.98x | 215287177 | yes | 0 |
+| full | `daachorse_charwise` | aho-corasick | 4949.957 | 1730627 | 28.45 | 1.30x | 134182852 | 1.86x | 134172505 | yes | 0 |
+| full | `crawdad_trie` | charwise-dat | 1296.260 | 1723370 | 28.33 | 1.31x | 54756936 | 0.76x | 54746580 | yes | 0 |
+| full | `crawdad_mptrie` | charwise-dat | 7519.756 | 1773652 | 29.15 | 1.27x | 48338934 | 0.67x | 48328584 | yes | 0 |
+| full | `fst_map_prefix_scan` | fst | 736.915 | 76801166 | 1262.35 | 0.03x | 29389330 | 0.41x | 29378962 | yes | 0 |
+| full | `rsmarisa_trie` | louds | 1068.786 | 18183977 | 298.88 | 0.12x | 11188924 | 0.16x | 11176784 | yes | 0 |
+
+## Interpretation
+
+Cache-aware Yada is the only option here that preserves the current Yada/Darts
+serialized trie format. It reaches the 5-10% lookup-speed target only on the
+full tier (`1.09x` to `1.10x`), but build time is far outside the acceptable
+range: `41.394 s` for classic full vs about `560-613 s` for cache-aware full.
+Trie size grows by about 1-2%. That is not a default-worthy tradeoff yet.
+
+Daachorse charwise one-pass is consistently faster than current Yada and keeps
+exact result parity, but it is not Yada-compatible and uses materially more
+memory: `1.86x` total heap on full.
+
+Crawdad is the strongest non-Yada comparison in this run: it is faster than
+current Yada, exact-result compatible through the adapter, and more compact on
+core/full. It is still a runtime/backend replacement decision, not an issue #117
+layout-only change.
+
+FST and MARISA are compact, but the prefix-scan adapters are much slower than
+current Yada on this workload.
+
+## Decision Gate
+
+Keep `classic_yada` as the default for issue #117 unless a real small/core/full
+workload shows:
+
+- Yada-compatible lookup speedup of at least 5-10%;
+- no more than 2% regression on miss-heavy workloads;
+- trie size growth below 3-5%;
+- core/full dictionary build-time growth below 10-20%;
+- `same_results=yes` for all benchmarked inputs.
+
+Based on the full small/core/full runs above, cache-aware Yada should remain
+opt-in. The bigger speed opportunities are separate matcher/backend decisions,
+not just a prefetch-compatible Yada layout change.

--- a/docs/issue-117-performance-report.md
+++ b/docs/issue-117-performance-report.md
@@ -1,5 +1,11 @@
 # Issue #117 Trie Layout And Matcher Comparison
 
+> **Note:** this report covers a *build-time* node-relayout experiment
+> (`--trie-layout cache-aware`) that was **rejected** (≤1.10x lookup for ~14x
+> build time). The accepted issue #117 answer is a *runtime*
+> software-pipelined prefetch that needs no format or build change and is
+> ~8–12% faster end-to-end — see `docs/trie-prefetch.md`.
+
 Issue #117 asks whether Sudachi can build a `darts-clone`/Yada-compatible trie
 whose node placement is friendlier to speculative cache prefetch. This report
 keeps that scope: trie layout and dictionary matcher candidates only. It does

--- a/docs/performance-investigation.md
+++ b/docs/performance-investigation.md
@@ -1,0 +1,134 @@
+# Sudachi.rs tokenization performance investigation
+
+A measured study of where tokenization time goes and which optimizations pay
+off. The headline result of issue #117 (runtime prefetch trie) lives in
+`docs/trie-prefetch.md`; this document is the broader investigation that frames
+it, including the negative results, so the trade-offs are explicit.
+
+## Methodology
+
+- **Hardware:** Apple M4 Max (12 performance + 4 efficiency cores), rustc 1.95.0,
+  `--release`.
+- **Dictionaries:** SudachiDict tiers built with the current `sudachi build`
+  from the real `matrix.def` (5981×5981, 71 MB connection matrix, shared by all
+  tiers): small (8.4 MB trie), core (27.5 MB), full (72 MB).
+- **Corpus:** 16,051 Kyoto lead sentences (461,815 chars), Mode C.
+- **Protocol:** end-to-end = reset → `do_tokenize` → `collect_results`
+  (`InfoSubset::all`). 31 trials, scalar and pipelined paths interleaved per
+  trial to avoid cache-warming bias. We report **median** (robust) and the
+  **coefficient of variation (CV)**; a win is credible only when it clears the
+  CV noise floor (~1.7% here). Best-of-N is reported too but is noisier.
+- **Reproduce:** `examples/tokenize_pipeline_bench` (single-thread A/B),
+  `examples/tokenize_parallel_bench` (scaling), `examples/dictionary_matcher_report`
+  (isolated lookup, `--features matcher-comparison`).
+
+## Where the time goes (production, pipelined path)
+
+`sample`-based profile of the pipelined tokenizer, full dict, self-time share of
+10,871 samples:
+
+| Subsystem | Share | Note |
+|---|---:|---|
+| Connection matrix (`Lattice::insert` / Viterbi) | **22.8%** | scattered reads into the 71 MB matrix, one per node pair |
+| Trie walk (`Trie::batch_impl`) | **16.9%** | the common-prefix search (already pipelined, #117) |
+| Allocations (malloc/free/realloc/memmove) | 9.6% | nodes, result strings, WordInfo |
+| WordInfo decode + UTF-16→UTF-8 | 9.6% | only paid when results are materialized |
+| word-id table varint expansion | 9.5% | delta-decompression of trie leaves → word ids |
+| OOV providers (MeCab + aho-corasick) | 7.5% | per boundary |
+| Input build / normalization | 4.3% | |
+| node build, path rewrite, backtrace, tail | ~20% | |
+
+Two facts drive everything below: the **matrix dominates** and the **trie walk
+is second** but already optimized.
+
+## Results per optimization
+
+### 1. Runtime prefetch trie lookup (issue #117) — SHIPPED, +~9%
+
+Software-pipelined + prefetched common-prefix search (see `docs/trie-prefetch.md`).
+End-to-end, median of 31 trials, CV ≤ 1.9%:
+
+| Tier | scalar (median) | pipelined (median) | speedup |
+|---|---:|---:|---:|
+| small | 182.83 ms | 168.30 ms | **1.086x** |
+| core | 189.63 ms | 174.77 ms | **1.085x** |
+| full | 197.52 ms | 180.46 ms | **1.095x** |
+
+A stable **+8.5–9.5%** across tiers, well above the ~1.7% noise floor, with
+byte-identical output, zero build/size/memory cost, and no format change.
+
+Isolated lookup (warm-cache micro-benchmark, K=4) is more modest — small 0.95x,
+core 1.07x, full 1.08x — because repeating lookups over the same inputs keeps the
+trie hot, so there is little latency to hide. End-to-end is larger because the
+trie competes with the 71 MB matrix for cache, exposing the misses the prefetch
+covers. The no-prefetch "pipelining only" variant is slower than scalar on every
+tier, so the explicit prefetch is doing the work.
+
+### 2. Multithreaded batch tokenization — the big lever, ~9× / ~10×
+
+Sentences are independent and the dictionary is `Send + Sync` (shared via `Arc`);
+each worker owns a `StatefulTokenizer`. Full dict, best-of-11:
+
+| Threads | sent/s | speedup | efficiency |
+|---:|---:|---:|---:|
+| 1 | 90,418 | 1.00x | 100% |
+| 2 | 176,706 | 1.95x | 98% |
+| 4 | 326,783 | 3.61x | 90% |
+| 8 | 630,763 | 6.98x | 87% |
+| 16 | 802,669 | **8.88x** | 56% |
+
+Near-linear through the 12 performance cores; the tail is the 4 efficiency cores.
+Combined with the pipeline, **~9.9× vs the original single-thread scalar**
+(802k vs ~81k sent/s). Morpheme counts are identical at every thread count.
+This is the dominant win for batch workloads and stacks multiplicatively with
+every per-pipeline optimization.
+
+### 3. Connection-matrix access — NEGATIVE result, do not prefetch
+
+The matrix is the #1 hotspot (22.8%), so it was the obvious target. Two attempts,
+both measured:
+
+- **Software prefetch of upcoming matrix entries in `connect_node`** — *hurt*:
+  pipelined full regressed from ~181 ms to ~202 ms. All predecessors of a node
+  read the *same* 12 KB matrix row (fixed `left_id`), which is largely
+  L2-resident, so there is little miss latency to hide; the per-predecessor
+  prefetch instructions and bookkeeping are pure overhead in this very hot loop.
+- **Hoisting the row base out of the loop** — *neutral*: LLVM already hoists the
+  loop-invariant `right * num_left`, so there was nothing to gain.
+
+The matrix cost is **volume-bound, not miss-bound**. Reducing it requires fewer
+lookups (beam/pruning), which is an approximation and changes results — out of
+scope for exact parity. **Recommendation: leave `connect_node` as-is.**
+
+### 4. Alternative trie backend (Crawdad / Daachorse) — low end-to-end ROI
+
+The cross-method report shows charwise Daachorse / Crawdad are 18–31% faster than
+Yada *on the isolated lookup*. But the trie walk is only 16.9% of end-to-end
+time, so replacing it buys ~**+3–5% end-to-end** — while changing the serialized
+dictionary format and breaking compatibility. Not worth it unless a workload is
+specifically lookup-dominated.
+
+### 5. Lookup de-iteratorization + faster varint — mostly done / minor
+
+The `flat_map` iterator overhead seen in mixed profiles comes mainly from the
+scalar path; the shipped pipelined `lookup_batch` already replaces it with a
+tight loop. The remaining lever is the varint expansion (~9.5%); a branchless
+LEB128 decoder might add ~+3% end-to-end, format-preserving. Modest.
+
+## Conclusions and recommendations
+
+- **Batch throughput: multithreading is the answer (~9–10×).** The library is
+  already thread-safe; the example documents the pattern. This dwarfs every
+  per-op optimization and composes with them.
+- **Single-thread latency is near its practical limit for *exact*
+  tokenization.** The +9% prefetch pipeline (#117) is most of the available
+  format-preserving gain. The dominant remaining cost (the Viterbi connection
+  matrix, ~23%) is volume-bound and cannot be reduced without approximate search.
+- **Negative results to respect:** matrix prefetch hurts; matrix row-hoist is a
+  no-op; an alternative trie backend is only ~+4% end-to-end for a format break.
+- **Optional small wins (format-preserving):** branchless varint (~+3%),
+  allocation reuse (a few %, diffuse), and lazy/subset `WordInfo` for
+  surface-only workloads.
+
+The recommended, shippable package: the #117 runtime prefetch pipeline (default
+on, +~9%, exact) plus documenting/benchmarking the ~10× batch parallelism.

--- a/docs/trie-layout.md
+++ b/docs/trie-layout.md
@@ -1,0 +1,158 @@
+# Cache-aware trie layout
+
+Issue #117 is implemented as a build-time layout strategy. The serialized trie
+remains the existing Yada/Darts-compatible `u32` double-array representation:
+runtime lookup, word-id table offsets, and dictionary block layout are unchanged.
+
+The default builder is still `ClassicYada`, so existing dictionary builds keep the
+same bytes unless the new strategy is selected explicitly.
+
+```bash
+cargo run -p sudachi-cli -- build \
+  --trie-layout cache-aware \
+  --trie-candidate-window 16 \
+  --trie-cache-line-bytes 64 \
+  -m resources/matrix.def \
+  -o system.dic \
+  path/to/lex.csv
+```
+
+An optional external profile can be supplied with `--trie-profile`. The format is
+one entry per line:
+
+```text
+# surface<TAB>count
+東京	120000
+hex:E4BAACE983BD	80000
+```
+
+`hex:` keys are interpreted as raw bytes. Missing profile entries use weight `1`.
+
+The cache-aware builder keeps deterministic output and uses three heuristics:
+hot-first recursion, bounded offset candidate search over recent 256-unit blocks,
+and cache-line-aware scoring of valid offsets. It is opt-in until benchmarks on
+full Sudachi dictionaries show a stable lookup win without unacceptable trie size
+or build-time regressions.
+
+Run the local harness with:
+
+```bash
+cargo bench -p sudachi --bench trie_layout
+```
+
+The benchmark compares these variants:
+
+```text
+classic_yada
+cache_aware_uniform
+cache_aware_prefix
+cache_aware_external_profile
+```
+
+These are the #117 production-compatible variants: every one emits the current
+Yada/Darts `u32` unit layout and is readable by the existing runtime trie.
+
+It validates common-prefix output against `classic_yada` before timing lookup,
+prints dictionary/trie byte sizes, and measures:
+
+```text
+trie_layout/build
+trie_layout/common_prefix_hit
+trie_layout/common_prefix_miss
+trie_layout/common_prefix_mixed
+```
+
+Use real dictionary sources by passing environment variables:
+
+```bash
+SUDACHI_TRIE_BENCH_MATRIX=path/to/matrix.def \
+SUDACHI_TRIE_BENCH_LEXICONS="path/to/lex.csv:path/to/lex2.csv" \
+SUDACHI_TRIE_BENCH_INPUTS=path/to/tokenization-inputs.txt \
+SUDACHI_TRIE_BENCH_PROFILE=path/to/profile.tsv \
+cargo bench -p sudachi --bench trie_layout
+```
+
+`SUDACHI_TRIE_BENCH_LEXICON` can be used instead of
+`SUDACHI_TRIE_BENCH_LEXICONS` for a single CSV file. If no profile is supplied,
+the benchmark generates a deterministic synthetic profile from indexed forms so
+the external-profile code path is still covered.
+
+For a maintainer-facing report, include:
+
+```text
+variant, dictionary size, trie size,
+build time,
+common-prefix hit/miss/mixed time,
+benchmark dictionary source,
+benchmark input corpus source
+```
+
+The proposed merge gate for making cache-aware the default is:
+
+```text
+lookup/common-prefix speedup >= 5-10% on realistic core/full workloads
+no >2% regression on miss/random workloads
+trie size growth <= 3-5%
+core dictionary build-time growth <= 10-20%
+classic_yada remains available as fallback
+```
+
+Suggested PR summary:
+
+```text
+This PR adds an opt-in cache-aware, Yada/Darts-compatible trie builder for
+dictionary compilation. It preserves the serialized trie format and runtime
+lookup semantics, while allowing deterministic profile-aware node placement.
+The default remains the existing Yada builder until the benchmark matrix shows
+a stable win on real Sudachi dictionaries.
+```
+
+For large dictionaries, Criterion's repeated build benchmark can be too
+expensive. Use the one-shot report example to collect maintainer-facing numbers:
+
+```bash
+SUDACHI_TRIE_BENCH_MATRIX=path/to/matrix.def \
+SUDACHI_TRIE_BENCH_LEXICONS="path/to/small_lex.csv:path/to/core_lex.csv" \
+cargo run -p sudachi --release --example trie_layout_report
+```
+
+It prints a tab-separated table with build time, dictionary size, trie size, and
+hit/miss/mixed common-prefix lookup timing for every variant.
+
+For the cross-method maintainer table, use:
+
+```bash
+cargo run -p sudachi --release --example dictionary_matcher_report
+```
+
+That report compares current Yada, cache-aware Yada variants, Daachorse,
+Crawdad, FST, and MARISA-style methods against current Yada for matcher pipeline
+speed, memory, serialized size, and result equality. Unlike the pure trie layout
+benchmarks, it runs over every UTF-8 character start in each input line and
+validates `(start, end, value)` matches.
+
+For the maintainer table, use real tier lexicons with `SUDACHI_TRIE_BENCH_MATRIX`
+and `SUDACHI_TRIE_BENCH_LEXICONS`. The current small/core/full results and exact
+commands are in `docs/issue-117-performance-report.md`.
+
+By default, the cross-method report prints one row per matcher using the same
+`vec_buckets_clear_all` storage. Set `SUDACHI_COMPARE_STORAGE_VARIANTS=1` only
+when you explicitly want to study storage strategies as a separate dimension.
+
+Use `SUDACHI_TRIE_BENCH_SURFACE_LEXICONS` only for a faster exploratory run when
+you want to isolate index-form trie/matcher cost from full connection-matrix
+parsing:
+
+```bash
+SUDACHI_TRIE_BENCH_SURFACE_LEXICONS="path/to/small_lex.csv:path/to/core_lex.csv:path/to/notcore_lex.csv" \
+SUDACHI_TRIE_BENCH_INPUTS=path/to/inputs.txt \
+SUDACHI_COMPARE_INPUT_LIMIT=2048 \
+SUDACHI_COMPARE_ROUNDS=100 \
+cargo run -p sudachi --release --example dictionary_matcher_report
+```
+
+## Current Results
+
+The maintainer-facing conclusion and report fields are kept in
+`docs/issue-117-performance-report.md`. This document only describes the
+cache-aware trie-layout controls and how to run them.

--- a/docs/trie-prefetch.md
+++ b/docs/trie-prefetch.md
@@ -1,0 +1,142 @@
+# Runtime prefetch-friendly trie lookup (issue #117)
+
+Issue #117 asks whether Sudachi can keep its `darts-clone`/Yada-compatible
+double-array trie but make lookups load the next symbol's nodes into L1
+"speculatively, even with not 100% accuracy". This document describes the
+**runtime** answer: a software-pipelined, prefetch-assisted common-prefix
+search. It is the default in lattice construction.
+
+It does **not** change the serialized dictionary at all: the trie bytes, the
+runtime `u32` double-array layout, word-id table, and build pipeline are
+untouched. Build time is unaffected. Only *how* the runtime walks the array
+changes.
+
+See `docs/issue-117-performance-report.md` for the separate, earlier
+exploration of a *build-time* node relayout (`--trie-layout cache-aware`), which
+was rejected: it costs ~14x build time for ≤1.10x lookup and is opt-in only.
+
+## The idea
+
+A double-array common-prefix walk is a pointer chase:
+
+```text
+node_pos ^= byte;  unit = trie[node_pos];  node_pos ^= offset(unit);  // repeat
+```
+
+Each step depends on the previous load, so a single walk cannot overlap its own
+memory latency. But Sudachi runs one **independent** walk per character boundary
+of a sentence (`build_lattice`), and a walk's *next* load address —
+`trie[node_pos ^ next_byte]` — is known one step ahead without another load.
+
+So we keep `K` independent walks in flight, advance them round-robin one byte at
+a time, and `prefetch` each lane's next node while the other lanes run. This is
+classic software-pipelined prefetching / group prefetching (Chen & Ailamaki;
+Kocberber et al. "AMAC"). A mis-speculated lane (one that hits a dead end before
+its prefetched line is used) just wastes a harmless hint — exactly the "not 100%
+accuracy" the issue allows.
+
+The shared per-step arithmetic (`step_once` in
+`sudachi/src/dic/lexicon/trie.rs`) is identical to the scalar iterator, so the
+two paths are byte-for-byte equivalent by construction.
+
+## API
+
+- `Trie::common_prefix_batch(input, starts, emit)` — pipelined search from many
+  start offsets; `emit(bucket, value, end)` per match, with per-`bucket` order
+  identical to `common_prefix_iterator(input, starts[bucket])`.
+- `Lexicon::lookup_batch` / `LexiconSet::lookup_batch` — the same over the
+  dictionary set, preserving `lookup()`'s ordering (user dicts first, then
+  system, each in trie-walk order).
+- `StatefulTokenizer::set_pipelined_lookup(bool)` — override the default
+  (on) for benchmarking; the result is unchanged either way.
+
+`K = 4` lanes (`Trie::DEFAULT_PREFETCH_LANES`) is the measured sweet spot: enough
+memory-level parallelism to hide L2/L3 misses, while the lane state stays in
+registers. Larger `K` adds scheduler overhead that outweighs the extra latency
+hiding on this workload.
+
+Prefetch primitive (`sudachi/src/util/prefetch.rs`): `_mm_prefetch` on
+x86/x86_64, `prfm pldl1keep` on aarch64, no-op elsewhere — all stable Rust.
+
+## Correctness
+
+- `dic::lexicon::trie::tests` — `common_prefix_batch` matches
+  `common_prefix_iterator` across lane counts {1,2,3,8,16}, prefetch on/off,
+  including empty input, misses, multibyte, leaf-with-children, and
+  sparse/unordered/duplicate starts.
+- `tests/pipelined_lookup_parity.rs` — full tokenization (modes A/B/C) is
+  identical between the scalar and pipelined lattice builders.
+- The entire existing test suite runs with the pipelined path as the default
+  and is unchanged.
+
+## Results
+
+Hardware: Apple M4 Max (aarch64), rustc 1.95.0, `--release`. Real SudachiDict
+tier lexicons + the full `matrix.def`; corpus = 16,051 Kyoto lead sentences
+(`target/issue-117-corpora/kyoto-leads.txt`). Connection matrix (~71 MB) is the
+same across tiers, so even the "small" dictionary tokenization is cache-pressured.
+
+### End-to-end tokenization (what users run) — best-of-15
+
+| Dictionary | trie size | scalar (sent/s) | pipelined (sent/s) | speedup |
+|---|---:|---:|---:|---:|
+| small | 8.4 MB | 84,943 | 91,877 | **1.082x** |
+| core | 27.5 MB | 82,573 | 91,742 | **1.111x** |
+| full | 72.2 MB | 78,585 | 88,322 | **1.124x** |
+
+~8–12% faster whole-pipeline tokenization, identical morpheme output, zero build
+or memory cost. Laptop run-to-run variance is real; the win is consistently
+positive across runs.
+
+### Isolated common-prefix lookup (warm-cache micro-benchmark) — ns/start
+
+| Dictionary | classic | pipelined+prefetch (K=4) | speedup |
+|---|---:|---:|---:|
+| small | 24.05 | 25.33 | 0.95x |
+| core | 29.50 | 27.58 | 1.07x |
+| full | 32.44 | 30.16 | 1.08x |
+
+The isolated benchmark repeats lookups over the same inputs, so the trie stays
+warm in cache and there is little latency to hide on smaller tiers — the
+scheduler overhead even shows a small regression on `small`. This understates
+the real workload: in `build_lattice` the trie competes with the connection
+matrix and lattice for cache, so misses are more frequent and prefetch helps
+more — hence the uniformly larger end-to-end wins above. Pure software
+pipelining without the prefetch hint is slower than scalar on every tier, so the
+explicit prefetch is doing the work, not just the reordering.
+
+## Decision
+
+Pipelined + prefetched lookup is the **default** in `build_lattice`:
+format-preserving, zero build/size/memory cost, byte-for-byte identical output,
+and ~8–12% faster end-to-end on real dictionaries. `set_pipelined_lookup(false)`
+restores the scalar path. On targets without a prefetch primitive the hint is a
+no-op and the (arch-neutral) pipelining still applies.
+
+## Reproduce
+
+End-to-end (no extra dependencies):
+
+```bash
+cargo run -p sudachi-cli --release -- build -o /tmp/full.dic \
+  -m target/bench-lookup/raw/unzipped/matrix/matrix.def \
+  target/bench-lookup/raw/unzipped/small/small_lex.csv \
+  target/bench-lookup/raw/unzipped/core/core_lex.csv \
+  target/bench-lookup/raw/unzipped/notcore/notcore_lex.csv
+
+SUDACHI_BENCH_DICT=/tmp/full.dic SUDACHI_BENCH_TRIALS=15 \
+  cargo run -p sudachi --release --example tokenize_pipeline_bench
+```
+
+Isolated lookup sweep (lane counts, prefetch on/off) needs the optional
+comparison crates:
+
+```bash
+SUDACHI_SKIP_BUILD_TIME_VARIANTS=1 \
+SUDACHI_TRIE_BENCH_MATRIX=target/bench-lookup/raw/unzipped/matrix/matrix.def \
+SUDACHI_TRIE_BENCH_INPUTS=target/issue-117-corpora/kyoto-leads.txt \
+SUDACHI_TRIE_BENCH_DATA_SET_NAME=full \
+SUDACHI_TRIE_BENCH_LEXICONS=.../small_lex.csv:.../core_lex.csv:.../notcore_lex.csv \
+cargo run -p sudachi --release --features matcher-comparison \
+  --example dictionary_matcher_report
+```

--- a/sudachi-cli/src/build.rs
+++ b/sudachi-cli/src/build.rs
@@ -25,7 +25,7 @@ use memmap2::Mmap;
 
 use sudachi::dic::binary_loader::{BinaryDictionary, LoadedDictionary};
 use sudachi::dic::build::report::DictPartReport;
-use sudachi::dic::build::DictBuilder;
+use sudachi::dic::build::{CacheAwareOptions, DictBuilder, TrieBuildStrategy, TrieProfileMode};
 use sudachi::dic::description::Description;
 use sudachi::dic::grammar::Grammar;
 use sudachi::dic::lexicon::Lexicon;
@@ -46,6 +46,12 @@ pub(crate) enum DumpPart {
     Matrix,
     Pos,
     Winfo,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+enum TrieLayoutArg {
+    Classic,
+    CacheAware,
 }
 
 /// Check that the first argument is a subcommand and the file with the same name does
@@ -128,6 +134,48 @@ pub(crate) struct BuildCmd {
     /// Description string to embed into dictionary
     #[arg(short, long, default_value = "")]
     description: String,
+
+    /// Trie layout strategy for dictionary compilation.
+    #[arg(long = "trie-layout", value_enum, default_value_t = TrieLayoutArg::Classic)]
+    trie_layout: TrieLayoutArg,
+
+    /// External key profile for cache-aware trie layout: <surface-or-hex>\t<count>.
+    #[arg(long = "trie-profile")]
+    trie_profile: Option<PathBuf>,
+
+    /// Cache line size in bytes used by the cache-aware trie layout scorer.
+    #[arg(long = "trie-cache-line-bytes", default_value_t = 64)]
+    trie_cache_line_bytes: usize,
+
+    /// Number of recent 256-unit blocks searched by the cache-aware trie layout builder.
+    #[arg(long = "trie-candidate-window", default_value_t = 16)]
+    trie_candidate_window: usize,
+}
+
+impl BuildCmd {
+    fn trie_build_strategy(&self) -> TrieBuildStrategy {
+        match self.trie_layout {
+            TrieLayoutArg::Classic => {
+                if self.trie_profile.is_some() {
+                    panic!("--trie-profile requires --trie-layout cache-aware");
+                }
+                TrieBuildStrategy::ClassicYada
+            }
+            TrieLayoutArg::CacheAware => {
+                let profile_mode = self
+                    .trie_profile
+                    .as_ref()
+                    .map(|path| TrieProfileMode::ExternalKeyProfile(path.clone()))
+                    .unwrap_or(TrieProfileMode::DictionaryPrefixCount);
+                TrieBuildStrategy::CacheAware(CacheAwareOptions {
+                    cache_line_bytes: self.trie_cache_line_bytes,
+                    candidate_window_blocks: self.trie_candidate_window,
+                    profile_mode,
+                    ..CacheAwareOptions::default()
+                })
+            }
+        }
+    }
 }
 
 pub fn build_main(subcommand: BuildCli) {
@@ -161,6 +209,7 @@ pub fn build_main(subcommand: BuildCli) {
 fn build_system(mut cmd: BuildCmd, matrix: PathBuf, pos: Option<PathBuf>) {
     let mut builder = DictBuilder::new_system();
     builder.set_description(std::mem::take(&mut cmd.description));
+    builder.set_trie_build_strategy(cmd.trie_build_strategy());
     builder
         .read_conn(matrix.as_path())
         .expect("failed to read matrix");
@@ -192,6 +241,7 @@ fn build_user(mut cmd: BuildCmd, system: PathBuf) {
 
     let mut builder = DictBuilder::new_user(&dict);
     builder.set_description(std::mem::take(&mut cmd.description));
+    builder.set_trie_build_strategy(cmd.trie_build_strategy());
     for d in cmd.inputs.iter() {
         builder
             .read_lexicon(d.as_path())

--- a/sudachi/Cargo.toml
+++ b/sudachi/Cargo.toml
@@ -29,13 +29,22 @@ thiserror = "1.0" # MIT/Apache 2.0
 unicode-normalization = "0.1" # MIT/Apache 2.0
 yada = "0.5" # MIT/Apache 2.0
 
+# Optional alternative matchers used only by the `dictionary_matcher_report`
+# example (issue #117 cross-method comparison). Gated behind the
+# `matcher-comparison` feature so they stay out of the default build/CI graph.
+crawdad = { version = "0.4", optional = true } # MIT/Apache 2.0
+daachorse = { git = "https://github.com/daac-tools/daachorse", tag = "v3.0.0", optional = true } # MIT/Apache 2.0
+fst = { version = "0.4", optional = true } # Unlicense/MIT
+rsmarisa = { version = "0.4", optional = true } # BSD-2-Clause
+
+[features]
+# Build the cross-method matcher comparison example, pulling in the optional
+# alternative trie/automaton crates above.
+matcher-comparison = ["dep:crawdad", "dep:daachorse", "dep:fst", "dep:rsmarisa"]
+
 [dev-dependencies]
 claim = "0.5" # MIT/Apache 2.0
 criterion = "0.5" # MIT/Apache 2.0
-crawdad = "0.4" # MIT/Apache 2.0
-daachorse = { git = "https://github.com/daac-tools/daachorse", tag = "v3.0.0" } # MIT/Apache 2.0
-fst = "0.4" # Unlicense/MIT
-rsmarisa = "0.4" # BSD-2-Clause
 tempfile = "3" # MIT/Apache 2.0
 
 # Plugins for tests
@@ -46,6 +55,10 @@ join_katakana_oov = { path = "../plugin/path_rewrite/join_katakana_oov" }
 
 [lib]
 crate-type = ["rlib"]
+
+[[example]]
+name = "dictionary_matcher_report"
+required-features = ["matcher-comparison"]
 
 [[bench]]
 name = "trie_layout"

--- a/sudachi/Cargo.toml
+++ b/sudachi/Cargo.toml
@@ -31,6 +31,11 @@ yada = "0.5" # MIT/Apache 2.0
 
 [dev-dependencies]
 claim = "0.5" # MIT/Apache 2.0
+criterion = "0.5" # MIT/Apache 2.0
+crawdad = "0.4" # MIT/Apache 2.0
+daachorse = { git = "https://github.com/daac-tools/daachorse", tag = "v3.0.0" } # MIT/Apache 2.0
+fst = "0.4" # Unlicense/MIT
+rsmarisa = "0.4" # BSD-2-Clause
 tempfile = "3" # MIT/Apache 2.0
 
 # Plugins for tests
@@ -41,3 +46,7 @@ join_katakana_oov = { path = "../plugin/path_rewrite/join_katakana_oov" }
 
 [lib]
 crate-type = ["rlib"]
+
+[[bench]]
+name = "trie_layout"
+harness = false

--- a/sudachi/benches/trie_layout.rs
+++ b/sudachi/benches/trie_layout.rs
@@ -1,0 +1,370 @@
+/*
+ *  Copyright (c) 2026 Works Applications Co., Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::collections::HashSet;
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use sudachi::dic::binary_loader::BinaryDictionary;
+use sudachi::dic::build::{CacheAwareOptions, DictBuilder, TrieBuildStrategy, TrieProfileMode};
+use tempfile::NamedTempFile;
+
+const MATRIX: &[u8] = include_bytes!("../src/dic/build/test/matrix_10x10.def");
+const LEXICON: &[u8] = include_bytes!("../src/dic/build/test/lex.csv");
+const DEFAULT_INPUTS: &[&str] = &[
+    "東京都に行く",
+    "京都府",
+    "東京湾",
+    "アイアイウ",
+    "六三四",
+    "01234567890123456789",
+    "存在しない語",
+];
+
+struct BenchFixture {
+    matrix: Vec<u8>,
+    lexicons: Vec<Vec<u8>>,
+    inputs: BenchInputs,
+    external_profile_path: PathBuf,
+    _generated_profile: Option<NamedTempFile>,
+}
+
+struct BenchInputs {
+    hits: Vec<String>,
+    misses: Vec<String>,
+    mixed: Vec<String>,
+}
+
+#[derive(Clone)]
+struct Variant {
+    name: &'static str,
+    strategy: TrieBuildStrategy,
+}
+
+struct CompiledVariant {
+    name: &'static str,
+    dict_bytes: usize,
+    trie_bytes: usize,
+    dictionary: BinaryDictionary<'static>,
+}
+
+fn fixture() -> BenchFixture {
+    let matrix = read_env_bytes("SUDACHI_TRIE_BENCH_MATRIX", MATRIX);
+    let lexicons = read_lexicons();
+    let inputs = build_inputs(&lexicons);
+    let (external_profile_path, generated_profile) = external_profile_path(&inputs.hits);
+
+    BenchFixture {
+        matrix,
+        lexicons,
+        inputs,
+        external_profile_path,
+        _generated_profile: generated_profile,
+    }
+}
+
+fn variants(external_profile_path: &Path) -> Vec<Variant> {
+    vec![
+        Variant {
+            name: "classic_yada",
+            strategy: TrieBuildStrategy::ClassicYada,
+        },
+        Variant {
+            name: "cache_aware_uniform",
+            strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions {
+                profile_mode: TrieProfileMode::Uniform,
+                ..CacheAwareOptions::default()
+            }),
+        },
+        Variant {
+            name: "cache_aware_prefix",
+            strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions::default()),
+        },
+        Variant {
+            name: "cache_aware_external_profile",
+            strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions {
+                profile_mode: TrieProfileMode::ExternalKeyProfile(external_profile_path.to_owned()),
+                ..CacheAwareOptions::default()
+            }),
+        },
+    ]
+}
+
+fn read_env_bytes(env_name: &str, fallback: &[u8]) -> Vec<u8> {
+    env::var_os(env_name)
+        .map(|path| fs::read(path).expect("failed to read benchmark input file"))
+        .unwrap_or_else(|| fallback.to_vec())
+}
+
+fn read_lexicons() -> Vec<Vec<u8>> {
+    if let Some(paths) = env::var_os("SUDACHI_TRIE_BENCH_LEXICONS") {
+        return env::split_paths(&paths)
+            .map(|path| fs::read(path).expect("failed to read benchmark lexicon"))
+            .collect();
+    }
+    if let Some(path) = env::var_os("SUDACHI_TRIE_BENCH_LEXICON") {
+        return vec![fs::read(path).expect("failed to read benchmark lexicon")];
+    }
+    vec![LEXICON.to_vec()]
+}
+
+fn build_inputs(lexicons: &[Vec<u8>]) -> BenchInputs {
+    let mut hits = index_forms(lexicons);
+    hits.truncate(256);
+    if hits.is_empty() {
+        hits.extend(DEFAULT_INPUTS.iter().map(|s| (*s).to_owned()));
+    }
+
+    let misses: Vec<String> = hits
+        .iter()
+        .take(256)
+        .map(|input| format!("{input}\u{e000}"))
+        .collect();
+
+    let mixed = env::var_os("SUDACHI_TRIE_BENCH_INPUTS")
+        .map(|path| read_inputs(PathBuf::from(path)))
+        .unwrap_or_else(|| {
+            let mut inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| (*s).to_owned()).collect();
+            inputs.extend(hits.iter().take(64).cloned());
+            inputs.extend(misses.iter().take(64).cloned());
+            dedup(inputs)
+        });
+
+    BenchInputs {
+        hits,
+        misses,
+        mixed,
+    }
+}
+
+fn read_inputs(path: PathBuf) -> Vec<String> {
+    fs::read_to_string(path)
+        .expect("failed to read benchmark inputs")
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn index_forms(lexicons: &[Vec<u8>]) -> Vec<String> {
+    let mut forms = Vec::new();
+    for lexicon in lexicons {
+        let mut reader = csv::ReaderBuilder::new()
+            .has_headers(true)
+            .from_reader(lexicon.as_slice());
+        let index_col = reader
+            .headers()
+            .ok()
+            .and_then(|headers| {
+                headers
+                    .iter()
+                    .position(|header| header.eq_ignore_ascii_case("index_form"))
+            })
+            .unwrap_or(0);
+
+        for record in reader.records().flatten() {
+            let Some(form) = record.get(index_col) else {
+                continue;
+            };
+            if !form.is_empty() {
+                forms.push(form.to_owned());
+            }
+        }
+    }
+    dedup(forms)
+}
+
+fn dedup(inputs: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    inputs
+        .into_iter()
+        .filter(|input| seen.insert(input.clone()))
+        .collect()
+}
+
+fn external_profile_path(hits: &[String]) -> (PathBuf, Option<NamedTempFile>) {
+    if let Some(path) = env::var_os("SUDACHI_TRIE_BENCH_PROFILE") {
+        return (PathBuf::from(path), None);
+    }
+
+    let mut file = NamedTempFile::new().expect("failed to create benchmark profile");
+    let max = hits.len().min(512);
+    for (rank, input) in hits.iter().take(max).enumerate() {
+        write_profile_key(&mut file, input.as_bytes());
+        writeln!(file, "\t{}", max - rank).expect("failed to write benchmark profile");
+    }
+    (file.path().to_owned(), Some(file))
+}
+
+fn write_profile_key<W: Write>(writer: &mut W, bytes: &[u8]) {
+    writer
+        .write_all(b"hex:")
+        .expect("failed to write benchmark profile");
+    for byte in bytes {
+        write!(writer, "{byte:02X}").expect("failed to write benchmark profile");
+    }
+}
+
+fn compile(fixture: &BenchFixture, strategy: TrieBuildStrategy) -> Vec<u8> {
+    let mut builder = DictBuilder::new_system();
+    builder.set_trie_build_strategy(strategy);
+    builder.read_conn(fixture.matrix.as_slice()).unwrap();
+    for lexicon in &fixture.lexicons {
+        builder.read_lexicon(lexicon.as_slice()).unwrap();
+    }
+    builder.resolve().unwrap();
+
+    let mut bytes = Vec::new();
+    builder.compile(&mut bytes).unwrap();
+    bytes
+}
+
+fn compile_variants(fixture: &BenchFixture) -> Vec<CompiledVariant> {
+    let mut compiled = Vec::new();
+    for variant in variants(&fixture.external_profile_path) {
+        let bytes = compile(fixture, variant.strategy);
+        let dict_bytes = bytes.len();
+        let leaked: &'static [u8] = Box::leak(bytes.into_boxed_slice());
+        let dictionary = BinaryDictionary::load_system(leaked).unwrap();
+        let trie_bytes = dictionary.lexicon.trie.total_size();
+        compiled.push(CompiledVariant {
+            name: variant.name,
+            dict_bytes,
+            trie_bytes,
+            dictionary,
+        });
+    }
+    validate_variants(&compiled, &fixture.inputs);
+    print_size_report(&compiled);
+    compiled
+}
+
+fn validate_variants(compiled: &[CompiledVariant], inputs: &BenchInputs) {
+    let Some(baseline) = compiled.first() else {
+        return;
+    };
+    for input in all_inputs(inputs) {
+        let expected = trie_entries(baseline, &input);
+        for variant in compiled.iter().skip(1) {
+            let actual = trie_entries(variant, &input);
+            assert_eq!(
+                actual, expected,
+                "variant {} disagrees with classic_yada for input {input:?}",
+                variant.name
+            );
+        }
+    }
+}
+
+fn all_inputs(inputs: &BenchInputs) -> Vec<String> {
+    let mut result = Vec::new();
+    result.extend(inputs.hits.iter().cloned());
+    result.extend(inputs.misses.iter().cloned());
+    result.extend(inputs.mixed.iter().cloned());
+    dedup(result)
+}
+
+fn trie_entries(variant: &CompiledVariant, input: &str) -> Vec<(u32, usize)> {
+    variant
+        .dictionary
+        .lexicon
+        .trie
+        .common_prefix_iterator(input.as_bytes(), 0)
+        .map(|entry| (entry.value, entry.end))
+        .collect()
+}
+
+fn print_size_report(compiled: &[CompiledVariant]) {
+    eprintln!("trie_layout/size_report");
+    for variant in compiled {
+        eprintln!(
+            "  {:30} dict_bytes={} trie_bytes={}",
+            variant.name, variant.dict_bytes, variant.trie_bytes
+        );
+    }
+}
+
+fn bench_trie_build(c: &mut Criterion) {
+    let fixture = fixture();
+    let mut group = c.benchmark_group("trie_layout/build");
+    for variant in variants(&fixture.external_profile_path) {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(variant.name),
+            &variant.strategy,
+            |b, strategy| {
+                b.iter(|| black_box(compile(&fixture, strategy.clone())));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_common_prefix(c: &mut Criterion) {
+    let fixture = fixture();
+    let compiled = compile_variants(&fixture);
+
+    bench_input_set(
+        c,
+        "trie_layout/common_prefix_hit",
+        &compiled,
+        &fixture.inputs.hits,
+    );
+    bench_input_set(
+        c,
+        "trie_layout/common_prefix_miss",
+        &compiled,
+        &fixture.inputs.misses,
+    );
+    bench_input_set(
+        c,
+        "trie_layout/common_prefix_mixed",
+        &compiled,
+        &fixture.inputs.mixed,
+    );
+}
+
+fn bench_input_set(
+    c: &mut Criterion,
+    group_name: &'static str,
+    compiled: &[CompiledVariant],
+    inputs: &[String],
+) {
+    let mut group = c.benchmark_group(group_name);
+    group.throughput(criterion::Throughput::Elements(inputs.len() as u64));
+    for variant in compiled {
+        group.bench_function(variant.name, |b| {
+            b.iter(|| {
+                let mut total = 0usize;
+                for input in inputs {
+                    total += variant
+                        .dictionary
+                        .lexicon
+                        .trie
+                        .common_prefix_iterator(input.as_bytes(), 0)
+                        .count();
+                }
+                black_box(total);
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_trie_build, bench_common_prefix);
+criterion_main!(benches);

--- a/sudachi/examples/dictionary_matcher_report.rs
+++ b/sudachi/examples/dictionary_matcher_report.rs
@@ -99,6 +99,13 @@ struct FailedMatcher {
 
 enum Matcher {
     Yada(BinaryDictionary<'static>),
+    /// Same serialized Yada/Darts trie as `Yada`, driven by the pipelined +
+    /// prefetched batch matcher (issue #117). Shares bytes with `classic_yada`.
+    YadaPipelined {
+        dict: BinaryDictionary<'static>,
+        lanes: usize,
+        prefetch: bool,
+    },
     DaachorseBytewise(DoubleArrayAhoCorasick<u32>),
     DaachorseCharwise(CharwiseDoubleArrayAhoCorasick<u32>),
     CrawdadTrie(CrawdadTrie),
@@ -400,11 +407,15 @@ impl TextInput {
 
 fn build_yada_variants(fixture: &Fixture) -> ReportResult<Vec<BuiltMatcher>> {
     let mut built = Vec::new();
+    let mut classic: Option<(&'static [u8], Duration, usize)> = None;
     for variant in yada_variants(&fixture.profile_path) {
         let (bytes, build_time) = timed(|| compile(fixture, variant.strategy))?;
         let leaked: &'static [u8] = Box::leak(bytes.into_boxed_slice());
         let dictionary = BinaryDictionary::load_system(leaked)?;
         let trie_bytes = dictionary.lexicon.trie.total_size();
+        if variant.name == "classic_yada" {
+            classic = Some((leaked, build_time, trie_bytes));
+        }
         built.push(BuiltMatcher {
             name: variant.name,
             family: "yada",
@@ -415,34 +426,102 @@ fn build_yada_variants(fixture: &Fixture) -> ReportResult<Vec<BuiltMatcher>> {
             matcher: Matcher::Yada(dictionary),
         });
     }
+
+    // Pipelined + prefetched variants run over the *same* serialized classic
+    // Yada bytes — no rebuild, identical trie/heap/serialized size. This is the
+    // issue #117 runtime change: only the lookup driver differs.
+    if let Some((leaked, build_time, trie_bytes)) = classic {
+        for spec in pipelined_specs() {
+            let dictionary = BinaryDictionary::load_system(leaked)?;
+            built.push(BuiltMatcher {
+                name: spec.name,
+                family: "yada",
+                mode: MatchMode::PrefixAllStarts,
+                build_time,
+                heap_bytes: trie_bytes,
+                serialized_bytes: trie_bytes,
+                matcher: Matcher::YadaPipelined {
+                    dict: dictionary,
+                    lanes: spec.lanes,
+                    prefetch: spec.prefetch,
+                },
+            });
+        }
+    }
     Ok(built)
 }
 
-fn yada_variants(profile_path: &Path) -> Vec<YadaVariant> {
+struct PipelinedSpec {
+    name: &'static str,
+    lanes: usize,
+    prefetch: bool,
+}
+
+/// Lane-count / prefetch sweep for the runtime matcher. `yada_pipelined`
+/// isolates pure software pipelining (no explicit prefetch) from the
+/// prefetch-assisted rows.
+fn pipelined_specs() -> Vec<PipelinedSpec> {
     vec![
-        YadaVariant {
-            name: "classic_yada",
-            strategy: TrieBuildStrategy::ClassicYada,
+        PipelinedSpec {
+            name: "yada_pipelined",
+            lanes: 8,
+            prefetch: false,
         },
-        YadaVariant {
-            name: "cache_aware_uniform",
-            strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions {
-                profile_mode: TrieProfileMode::Uniform,
-                ..CacheAwareOptions::default()
-            }),
+        PipelinedSpec {
+            name: "yada_pipelined_prefetch_k4",
+            lanes: 4,
+            prefetch: true,
         },
-        YadaVariant {
-            name: "cache_aware_prefix",
-            strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions::default()),
+        PipelinedSpec {
+            name: "yada_pipelined_prefetch_k8",
+            lanes: 8,
+            prefetch: true,
         },
-        YadaVariant {
-            name: "cache_aware_external_profile",
-            strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions {
-                profile_mode: TrieProfileMode::ExternalKeyProfile(profile_path.to_owned()),
-                ..CacheAwareOptions::default()
-            }),
+        PipelinedSpec {
+            name: "yada_pipelined_prefetch_k12",
+            lanes: 12,
+            prefetch: true,
+        },
+        PipelinedSpec {
+            name: "yada_pipelined_prefetch_k16",
+            lanes: 16,
+            prefetch: true,
         },
     ]
+}
+
+fn yada_variants(profile_path: &Path) -> Vec<YadaVariant> {
+    let mut variants = vec![YadaVariant {
+        name: "classic_yada",
+        strategy: TrieBuildStrategy::ClassicYada,
+    }];
+    // The cache-aware *build-time* relayout variants are expensive to build
+    // (minutes per tier). Set SUDACHI_SKIP_BUILD_TIME_VARIANTS=1 to benchmark
+    // only the classic trie vs the runtime pipelined/prefetch matcher, which
+    // all share the same classic bytes and need just one fast build.
+    if !env_flag("SUDACHI_SKIP_BUILD_TIME_VARIANTS") {
+        variants.extend([
+            YadaVariant {
+                name: "cache_aware_uniform",
+                strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions {
+                    profile_mode: TrieProfileMode::Uniform,
+                    ..CacheAwareOptions::default()
+                }),
+            },
+            YadaVariant {
+                name: "cache_aware_prefix",
+                strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions::default()),
+            },
+            YadaVariant {
+                name: "cache_aware_external_profile",
+                strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions {
+                    profile_mode: TrieProfileMode::ExternalKeyProfile(profile_path.to_owned()),
+                    ..CacheAwareOptions::default()
+                }),
+            },
+        ]);
+    }
+    variants
 }
 
 fn compile(fixture: &Fixture, strategy: TrieBuildStrategy) -> ReportResult<Vec<u8>> {
@@ -807,6 +886,22 @@ impl Matcher {
                     }
                 }
             }
+            Matcher::YadaPipelined {
+                dict,
+                lanes,
+                prefetch,
+            } => {
+                let bytes = input.text.as_bytes();
+                dict.lexicon.trie.common_prefix_batch_cfg(
+                    bytes,
+                    &input.starts,
+                    *lanes,
+                    *prefetch,
+                    |bucket, value, end| {
+                        storage.push(bucket, StoredMatch { end, value });
+                    },
+                );
+            }
             Matcher::DaachorseBytewise(matcher) => {
                 for entry in matcher.find_overlapping_iter(input.text.as_bytes()) {
                     if !input.is_boundary(entry.end()) {
@@ -907,7 +1002,10 @@ impl Matcher {
         let mut storage = Storage::new(StorageKind::VecBucketsClearAll);
         storage.begin(text.starts.len().min(1));
         match self {
-            Matcher::Yada(dictionary) => {
+            Matcher::Yada(dictionary)
+            | Matcher::YadaPipelined {
+                dict: dictionary, ..
+            } => {
                 for entry in dictionary
                     .lexicon
                     .trie

--- a/sudachi/examples/dictionary_matcher_report.rs
+++ b/sudachi/examples/dictionary_matcher_report.rs
@@ -1,0 +1,1541 @@
+/*
+ *  Copyright (c) 2026 Works Applications Co., Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+use crawdad::{MpTrie as CrawdadMpTrie, Trie as CrawdadTrie};
+use daachorse::{CharwiseDoubleArrayAhoCorasick, DoubleArrayAhoCorasick};
+use fst::Map as FstMap;
+use rsmarisa::{Agent as MarisaAgent, Keyset as MarisaKeyset, Trie as MarisaTrie};
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::hint::black_box;
+use std::io::Write;
+use std::mem::size_of;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+use sudachi::dic::binary_loader::BinaryDictionary;
+use sudachi::dic::build::{CacheAwareOptions, DictBuilder, TrieBuildStrategy, TrieProfileMode};
+use tempfile::NamedTempFile;
+
+const MATRIX: &[u8] = include_bytes!("../src/dic/build/test/matrix_10x10.def");
+const LEXICON: &[u8] = include_bytes!("../src/dic/build/test/lex.csv");
+const DEFAULT_ROUNDS: usize = 1_000;
+const DEFAULT_INPUT_LIMIT: usize = 512;
+
+type ReportResult<T> = Result<T, Box<dyn Error>>;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct PipelineMatch {
+    start: usize,
+    end: usize,
+    value: u32,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct StoredMatch {
+    end: usize,
+    value: u32,
+}
+
+#[derive(Clone)]
+struct Entry {
+    surface: String,
+    value: u32,
+}
+
+struct Fixture {
+    data_set: String,
+    matrix: Vec<u8>,
+    lexicons: Vec<Vec<u8>>,
+    inputs: Vec<TextInput>,
+    rounds: usize,
+    profile_path: PathBuf,
+    _generated_profile: Option<NamedTempFile>,
+}
+
+struct TextInput {
+    text: String,
+    starts: Vec<usize>,
+    byte_to_start: Vec<usize>,
+    byte_boundaries: Vec<bool>,
+}
+
+#[derive(Clone)]
+struct YadaVariant {
+    name: &'static str,
+    strategy: TrieBuildStrategy,
+}
+
+struct BuiltMatcher {
+    name: &'static str,
+    family: &'static str,
+    mode: MatchMode,
+    build_time: Duration,
+    heap_bytes: usize,
+    serialized_bytes: usize,
+    matcher: Matcher,
+}
+
+struct FailedMatcher {
+    name: &'static str,
+    family: &'static str,
+    build_time: Duration,
+    error: String,
+}
+
+enum Matcher {
+    Yada(BinaryDictionary<'static>),
+    DaachorseBytewise(DoubleArrayAhoCorasick<u32>),
+    DaachorseCharwise(CharwiseDoubleArrayAhoCorasick<u32>),
+    CrawdadTrie(CrawdadTrie),
+    CrawdadMpTrie(CrawdadMpTrie),
+    Fst(FstMap<Vec<u8>>),
+    Marisa {
+        trie: MarisaTrie,
+        values: HashMap<Vec<u8>, u32>,
+    },
+}
+
+#[derive(Clone, Copy)]
+enum MatchMode {
+    PrefixAllStarts,
+    OnePassOverlapping,
+}
+
+#[derive(Clone, Copy)]
+enum StorageKind {
+    VecBucketsClearAll,
+    FlatBucketsClearAll,
+    FlatGenerationBuckets,
+}
+
+struct BenchmarkCase<'a> {
+    matcher: &'a BuiltMatcher,
+    storage: StorageKind,
+}
+
+struct ReportRow {
+    variant: String,
+    matcher: &'static str,
+    family: &'static str,
+    mode: &'static str,
+    storage: &'static str,
+    build_ms: f64,
+    match_ns_per_batch: u128,
+    match_ns_per_start: f64,
+    speed_vs_current: f64,
+    matcher_heap_bytes: usize,
+    storage_heap_bytes: usize,
+    total_heap_bytes: usize,
+    total_heap_vs_current: f64,
+    serialized_bytes: usize,
+    same_order: bool,
+    same_results: bool,
+    mismatches: usize,
+    checksum: u64,
+}
+
+struct Validation {
+    same_order: bool,
+    same_results: bool,
+    mismatches: usize,
+}
+
+fn main() -> ReportResult<()> {
+    let fixture = fixture();
+    let mut built = build_yada_variants(&fixture)?;
+    let entries = indexed_entries(&built[0], &fixture.lexicons)?;
+    let (alternative_matchers, failed_matchers) = build_alternative_matchers(&entries)?;
+    built.extend(alternative_matchers);
+
+    let rows = report_rows(&built, &fixture.inputs, fixture.rounds);
+    print_summary(&fixture);
+    print_tsv(&rows, &failed_matchers);
+    println!();
+    print_markdown(&rows, &failed_matchers);
+    Ok(())
+}
+
+fn fixture() -> Fixture {
+    let (matrix, lexicons, data_set) = read_dictionary_fixture();
+    let inputs = build_inputs(&lexicons);
+    let (profile_path, generated_profile) = external_profile_path(&inputs);
+    let rounds = env::var("SUDACHI_COMPARE_ROUNDS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_ROUNDS);
+
+    Fixture {
+        data_set,
+        matrix,
+        lexicons,
+        inputs,
+        rounds,
+        profile_path,
+        _generated_profile: generated_profile,
+    }
+}
+
+fn read_dictionary_fixture() -> (Vec<u8>, Vec<Vec<u8>>, String) {
+    let data_set_name = env::var("SUDACHI_TRIE_BENCH_DATA_SET_NAME").ok();
+    if let Some(paths) = env::var_os("SUDACHI_TRIE_BENCH_SURFACE_LEXICONS") {
+        let forms = read_surface_forms(paths);
+        let data_set = data_set_name
+            .unwrap_or_else(|| format!("generated lexicon from {} index forms", forms.len()));
+        return (MATRIX.to_vec(), vec![synthesize_lexicon(&forms)], data_set);
+    }
+
+    let matrix = read_env_bytes("SUDACHI_TRIE_BENCH_MATRIX", MATRIX);
+    let lexicons = read_lexicons();
+    let data_set = data_set_name.unwrap_or_else(|| {
+        if env::var_os("SUDACHI_TRIE_BENCH_LEXICONS").is_some()
+            || env::var_os("SUDACHI_TRIE_BENCH_LEXICON").is_some()
+        {
+            format!("provided lexicon files ({})", lexicons.len())
+        } else {
+            "built-in builder fixture".to_owned()
+        }
+    });
+    (matrix, lexicons, data_set)
+}
+
+fn read_surface_forms(paths: std::ffi::OsString) -> Vec<String> {
+    let mut forms = Vec::new();
+    for path in env::split_paths(&paths) {
+        let bytes = fs::read(&path).expect("failed to read surface source lexicon");
+        forms.extend(index_forms(&[bytes]));
+    }
+    forms.sort();
+    forms.dedup();
+    if let Some(limit) = env_usize("SUDACHI_TRIE_BENCH_ENTRY_LIMIT") {
+        forms = sample_inputs(forms, limit);
+    }
+    if forms.is_empty() {
+        panic!("surface source lexicons did not contain any index forms");
+    }
+    forms
+}
+
+fn synthesize_lexicon(forms: &[String]) -> Vec<u8> {
+    let mut writer = csv::WriterBuilder::new()
+        .has_headers(false)
+        .from_writer(Vec::new());
+    writer
+        .write_record([
+            "IndexForm",
+            "LeftId",
+            "RightId",
+            "Cost",
+            "Headword",
+            "POS1",
+            "POS2",
+            "POS3",
+            "POS4",
+            "POS5",
+            "POS6",
+            "Reading_Form",
+            "Normalized_Form",
+            "Dictionary_Form",
+            "Split_A",
+            "Split_B",
+            "Split_C",
+            "WordStructure",
+            "SynonymGroups",
+            "reference_id",
+        ])
+        .expect("failed to write generated lexicon header");
+    for form in forms {
+        writer
+            .write_record([
+                form.as_str(),
+                "1",
+                "1",
+                "5000",
+                "",
+                "名詞",
+                "普通名詞",
+                "一般",
+                "*",
+                "*",
+                "*",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+            ])
+            .expect("failed to write generated lexicon row");
+    }
+    writer
+        .into_inner()
+        .expect("failed to finish generated lexicon")
+}
+
+fn read_env_bytes(env_name: &str, fallback: &[u8]) -> Vec<u8> {
+    env::var_os(env_name)
+        .map(|path| fs::read(path).expect("failed to read benchmark input file"))
+        .unwrap_or_else(|| fallback.to_vec())
+}
+
+fn read_lexicons() -> Vec<Vec<u8>> {
+    if let Some(paths) = env::var_os("SUDACHI_TRIE_BENCH_LEXICONS") {
+        return env::split_paths(&paths)
+            .map(|path| fs::read(path).expect("failed to read benchmark lexicon"))
+            .collect();
+    }
+    if let Some(path) = env::var_os("SUDACHI_TRIE_BENCH_LEXICON") {
+        return vec![fs::read(path).expect("failed to read benchmark lexicon")];
+    }
+    vec![LEXICON.to_vec()]
+}
+
+fn build_inputs(lexicons: &[Vec<u8>]) -> Vec<TextInput> {
+    let limit = env_usize("SUDACHI_COMPARE_INPUT_LIMIT").unwrap_or(DEFAULT_INPUT_LIMIT);
+    let lines = env::var_os("SUDACHI_TRIE_BENCH_INPUTS")
+        .map(|path| read_inputs(PathBuf::from(path), limit))
+        .unwrap_or_else(|| synthetic_inputs(index_forms(lexicons), limit));
+    let inputs = lines
+        .into_iter()
+        .filter(|line| !line.is_empty())
+        .map(TextInput::new)
+        .filter(|input| !input.starts.is_empty())
+        .collect::<Vec<_>>();
+    if inputs.is_empty() {
+        vec![TextInput::new("東京都京都府".to_owned())]
+    } else {
+        inputs
+    }
+}
+
+fn synthetic_inputs(forms: Vec<String>, limit: usize) -> Vec<String> {
+    let mut forms = sample_inputs(forms, limit.saturating_mul(6).max(1));
+    if forms.is_empty() {
+        forms.push("東京都".to_owned());
+        forms.push("京都府".to_owned());
+    }
+
+    let mut lines = Vec::new();
+    for i in 0..limit.max(1) {
+        let a = &forms[i % forms.len()];
+        let b = &forms[(i * 7 + 3) % forms.len()];
+        let c = &forms[(i * 13 + 5) % forms.len()];
+        let d = &forms[(i * 17 + 11) % forms.len()];
+        lines.push(format!("{a}{b}、{c}{d}"));
+    }
+    lines.extend(
+        forms
+            .iter()
+            .take(limit / 4)
+            .map(|form| format!("{form}\u{e000}")),
+    );
+    dedup(lines)
+}
+
+fn read_inputs(path: PathBuf, limit: usize) -> Vec<String> {
+    fs::read_to_string(path)
+        .expect("failed to read benchmark inputs")
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .take(limit)
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn env_usize(name: &str) -> Option<usize> {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+}
+
+impl TextInput {
+    fn new(text: String) -> Self {
+        let mut starts = Vec::new();
+        let mut byte_to_start = vec![usize::MAX; text.len() + 1];
+        let mut byte_boundaries = vec![false; text.len() + 1];
+        for (ordinal, (offset, _)) in text.char_indices().enumerate() {
+            starts.push(offset);
+            byte_to_start[offset] = ordinal;
+            byte_boundaries[offset] = true;
+        }
+        byte_boundaries[text.len()] = true;
+
+        Self {
+            text,
+            starts,
+            byte_to_start,
+            byte_boundaries,
+        }
+    }
+
+    fn bucket_for_start(&self, offset: usize) -> Option<usize> {
+        self.byte_to_start
+            .get(offset)
+            .copied()
+            .filter(|bucket| *bucket != usize::MAX)
+    }
+
+    fn is_boundary(&self, offset: usize) -> bool {
+        self.byte_boundaries.get(offset).copied().unwrap_or(false)
+    }
+}
+
+fn build_yada_variants(fixture: &Fixture) -> ReportResult<Vec<BuiltMatcher>> {
+    let mut built = Vec::new();
+    for variant in yada_variants(&fixture.profile_path) {
+        let (bytes, build_time) = timed(|| compile(fixture, variant.strategy))?;
+        let leaked: &'static [u8] = Box::leak(bytes.into_boxed_slice());
+        let dictionary = BinaryDictionary::load_system(leaked)?;
+        let trie_bytes = dictionary.lexicon.trie.total_size();
+        built.push(BuiltMatcher {
+            name: variant.name,
+            family: "yada",
+            mode: MatchMode::PrefixAllStarts,
+            build_time,
+            heap_bytes: trie_bytes,
+            serialized_bytes: trie_bytes,
+            matcher: Matcher::Yada(dictionary),
+        });
+    }
+    Ok(built)
+}
+
+fn yada_variants(profile_path: &Path) -> Vec<YadaVariant> {
+    vec![
+        YadaVariant {
+            name: "classic_yada",
+            strategy: TrieBuildStrategy::ClassicYada,
+        },
+        YadaVariant {
+            name: "cache_aware_uniform",
+            strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions {
+                profile_mode: TrieProfileMode::Uniform,
+                ..CacheAwareOptions::default()
+            }),
+        },
+        YadaVariant {
+            name: "cache_aware_prefix",
+            strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions::default()),
+        },
+        YadaVariant {
+            name: "cache_aware_external_profile",
+            strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions {
+                profile_mode: TrieProfileMode::ExternalKeyProfile(profile_path.to_owned()),
+                ..CacheAwareOptions::default()
+            }),
+        },
+    ]
+}
+
+fn compile(fixture: &Fixture, strategy: TrieBuildStrategy) -> ReportResult<Vec<u8>> {
+    let mut builder = DictBuilder::new_system();
+    builder.set_trie_build_strategy(strategy);
+    builder.read_conn(fixture.matrix.as_slice())?;
+    for lexicon in &fixture.lexicons {
+        builder.read_lexicon(lexicon.as_slice())?;
+    }
+    builder.resolve()?;
+
+    let mut bytes = Vec::new();
+    builder.compile(&mut bytes)?;
+    Ok(bytes)
+}
+
+fn build_alternative_matchers(
+    entries: &[Entry],
+) -> ReportResult<(Vec<BuiltMatcher>, Vec<FailedMatcher>)> {
+    let mut built = Vec::new();
+    let mut failed = Vec::new();
+
+    let (matcher, build_time) = timed(|| {
+        DoubleArrayAhoCorasick::with_values(
+            entries
+                .iter()
+                .map(|entry| (entry.surface.as_bytes(), entry.value)),
+        )
+        .map_err(|error| other_error(format!("failed to build daachorse bytewise: {error:?}")))
+    })?;
+    let heap_bytes = matcher.heap_bytes();
+    let serialized_bytes = matcher.serialize().len();
+    built.push(BuiltMatcher {
+        name: "daachorse_bytewise",
+        family: "aho-corasick",
+        mode: MatchMode::OnePassOverlapping,
+        build_time,
+        heap_bytes,
+        serialized_bytes,
+        matcher: Matcher::DaachorseBytewise(matcher),
+    });
+
+    let (matcher, build_time) = timed(|| {
+        CharwiseDoubleArrayAhoCorasick::with_values(
+            entries
+                .iter()
+                .map(|entry| (entry.surface.as_str(), entry.value)),
+        )
+        .map_err(|error| other_error(format!("failed to build daachorse charwise: {error:?}")))
+    })?;
+    let heap_bytes = matcher.heap_bytes();
+    let serialized_bytes = matcher.serialize().len();
+    built.push(BuiltMatcher {
+        name: "daachorse_charwise",
+        family: "aho-corasick",
+        mode: MatchMode::OnePassOverlapping,
+        build_time,
+        heap_bytes,
+        serialized_bytes,
+        matcher: Matcher::DaachorseCharwise(matcher),
+    });
+
+    let records = entries
+        .iter()
+        .map(|entry| (entry.surface.as_str(), entry.value))
+        .collect::<Vec<_>>();
+
+    let (matcher, build_time) = timed(|| {
+        CrawdadTrie::from_records(records.iter().copied())
+            .map_err(|error| other_error(format!("failed to build crawdad trie: {error:?}")))
+    })?;
+    let heap_bytes = matcher.heap_bytes();
+    let serialized_bytes = matcher.io_bytes();
+    built.push(BuiltMatcher {
+        name: "crawdad_trie",
+        family: "charwise-dat",
+        mode: MatchMode::PrefixAllStarts,
+        build_time,
+        heap_bytes,
+        serialized_bytes,
+        matcher: Matcher::CrawdadTrie(matcher),
+    });
+
+    match timed(|| {
+        CrawdadMpTrie::from_records(records.iter().copied())
+            .map_err(|error| other_error(format!("failed to build crawdad mptrie: {error:?}")))
+    }) {
+        Ok((matcher, build_time)) => {
+            let heap_bytes = matcher.heap_bytes();
+            let serialized_bytes = matcher.io_bytes();
+            built.push(BuiltMatcher {
+                name: "crawdad_mptrie",
+                family: "charwise-dat",
+                mode: MatchMode::PrefixAllStarts,
+                build_time,
+                heap_bytes,
+                serialized_bytes,
+                matcher: Matcher::CrawdadMpTrie(matcher),
+            });
+        }
+        Err(error) => failed.push(FailedMatcher {
+            name: "crawdad_mptrie",
+            family: "charwise-dat",
+            build_time: Duration::ZERO,
+            error: error.to_string(),
+        }),
+    }
+
+    let (matcher, build_time) = timed(|| {
+        FstMap::from_iter(
+            entries
+                .iter()
+                .map(|entry| (entry.surface.as_bytes(), entry.value as u64)),
+        )
+    })?;
+    let serialized_bytes = matcher.as_fst().size();
+    built.push(BuiltMatcher {
+        name: "fst_map_prefix_scan",
+        family: "fst",
+        mode: MatchMode::PrefixAllStarts,
+        build_time,
+        heap_bytes: serialized_bytes,
+        serialized_bytes,
+        matcher: Matcher::Fst(matcher),
+    });
+
+    let (matcher, build_time) = timed(|| build_marisa(entries))?;
+    let heap_bytes = matcher.total_size();
+    let serialized_bytes = matcher.io_size();
+    let values = entries
+        .iter()
+        .map(|entry| (entry.surface.as_bytes().to_vec(), entry.value))
+        .collect();
+    built.push(BuiltMatcher {
+        name: "rsmarisa_trie",
+        family: "louds",
+        mode: MatchMode::PrefixAllStarts,
+        build_time,
+        heap_bytes,
+        serialized_bytes,
+        matcher: Matcher::Marisa {
+            trie: matcher,
+            values,
+        },
+    });
+
+    Ok((built, failed))
+}
+
+fn build_marisa(entries: &[Entry]) -> ReportResult<MarisaTrie> {
+    let mut keyset = MarisaKeyset::new();
+    for entry in entries {
+        keyset.push_back_str(&entry.surface)?;
+    }
+    let mut trie = MarisaTrie::new();
+    trie.build(&mut keyset, 0);
+    Ok(trie)
+}
+
+fn other_error(message: String) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::Other, message)
+}
+
+fn indexed_entries(baseline: &BuiltMatcher, lexicons: &[Vec<u8>]) -> ReportResult<Vec<Entry>> {
+    let mut entries = Vec::new();
+    for surface in index_forms(lexicons) {
+        let exact = baseline
+            .matcher
+            .lookup_from_start(&surface)
+            .into_iter()
+            .find(|entry| entry.end == surface.len());
+        if let Some(entry) = exact {
+            entries.push(Entry {
+                surface,
+                value: entry.value,
+            });
+        }
+    }
+    entries.sort_by(|left, right| left.surface.cmp(&right.surface));
+    entries.dedup_by(|left, right| left.surface == right.surface);
+    if entries.is_empty() {
+        return Err("no indexed entries were collected from the baseline trie".into());
+    }
+    Ok(entries)
+}
+
+fn report_rows(built: &[BuiltMatcher], inputs: &[TextInput], rounds: usize) -> Vec<ReportRow> {
+    let baseline_results = collect_all_matches(&built[0].matcher, inputs);
+    let validations = built
+        .iter()
+        .map(|candidate| validate(&candidate.matcher, inputs, &baseline_results))
+        .collect::<Vec<_>>();
+    let total_starts = total_char_starts(inputs).max(1);
+
+    let mut rows = benchmark_cases(built)
+        .into_iter()
+        .map(|case| {
+            let validation = &validations[matcher_index(built, case.matcher)];
+            let (match_ns_per_batch, checksum, storage_heap_bytes) =
+                measure(&case.matcher.matcher, case.storage, inputs, rounds);
+            let total_heap_bytes = case.matcher.heap_bytes + storage_heap_bytes;
+            ReportRow {
+                variant: case.variant_name(),
+                matcher: case.matcher.name,
+                family: case.matcher.family,
+                mode: case.matcher.mode.name(),
+                storage: case.storage.name(),
+                build_ms: case.matcher.build_time.as_secs_f64() * 1000.0,
+                match_ns_per_batch,
+                match_ns_per_start: match_ns_per_batch as f64 / total_starts as f64,
+                speed_vs_current: 1.0,
+                matcher_heap_bytes: case.matcher.heap_bytes,
+                storage_heap_bytes,
+                total_heap_bytes,
+                total_heap_vs_current: 1.0,
+                serialized_bytes: case.matcher.serialized_bytes,
+                same_order: validation.same_order,
+                same_results: validation.same_results,
+                mismatches: validation.mismatches,
+                checksum,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let baseline_ns = rows[0].match_ns_per_batch.max(1);
+    let baseline_heap = rows[0].total_heap_bytes.max(1) as f64;
+    for row in &mut rows {
+        row.speed_vs_current = baseline_ns as f64 / row.match_ns_per_batch.max(1) as f64;
+        row.total_heap_vs_current = row.total_heap_bytes as f64 / baseline_heap;
+    }
+    rows
+}
+
+fn matcher_index(built: &[BuiltMatcher], matcher: &BuiltMatcher) -> usize {
+    built
+        .iter()
+        .position(|candidate| std::ptr::eq(candidate, matcher))
+        .expect("benchmark case references unknown matcher")
+}
+
+fn benchmark_cases(built: &[BuiltMatcher]) -> Vec<BenchmarkCase<'_>> {
+    if !env_flag("SUDACHI_COMPARE_STORAGE_VARIANTS") {
+        return built
+            .iter()
+            .map(|matcher| BenchmarkCase {
+                matcher,
+                storage: StorageKind::VecBucketsClearAll,
+            })
+            .collect();
+    }
+
+    let mut cases = Vec::new();
+    for matcher in built {
+        match matcher.name {
+            "classic_yada" | "cache_aware_prefix" | "daachorse_charwise" => {
+                cases.push(BenchmarkCase {
+                    matcher,
+                    storage: StorageKind::VecBucketsClearAll,
+                });
+                cases.push(BenchmarkCase {
+                    matcher,
+                    storage: StorageKind::FlatBucketsClearAll,
+                });
+                cases.push(BenchmarkCase {
+                    matcher,
+                    storage: StorageKind::FlatGenerationBuckets,
+                });
+            }
+            "cache_aware_uniform" | "cache_aware_external_profile" => cases.push(BenchmarkCase {
+                matcher,
+                storage: StorageKind::VecBucketsClearAll,
+            }),
+            "daachorse_bytewise" => {
+                cases.push(BenchmarkCase {
+                    matcher,
+                    storage: StorageKind::FlatBucketsClearAll,
+                });
+                cases.push(BenchmarkCase {
+                    matcher,
+                    storage: StorageKind::FlatGenerationBuckets,
+                });
+            }
+            _ => cases.push(BenchmarkCase {
+                matcher,
+                storage: StorageKind::FlatBucketsClearAll,
+            }),
+        }
+    }
+    cases
+}
+
+fn env_flag(name: &str) -> bool {
+    env::var(name)
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
+}
+
+impl BenchmarkCase<'_> {
+    fn variant_name(&self) -> String {
+        format!(
+            "{}_{}+{}",
+            self.matcher.name,
+            self.matcher.mode.name(),
+            self.storage.name()
+        )
+    }
+}
+
+fn collect_all_matches(matcher: &Matcher, inputs: &[TextInput]) -> Vec<Vec<PipelineMatch>> {
+    let mut storage = Storage::new(StorageKind::VecBucketsClearAll);
+    inputs
+        .iter()
+        .map(|input| {
+            storage.begin(input.starts.len());
+            matcher.emit(input, &mut storage);
+            storage.finish_matches(&input.starts)
+        })
+        .collect()
+}
+
+fn validate(
+    candidate: &Matcher,
+    inputs: &[TextInput],
+    baseline_results: &[Vec<PipelineMatch>],
+) -> Validation {
+    let actual_results = collect_all_matches(candidate, inputs);
+    let mut same_order = true;
+    let mut same_results = true;
+    let mut mismatches = 0;
+
+    for (actual, expected) in actual_results.into_iter().zip(baseline_results) {
+        if &actual != expected {
+            same_order = false;
+        }
+        if sorted(actual) != sorted(expected.clone()) {
+            same_results = false;
+            mismatches += 1;
+        }
+    }
+
+    Validation {
+        same_order,
+        same_results,
+        mismatches,
+    }
+}
+
+impl Matcher {
+    fn emit(&self, input: &TextInput, storage: &mut Storage) {
+        match self {
+            Matcher::Yada(dictionary) => {
+                let bytes = input.text.as_bytes();
+                for (bucket, &start) in input.starts.iter().enumerate() {
+                    for entry in dictionary.lexicon.trie.common_prefix_iterator(bytes, start) {
+                        storage.push(
+                            bucket,
+                            StoredMatch {
+                                end: entry.end,
+                                value: entry.value,
+                            },
+                        );
+                    }
+                }
+            }
+            Matcher::DaachorseBytewise(matcher) => {
+                for entry in matcher.find_overlapping_iter(input.text.as_bytes()) {
+                    if !input.is_boundary(entry.end()) {
+                        continue;
+                    }
+                    if let Some(bucket) = input.bucket_for_start(entry.start()) {
+                        storage.push(
+                            bucket,
+                            StoredMatch {
+                                end: entry.end(),
+                                value: entry.value(),
+                            },
+                        );
+                    }
+                }
+            }
+            Matcher::DaachorseCharwise(matcher) => {
+                for entry in matcher.find_overlapping_iter(&input.text) {
+                    if let Some(bucket) = input.bucket_for_start(entry.start()) {
+                        storage.push(
+                            bucket,
+                            StoredMatch {
+                                end: entry.end(),
+                                value: entry.value(),
+                            },
+                        );
+                    }
+                }
+            }
+            Matcher::CrawdadTrie(matcher) => {
+                for (bucket, &start) in input.starts.iter().enumerate() {
+                    let suffix = &input.text[start..];
+                    for (value, char_len) in matcher.common_prefix_search(suffix.chars()) {
+                        storage.push(
+                            bucket,
+                            StoredMatch {
+                                end: start + byte_end_for_chars(suffix, char_len),
+                                value,
+                            },
+                        );
+                    }
+                }
+            }
+            Matcher::CrawdadMpTrie(matcher) => {
+                for (bucket, &start) in input.starts.iter().enumerate() {
+                    let suffix = &input.text[start..];
+                    for (value, char_len) in matcher.common_prefix_search(suffix.chars()) {
+                        storage.push(
+                            bucket,
+                            StoredMatch {
+                                end: start + byte_end_for_chars(suffix, char_len),
+                                value,
+                            },
+                        );
+                    }
+                }
+            }
+            Matcher::Fst(matcher) => {
+                for (bucket, &start) in input.starts.iter().enumerate() {
+                    let suffix = &input.text[start..];
+                    for end in prefix_byte_ends(suffix).map(|end| start + end) {
+                        if let Some(value) = matcher.get(&input.text.as_bytes()[start..end]) {
+                            storage.push(
+                                bucket,
+                                StoredMatch {
+                                    end,
+                                    value: value as u32,
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+            Matcher::Marisa { trie, values } => {
+                for (bucket, &start) in input.starts.iter().enumerate() {
+                    let suffix = &input.text[start..];
+                    let mut agent = MarisaAgent::new();
+                    agent.set_query_str(suffix);
+                    while trie.common_prefix_search(&mut agent) {
+                        let key = agent.key().as_bytes();
+                        if let Some(value) = values.get(key) {
+                            storage.push(
+                                bucket,
+                                StoredMatch {
+                                    end: start + key.len(),
+                                    value: *value,
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn lookup_from_start(&self, input: &str) -> Vec<PipelineMatch> {
+        let text = TextInput::new(input.to_owned());
+        let mut storage = Storage::new(StorageKind::VecBucketsClearAll);
+        storage.begin(text.starts.len().min(1));
+        match self {
+            Matcher::Yada(dictionary) => {
+                for entry in dictionary
+                    .lexicon
+                    .trie
+                    .common_prefix_iterator(input.as_bytes(), 0)
+                {
+                    storage.push(
+                        0,
+                        StoredMatch {
+                            end: entry.end,
+                            value: entry.value,
+                        },
+                    );
+                }
+            }
+            _ => self.emit(&text, &mut storage),
+        }
+        storage.finish_matches(&[0])
+    }
+}
+
+fn measure(
+    matcher: &Matcher,
+    storage_kind: StorageKind,
+    inputs: &[TextInput],
+    rounds: usize,
+) -> (u128, u64, usize) {
+    let mut storage = Storage::new(storage_kind);
+    let started = Instant::now();
+    let mut checksum = 0u64;
+    for _ in 0..rounds {
+        for input in inputs {
+            storage.begin(input.starts.len());
+            matcher.emit(input, &mut storage);
+            checksum = storage.finish_checksum(&input.starts, checksum);
+        }
+    }
+    black_box(checksum);
+    (
+        started.elapsed().as_nanos() / rounds.max(1) as u128,
+        checksum,
+        storage.retained_bytes(),
+    )
+}
+
+enum Storage {
+    VecBuckets(VecBucketStorage),
+    FlatBuckets(FlatBucketStorage),
+    FlatGeneration(FlatGenerationStorage),
+}
+
+impl Storage {
+    fn new(kind: StorageKind) -> Self {
+        match kind {
+            StorageKind::VecBucketsClearAll => Self::VecBuckets(VecBucketStorage::default()),
+            StorageKind::FlatBucketsClearAll => Self::FlatBuckets(FlatBucketStorage::default()),
+            StorageKind::FlatGenerationBuckets => {
+                Self::FlatGeneration(FlatGenerationStorage::default())
+            }
+        }
+    }
+
+    fn begin(&mut self, bucket_count: usize) {
+        match self {
+            Self::VecBuckets(storage) => storage.begin(bucket_count),
+            Self::FlatBuckets(storage) => storage.begin(bucket_count),
+            Self::FlatGeneration(storage) => storage.begin(bucket_count),
+        }
+    }
+
+    fn push(&mut self, bucket: usize, item: StoredMatch) {
+        match self {
+            Self::VecBuckets(storage) => storage.push(bucket, item),
+            Self::FlatBuckets(storage) => storage.push(bucket, item),
+            Self::FlatGeneration(storage) => storage.push(bucket, item),
+        }
+    }
+
+    fn finish_checksum(&mut self, starts: &[usize], checksum: u64) -> u64 {
+        match self {
+            Self::VecBuckets(storage) => storage.finish_checksum(starts, checksum),
+            Self::FlatBuckets(storage) => storage.finish_checksum(starts, checksum),
+            Self::FlatGeneration(storage) => storage.finish_checksum(starts, checksum),
+        }
+    }
+
+    fn finish_matches(&mut self, starts: &[usize]) -> Vec<PipelineMatch> {
+        match self {
+            Self::VecBuckets(storage) => storage.finish_matches(starts),
+            Self::FlatBuckets(storage) => storage.finish_matches(starts),
+            Self::FlatGeneration(storage) => storage.finish_matches(starts),
+        }
+    }
+
+    fn retained_bytes(&self) -> usize {
+        match self {
+            Self::VecBuckets(storage) => storage.retained_bytes(),
+            Self::FlatBuckets(storage) => storage.retained_bytes(),
+            Self::FlatGeneration(storage) => storage.retained_bytes(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct VecBucketStorage {
+    buckets: Vec<Vec<StoredMatch>>,
+}
+
+impl VecBucketStorage {
+    fn begin(&mut self, bucket_count: usize) {
+        if self.buckets.len() < bucket_count {
+            self.buckets.resize_with(bucket_count, Vec::new);
+        }
+        for bucket in self.buckets.iter_mut().take(bucket_count) {
+            bucket.clear();
+        }
+    }
+
+    fn push(&mut self, bucket: usize, item: StoredMatch) {
+        if let Some(items) = self.buckets.get_mut(bucket) {
+            items.push(item);
+        }
+    }
+
+    fn finish_checksum(&self, starts: &[usize], mut checksum: u64) -> u64 {
+        for (bucket, &start) in starts.iter().enumerate() {
+            if let Some(items) = self.buckets.get(bucket) {
+                for item in items {
+                    checksum = mix_checksum(checksum, start, *item);
+                }
+            }
+        }
+        checksum
+    }
+
+    fn finish_matches(&self, starts: &[usize]) -> Vec<PipelineMatch> {
+        let mut matches = Vec::new();
+        for (bucket, &start) in starts.iter().enumerate() {
+            if let Some(items) = self.buckets.get(bucket) {
+                matches.extend(items.iter().map(|item| PipelineMatch {
+                    start,
+                    end: item.end,
+                    value: item.value,
+                }));
+            }
+        }
+        matches
+    }
+
+    fn retained_bytes(&self) -> usize {
+        self.buckets.capacity() * size_of::<Vec<StoredMatch>>()
+            + self
+                .buckets
+                .iter()
+                .map(|bucket| bucket.capacity() * size_of::<StoredMatch>())
+                .sum::<usize>()
+    }
+}
+
+#[derive(Default)]
+struct FlatBucketStorage {
+    heads: Vec<usize>,
+    tails: Vec<usize>,
+    next: Vec<usize>,
+    items: Vec<StoredMatch>,
+    bucket_count: usize,
+}
+
+impl FlatBucketStorage {
+    fn begin(&mut self, bucket_count: usize) {
+        self.bucket_count = bucket_count;
+        if self.heads.len() < bucket_count {
+            self.heads.resize(bucket_count, usize::MAX);
+            self.tails.resize(bucket_count, usize::MAX);
+        }
+        for bucket in 0..bucket_count {
+            self.heads[bucket] = usize::MAX;
+            self.tails[bucket] = usize::MAX;
+        }
+        self.items.clear();
+        self.next.clear();
+    }
+
+    fn push(&mut self, bucket: usize, item: StoredMatch) {
+        if bucket < self.bucket_count {
+            let index = self.items.len();
+            self.items.push(item);
+            self.next.push(usize::MAX);
+            if self.heads[bucket] == usize::MAX {
+                self.heads[bucket] = index;
+            } else {
+                self.next[self.tails[bucket]] = index;
+            }
+            self.tails[bucket] = index;
+        }
+    }
+
+    fn finish_checksum(&mut self, starts: &[usize], checksum: u64) -> u64 {
+        checksum_from_linked(starts, &self.heads, &self.next, &self.items, checksum)
+    }
+
+    fn finish_matches(&mut self, starts: &[usize]) -> Vec<PipelineMatch> {
+        matches_from_linked(starts, &self.heads, &self.next, &self.items)
+    }
+
+    fn retained_bytes(&self) -> usize {
+        self.heads.capacity() * size_of::<usize>()
+            + self.tails.capacity() * size_of::<usize>()
+            + self.next.capacity() * size_of::<usize>()
+            + self.items.capacity() * size_of::<StoredMatch>()
+    }
+}
+
+#[derive(Default)]
+struct FlatGenerationStorage {
+    heads: Vec<usize>,
+    tails: Vec<usize>,
+    generations: Vec<u32>,
+    next: Vec<usize>,
+    items: Vec<StoredMatch>,
+    bucket_count: usize,
+    current_generation: u32,
+}
+
+impl FlatGenerationStorage {
+    fn begin(&mut self, bucket_count: usize) {
+        self.bucket_count = bucket_count;
+        self.current_generation = self.current_generation.wrapping_add(1).max(1);
+        if self.heads.len() < bucket_count {
+            self.heads.resize(bucket_count, usize::MAX);
+            self.tails.resize(bucket_count, usize::MAX);
+            self.generations.resize(bucket_count, 0);
+        }
+        if self.current_generation == u32::MAX {
+            self.generations.fill(0);
+            self.current_generation = 1;
+        }
+        self.items.clear();
+        self.next.clear();
+    }
+
+    fn push(&mut self, bucket: usize, item: StoredMatch) {
+        if bucket >= self.bucket_count {
+            return;
+        }
+        if self.generations[bucket] != self.current_generation {
+            self.generations[bucket] = self.current_generation;
+            self.heads[bucket] = usize::MAX;
+            self.tails[bucket] = usize::MAX;
+        }
+        let index = self.items.len();
+        self.items.push(item);
+        self.next.push(usize::MAX);
+        if self.heads[bucket] == usize::MAX {
+            self.heads[bucket] = index;
+        } else {
+            self.next[self.tails[bucket]] = index;
+        }
+        self.tails[bucket] = index;
+    }
+
+    fn finish_checksum(&mut self, starts: &[usize], checksum: u64) -> u64 {
+        let current_generation = self.current_generation;
+        checksum_from_linked_with_generation(
+            starts,
+            &self.heads,
+            &self.next,
+            &self.items,
+            &self.generations,
+            current_generation,
+            checksum,
+        )
+    }
+
+    fn finish_matches(&mut self, starts: &[usize]) -> Vec<PipelineMatch> {
+        matches_from_linked_with_generation(
+            starts,
+            &self.heads,
+            &self.next,
+            &self.items,
+            &self.generations,
+            self.current_generation,
+        )
+    }
+
+    fn retained_bytes(&self) -> usize {
+        self.heads.capacity() * size_of::<usize>()
+            + self.tails.capacity() * size_of::<usize>()
+            + self.generations.capacity() * size_of::<u32>()
+            + self.next.capacity() * size_of::<usize>()
+            + self.items.capacity() * size_of::<StoredMatch>()
+    }
+}
+
+fn checksum_from_linked(
+    starts: &[usize],
+    heads: &[usize],
+    next: &[usize],
+    items: &[StoredMatch],
+    mut checksum: u64,
+) -> u64 {
+    for (bucket, &start) in starts.iter().enumerate() {
+        let mut index = heads[bucket];
+        while index != usize::MAX {
+            checksum = mix_checksum(checksum, start, items[index]);
+            index = next[index];
+        }
+    }
+    checksum
+}
+
+fn matches_from_linked(
+    starts: &[usize],
+    heads: &[usize],
+    next: &[usize],
+    items: &[StoredMatch],
+) -> Vec<PipelineMatch> {
+    let mut matches = Vec::new();
+    for (bucket, &start) in starts.iter().enumerate() {
+        let mut index = heads[bucket];
+        while index != usize::MAX {
+            let item = items[index];
+            matches.push(PipelineMatch {
+                start,
+                end: item.end,
+                value: item.value,
+            });
+            index = next[index];
+        }
+    }
+    matches
+}
+
+fn checksum_from_linked_with_generation(
+    starts: &[usize],
+    heads: &[usize],
+    next: &[usize],
+    items: &[StoredMatch],
+    generations: &[u32],
+    current_generation: u32,
+    mut checksum: u64,
+) -> u64 {
+    for (bucket, &start) in starts.iter().enumerate() {
+        if generations[bucket] != current_generation {
+            continue;
+        }
+        let mut index = heads[bucket];
+        while index != usize::MAX {
+            checksum = mix_checksum(checksum, start, items[index]);
+            index = next[index];
+        }
+    }
+    checksum
+}
+
+fn matches_from_linked_with_generation(
+    starts: &[usize],
+    heads: &[usize],
+    next: &[usize],
+    items: &[StoredMatch],
+    generations: &[u32],
+    current_generation: u32,
+) -> Vec<PipelineMatch> {
+    let mut matches = Vec::new();
+    for (bucket, &start) in starts.iter().enumerate() {
+        if generations[bucket] != current_generation {
+            continue;
+        }
+        let mut index = heads[bucket];
+        while index != usize::MAX {
+            let item = items[index];
+            matches.push(PipelineMatch {
+                start,
+                end: item.end,
+                value: item.value,
+            });
+            index = next[index];
+        }
+    }
+    matches
+}
+
+fn mix_checksum(checksum: u64, start: usize, item: StoredMatch) -> u64 {
+    checksum
+        .wrapping_mul(16_777_619)
+        .wrapping_add(start as u64)
+        .wrapping_mul(16_777_619)
+        .wrapping_add(item.end as u64)
+        .wrapping_mul(16_777_619)
+        .wrapping_add(item.value as u64)
+}
+
+impl MatchMode {
+    fn name(self) -> &'static str {
+        match self {
+            Self::PrefixAllStarts => "prefix_all_starts",
+            Self::OnePassOverlapping => "one_pass_overlapping",
+        }
+    }
+}
+
+impl StorageKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::VecBucketsClearAll => "vec_buckets_clear_all",
+            Self::FlatBucketsClearAll => "flat_buckets_clear_all",
+            Self::FlatGenerationBuckets => "flat_generation_buckets",
+        }
+    }
+}
+
+fn index_forms(lexicons: &[Vec<u8>]) -> Vec<String> {
+    let mut forms = Vec::new();
+    for lexicon in lexicons {
+        forms.extend(index_forms_with_headers(lexicon));
+    }
+    if forms.is_empty() {
+        for lexicon in lexicons {
+            forms.extend(index_forms_without_headers(lexicon));
+        }
+    }
+    dedup(forms)
+}
+
+fn index_forms_with_headers(lexicon: &[u8]) -> Vec<String> {
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .from_reader(lexicon);
+    let index_col = reader
+        .headers()
+        .ok()
+        .and_then(|headers| {
+            headers
+                .iter()
+                .position(|header| header.eq_ignore_ascii_case("index_form"))
+        })
+        .unwrap_or(0);
+    reader
+        .records()
+        .flatten()
+        .filter_map(|record| record.get(index_col).map(ToOwned::to_owned))
+        .filter(|form| !form.is_empty())
+        .collect()
+}
+
+fn index_forms_without_headers(lexicon: &[u8]) -> Vec<String> {
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .from_reader(lexicon);
+    reader
+        .records()
+        .flatten()
+        .filter_map(|record| record.get(0).map(ToOwned::to_owned))
+        .filter(|form| {
+            !form.is_empty()
+                && !form.eq_ignore_ascii_case("index_form")
+                && !form.eq_ignore_ascii_case("indexform")
+        })
+        .collect()
+}
+
+fn sample_inputs(mut inputs: Vec<String>, limit: usize) -> Vec<String> {
+    inputs.sort();
+    inputs.dedup();
+    if limit == 0 || inputs.len() <= limit {
+        return inputs;
+    }
+
+    (0..limit)
+        .map(|i| {
+            let index = i * inputs.len() / limit;
+            inputs[index].clone()
+        })
+        .collect()
+}
+
+fn dedup(inputs: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    inputs
+        .into_iter()
+        .filter(|input| seen.insert(input.clone()))
+        .collect()
+}
+
+fn external_profile_path(inputs: &[TextInput]) -> (PathBuf, Option<NamedTempFile>) {
+    if let Some(path) = env::var_os("SUDACHI_TRIE_BENCH_PROFILE") {
+        return (PathBuf::from(path), None);
+    }
+
+    let mut file = NamedTempFile::new().expect("failed to create benchmark profile");
+    let max = inputs.len();
+    for (rank, input) in inputs.iter().enumerate() {
+        write_profile_key(&mut file, input.text.as_bytes());
+        writeln!(file, "\t{}", max - rank).expect("failed to write benchmark profile");
+    }
+    (file.path().to_owned(), Some(file))
+}
+
+fn write_profile_key<W: Write>(writer: &mut W, bytes: &[u8]) {
+    writer
+        .write_all(b"hex:")
+        .expect("failed to write benchmark profile");
+    for byte in bytes {
+        write!(writer, "{byte:02X}").expect("failed to write benchmark profile");
+    }
+}
+
+fn prefix_byte_ends(input: &str) -> impl Iterator<Item = usize> + '_ {
+    input
+        .char_indices()
+        .map(|(idx, ch)| idx + ch.len_utf8())
+        .filter(|end| *end <= input.len())
+}
+
+fn byte_end_for_chars(input: &str, char_len: usize) -> usize {
+    input
+        .char_indices()
+        .nth(char_len)
+        .map(|(idx, _)| idx)
+        .unwrap_or_else(|| input.len())
+}
+
+fn sorted(mut entries: Vec<PipelineMatch>) -> Vec<PipelineMatch> {
+    entries.sort();
+    entries
+}
+
+fn timed<T, E>(f: impl FnOnce() -> Result<T, E>) -> Result<(T, Duration), E> {
+    let started = Instant::now();
+    let value = f()?;
+    Ok((value, started.elapsed()))
+}
+
+fn total_char_starts(inputs: &[TextInput]) -> usize {
+    inputs.iter().map(|input| input.starts.len()).sum()
+}
+
+fn print_summary(fixture: &Fixture) {
+    let chars: usize = fixture
+        .inputs
+        .iter()
+        .map(|input| input.text.chars().count())
+        .sum();
+    println!("# data_set: {}", fixture.data_set);
+    println!("# inputs: {}", fixture.inputs.len());
+    println!("# chars_per_batch: {}", chars);
+    println!(
+        "# char_starts_per_batch: {}",
+        total_char_starts(&fixture.inputs)
+    );
+    println!("# rounds: {}", fixture.rounds);
+}
+
+fn print_tsv(rows: &[ReportRow], failed: &[FailedMatcher]) {
+    println!(
+        "variant\tmatcher\tfamily\tmode\tstorage\tbuild_ms\tmatch_ns_per_batch\tmatch_ns_per_start\tspeed_vs_current\tmatcher_heap_bytes\tstorage_heap_bytes\ttotal_heap_bytes\ttotal_heap_vs_current\tserialized_bytes\tsame_order\tsame_results\tmismatches\tchecksum"
+    );
+    for row in rows {
+        println!(
+            "{}\t{}\t{}\t{}\t{}\t{:.3}\t{}\t{:.3}\t{:.3}\t{}\t{}\t{}\t{:.3}\t{}\t{}\t{}\t{}\t{}",
+            row.variant,
+            row.matcher,
+            row.family,
+            row.mode,
+            row.storage,
+            row.build_ms,
+            row.match_ns_per_batch,
+            row.match_ns_per_start,
+            row.speed_vs_current,
+            row.matcher_heap_bytes,
+            row.storage_heap_bytes,
+            row.total_heap_bytes,
+            row.total_heap_vs_current,
+            row.serialized_bytes,
+            row.same_order,
+            row.same_results,
+            row.mismatches,
+            row.checksum
+        );
+    }
+    for row in failed {
+        println!(
+            "{}\t{}\t{}\tn/a\tn/a\t{:.3}\tn/a\tn/a\tn/a\tn/a\tn/a\tn/a\tn/a\tn/a\tfalse\tfalse\tn/a\t{}",
+            row.name,
+            row.name,
+            row.family,
+            row.build_time.as_secs_f64() * 1000.0,
+            row.error
+        );
+    }
+}
+
+fn print_markdown(rows: &[ReportRow], failed: &[FailedMatcher]) {
+    println!("| Variant | Mode | Storage | Build ms | Match ns/batch | ns/start | Speed vs current | Matcher heap | Storage heap | Total heap | Total heap vs current | Serialized bytes | Same order | Same results | Mismatches | Note |");
+    println!("|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---:|---|");
+    for row in rows {
+        println!(
+            "| `{}` | {} | {} | {:.3} | {} | {:.2} | {:.2}x | {} | {} | {} | {:.2}x | {} | {} | {} | {} |  |",
+            row.variant,
+            row.mode,
+            row.storage,
+            row.build_ms,
+            row.match_ns_per_batch,
+            row.match_ns_per_start,
+            row.speed_vs_current,
+            row.matcher_heap_bytes,
+            row.storage_heap_bytes,
+            row.total_heap_bytes,
+            row.total_heap_vs_current,
+            row.serialized_bytes,
+            yes_no(row.same_order),
+            yes_no(row.same_results),
+            row.mismatches
+        );
+    }
+    for row in failed {
+        println!(
+            "| `{}` | n/a | n/a | {:.3} | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | no | no | n/a | {} |",
+            row.name,
+            row.build_time.as_secs_f64() * 1000.0,
+            row.error.replace('|', "\\|")
+        );
+    }
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value {
+        "yes"
+    } else {
+        "no"
+    }
+}

--- a/sudachi/examples/tokenize_parallel_bench.rs
+++ b/sudachi/examples/tokenize_parallel_bench.rs
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Batch tokenization throughput vs thread count. Sentences are independent and
+//! the dictionary is shared read-only via `Arc`, so throughput scales close to
+//! linearly with cores. Each worker owns its own `StatefulTokenizer`.
+//!
+//! ```bash
+//! SUDACHI_BENCH_DICT=/path/system.dic \
+//! cargo run -p sudachi --release --example tokenize_parallel_bench
+//! ```
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use sudachi::analysis::mlist::MorphemeList;
+use sudachi::analysis::stateful_tokenizer::StatefulTokenizer;
+use sudachi::analysis::Mode;
+use sudachi::config::Config;
+use sudachi::dic::dictionary::JapaneseDictionary;
+
+fn env_path(key: &str, default: &str) -> PathBuf {
+    std::env::var_os(key)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(default))
+}
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Tokenize a slice of sentences with one fresh tokenizer; returns morpheme count.
+fn tokenize_chunk(dict: Arc<JapaneseDictionary>, lines: &[String]) -> usize {
+    let mut tok = StatefulTokenizer::new(dict.clone(), Mode::C);
+    let mut result = MorphemeList::empty(dict);
+    let mut total = 0;
+    for line in lines {
+        tok.reset().push_str(line);
+        tok.do_tokenize().expect("tokenization failed");
+        result.collect_results(&mut tok).expect("collect failed");
+        total += result.len();
+    }
+    total
+}
+
+fn run_threads(
+    dict: &Arc<JapaneseDictionary>,
+    lines: &[String],
+    threads: usize,
+) -> (Duration, usize) {
+    let chunk = lines.len().div_ceil(threads.max(1));
+    let start = Instant::now();
+    let total: usize = std::thread::scope(|scope| {
+        let handles: Vec<_> = lines
+            .chunks(chunk.max(1))
+            .map(|part| {
+                let dict = Arc::clone(dict);
+                scope.spawn(move || tokenize_chunk(dict, part))
+            })
+            .collect();
+        handles.into_iter().map(|h| h.join().unwrap()).sum()
+    });
+    (start.elapsed(), total)
+}
+
+fn main() {
+    let config_path = env_path("SUDACHI_BENCH_CONFIG", "resources/sudachi.json");
+    let resource_dir = config_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .filter(|p| !p.as_os_str().is_empty());
+    let dict_override = std::env::var_os("SUDACHI_BENCH_DICT").map(PathBuf::from);
+    let config =
+        Config::new(Some(config_path), resource_dir, dict_override).expect("failed to load config");
+    let dict = Arc::new(JapaneseDictionary::from_cfg(&config).expect("failed to load dictionary"));
+
+    let inputs_path = env_path(
+        "SUDACHI_BENCH_INPUTS",
+        "target/issue-117-corpora/kyoto-leads.txt",
+    );
+    let limit = env_usize("SUDACHI_BENCH_LIMIT", usize::MAX);
+    let trials = env_usize("SUDACHI_BENCH_TRIALS", 5);
+    let text = std::fs::read_to_string(&inputs_path).expect("failed to read inputs");
+    let lines: Vec<String> = text.lines().take(limit).map(|s| s.to_owned()).collect();
+
+    let max_threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(8);
+    let mut thread_counts = vec![1usize, 2, 4, 8];
+    thread_counts.retain(|&t| t < max_threads);
+    thread_counts.push(max_threads);
+
+    // Warm up / correctness: morpheme count must not depend on thread count.
+    let (_, base_total) = run_threads(&dict, &lines, 1);
+
+    println!("# inputs: {}", inputs_path.display());
+    println!(
+        "# sentences: {}, morphemes: {base_total}, max_threads: {max_threads}, trials: {trials} (best-of)",
+        lines.len()
+    );
+
+    let mut single = Duration::MAX;
+    for &threads in &thread_counts {
+        let mut best = Duration::MAX;
+        for _ in 0..trials {
+            let (dt, total) = run_threads(&dict, &lines, threads);
+            assert_eq!(
+                total, base_total,
+                "morpheme count changed at {threads} threads"
+            );
+            best = best.min(dt);
+        }
+        if threads == 1 {
+            single = best;
+        }
+        let sent_s = lines.len() as f64 / best.as_secs_f64();
+        let speedup = single.as_secs_f64() / best.as_secs_f64();
+        println!(
+            "threads={threads:<3} {:>8.2} ms  {:>10.0} sent/s  {:>5.2}x vs 1 thread",
+            best.as_nanos() as f64 / 1e6,
+            sent_s,
+            speedup,
+        );
+    }
+}

--- a/sudachi/examples/tokenize_pipeline_bench.rs
+++ b/sudachi/examples/tokenize_pipeline_bench.rs
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! End-to-end tokenization throughput: scalar vs pipelined+prefetched lattice
+//! lookup (issue #117). Both paths must produce the same morpheme count; only
+//! the dictionary-lookup driver differs.
+//!
+//! ```bash
+//! SUDACHI_BENCH_CONFIG=resources/sudachi.json \
+//! SUDACHI_BENCH_INPUTS=target/issue-117-corpora/kyoto-leads.txt \
+//! cargo run -p sudachi --release --example tokenize_pipeline_bench
+//! ```
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use sudachi::analysis::mlist::MorphemeList;
+use sudachi::analysis::stateful_tokenizer::StatefulTokenizer;
+use sudachi::analysis::Mode;
+use sudachi::config::Config;
+use sudachi::dic::dictionary::JapaneseDictionary;
+
+fn env_path(key: &str, default: &str) -> PathBuf {
+    std::env::var_os(key)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(default))
+}
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn run_pass(
+    tok: &mut StatefulTokenizer<Arc<JapaneseDictionary>>,
+    result: &mut MorphemeList<Arc<JapaneseDictionary>>,
+    lines: &[&str],
+) -> usize {
+    let mut total = 0;
+    for line in lines {
+        tok.reset().push_str(line);
+        tok.do_tokenize().expect("tokenization failed");
+        result.collect_results(tok).expect("collect failed");
+        total += result.len();
+    }
+    total
+}
+
+fn main() {
+    let config_path = env_path("SUDACHI_BENCH_CONFIG", "resources/sudachi.json");
+    let resource_dir = config_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .filter(|p| !p.as_os_str().is_empty());
+    // Optional system-dictionary override (the committed resources/system.dic is
+    // an older V0-format dict; point this at a freshly built current-format one).
+    let dict_override = std::env::var_os("SUDACHI_BENCH_DICT").map(PathBuf::from);
+    let config = Config::new(Some(config_path.clone()), resource_dir, dict_override)
+        .expect("failed to load config");
+    let dict = Arc::new(JapaneseDictionary::from_cfg(&config).expect("failed to load dictionary"));
+
+    let inputs_path = env_path(
+        "SUDACHI_BENCH_INPUTS",
+        "target/issue-117-corpora/kyoto-leads.txt",
+    );
+    let limit = env_usize("SUDACHI_BENCH_LIMIT", usize::MAX);
+    let trials = env_usize("SUDACHI_BENCH_TRIALS", 7);
+    let text = std::fs::read_to_string(&inputs_path).expect("failed to read inputs");
+    let lines: Vec<&str> = text.lines().take(limit).collect();
+    let total_chars: usize = lines.iter().map(|l| l.chars().count()).sum();
+
+    let mut tok = StatefulTokenizer::new(dict.clone(), Mode::C);
+    let mut result = MorphemeList::empty(dict.clone());
+
+    // Warm up and check both paths agree on output volume.
+    tok.set_pipelined_lookup(false);
+    let morphs_scalar = run_pass(&mut tok, &mut result, &lines);
+    tok.set_pipelined_lookup(true);
+    let morphs_pipelined = run_pass(&mut tok, &mut result, &lines);
+    assert_eq!(
+        morphs_scalar, morphs_pipelined,
+        "scalar and pipelined disagree on total morpheme count"
+    );
+
+    let mut best_scalar = Duration::MAX;
+    let mut best_pipelined = Duration::MAX;
+    for t in 0..trials {
+        // Alternate which path runs first so neither systematically benefits
+        // from the other warming the caches.
+        let order = if t % 2 == 0 {
+            [false, true]
+        } else {
+            [true, false]
+        };
+        for &pipelined in &order {
+            tok.set_pipelined_lookup(pipelined);
+            let start = Instant::now();
+            run_pass(&mut tok, &mut result, &lines);
+            let elapsed = start.elapsed();
+            if pipelined {
+                best_pipelined = best_pipelined.min(elapsed);
+            } else {
+                best_scalar = best_scalar.min(elapsed);
+            }
+        }
+    }
+
+    let n = lines.len().max(1);
+    let report = |name: &str, d: Duration| {
+        let ns = d.as_nanos() as f64;
+        println!(
+            "{name:<20} {:>9.2} ms  {:>8.0} ns/sentence  {:>6.2} ns/char  {:>9.0} sent/s",
+            ns / 1e6,
+            ns / n as f64,
+            ns / total_chars.max(1) as f64,
+            n as f64 / d.as_secs_f64(),
+        );
+    };
+
+    println!("# config: {}", config_path.display());
+    println!("# inputs: {}", inputs_path.display());
+    println!(
+        "# sentences: {n}, chars: {total_chars}, morphemes: {morphs_scalar}, trials: {trials} (best-of)"
+    );
+    report("scalar", best_scalar);
+    report("pipelined+prefetch", best_pipelined);
+    println!(
+        "# speedup (scalar / pipelined): {:.4}x",
+        best_scalar.as_secs_f64() / best_pipelined.as_secs_f64()
+    );
+}

--- a/sudachi/examples/tokenize_pipeline_bench.rs
+++ b/sudachi/examples/tokenize_pipeline_bench.rs
@@ -26,7 +26,7 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use sudachi::analysis::mlist::MorphemeList;
 use sudachi::analysis::stateful_tokenizer::StatefulTokenizer;
@@ -98,8 +98,8 @@ fn main() {
         "scalar and pipelined disagree on total morpheme count"
     );
 
-    let mut best_scalar = Duration::MAX;
-    let mut best_pipelined = Duration::MAX;
+    let mut scalar_ms: Vec<f64> = Vec::new();
+    let mut pipelined_ms: Vec<f64> = Vec::new();
     for t in 0..trials {
         // Alternate which path runs first so neither systematically benefits
         // from the other warming the caches.
@@ -109,39 +109,69 @@ fn main() {
             [true, false]
         };
         for &pipelined in &order {
+            // SUDACHI_BENCH_ONLY=scalar|pipelined restricts to one path (for profiling).
+            match std::env::var("SUDACHI_BENCH_ONLY").ok().as_deref() {
+                Some("scalar") if pipelined => continue,
+                Some("pipelined") if !pipelined => continue,
+                _ => {}
+            }
             tok.set_pipelined_lookup(pipelined);
             let start = Instant::now();
             run_pass(&mut tok, &mut result, &lines);
-            let elapsed = start.elapsed();
+            let ms = start.elapsed().as_secs_f64() * 1e3;
             if pipelined {
-                best_pipelined = best_pipelined.min(elapsed);
+                pipelined_ms.push(ms);
             } else {
-                best_scalar = best_scalar.min(elapsed);
+                scalar_ms.push(ms);
             }
         }
     }
 
+    // (min, median, mean, coefficient-of-variation %)
+    fn stats(samples: &mut [f64]) -> (f64, f64, f64, f64) {
+        samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let min = samples[0];
+        let median = samples[samples.len() / 2];
+        let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+        let var = samples.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / samples.len() as f64;
+        let cv = if mean > 0.0 {
+            var.sqrt() / mean * 100.0
+        } else {
+            0.0
+        };
+        (min, median, mean, cv)
+    }
+
     let n = lines.len().max(1);
-    let report = |name: &str, d: Duration| {
-        let ns = d.as_nanos() as f64;
+    let report = |name: &str, samples: &mut Vec<f64>| -> (f64, f64) {
+        if samples.is_empty() {
+            return (0.0, 0.0);
+        }
+        let (min, median, mean, cv) = stats(samples);
         println!(
-            "{name:<20} {:>9.2} ms  {:>8.0} ns/sentence  {:>6.2} ns/char  {:>9.0} sent/s",
-            ns / 1e6,
-            ns / n as f64,
-            ns / total_chars.max(1) as f64,
-            n as f64 / d.as_secs_f64(),
+            "{name:<20} min {:>7.2}  median {:>7.2}  mean {:>7.2} ms  cv {:>4.1}%  | {:>8.0} sent/s  {:>6.2} ns/char",
+            min,
+            median,
+            mean,
+            cv,
+            n as f64 / (median / 1e3),
+            median * 1e6 / total_chars.max(1) as f64,
         );
+        (min, median)
     };
 
     println!("# config: {}", config_path.display());
     println!("# inputs: {}", inputs_path.display());
     println!(
-        "# sentences: {n}, chars: {total_chars}, morphemes: {morphs_scalar}, trials: {trials} (best-of)"
+        "# sentences: {n}, chars: {total_chars}, morphemes: {morphs_scalar}, trials: {trials}"
     );
-    report("scalar", best_scalar);
-    report("pipelined+prefetch", best_pipelined);
-    println!(
-        "# speedup (scalar / pipelined): {:.4}x",
-        best_scalar.as_secs_f64() / best_pipelined.as_secs_f64()
-    );
+    let (smin, smed) = report("scalar", &mut scalar_ms);
+    let (pmin, pmed) = report("pipelined+prefetch", &mut pipelined_ms);
+    if smed > 0.0 && pmed > 0.0 {
+        println!(
+            "# speedup  median {:.4}x   best-of {:.4}x",
+            smed / pmed,
+            smin / pmin
+        );
+    }
 }

--- a/sudachi/examples/trie_layout_report.rs
+++ b/sudachi/examples/trie_layout_report.rs
@@ -1,0 +1,335 @@
+/*
+ *  Copyright (c) 2026 Works Applications Co., Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+use std::collections::HashSet;
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+use sudachi::dic::binary_loader::BinaryDictionary;
+use sudachi::dic::build::{CacheAwareOptions, DictBuilder, TrieBuildStrategy, TrieProfileMode};
+use tempfile::NamedTempFile;
+
+const MATRIX: &[u8] = include_bytes!("../src/dic/build/test/matrix_10x10.def");
+const LEXICON: &[u8] = include_bytes!("../src/dic/build/test/lex.csv");
+const LOOKUP_ROUNDS: usize = 20_000;
+const DEFAULT_INPUT_LIMIT: usize = 256;
+
+struct Fixture {
+    matrix: Vec<u8>,
+    lexicons: Vec<Vec<u8>>,
+    inputs: Inputs,
+    profile_path: PathBuf,
+    _generated_profile: Option<NamedTempFile>,
+}
+
+struct Inputs {
+    hits: Vec<String>,
+    misses: Vec<String>,
+    mixed: Vec<String>,
+}
+
+#[derive(Clone)]
+struct Variant {
+    name: &'static str,
+    strategy: TrieBuildStrategy,
+}
+
+struct Built {
+    name: &'static str,
+    build_time: Duration,
+    dict_bytes: usize,
+    trie_bytes: usize,
+    dictionary: BinaryDictionary<'static>,
+}
+
+fn main() {
+    let fixture = fixture();
+    let variants = variants(&fixture.profile_path);
+    let mut built = Vec::new();
+
+    for variant in variants {
+        let started = Instant::now();
+        let bytes = compile(&fixture, variant.strategy);
+        let build_time = started.elapsed();
+        let dict_bytes = bytes.len();
+        let leaked: &'static [u8] = Box::leak(bytes.into_boxed_slice());
+        let dictionary = BinaryDictionary::load_system(leaked).unwrap();
+        let trie_bytes = dictionary.lexicon.trie.total_size();
+        built.push(Built {
+            name: variant.name,
+            build_time,
+            dict_bytes,
+            trie_bytes,
+            dictionary,
+        });
+    }
+
+    validate(&built, &fixture.inputs);
+    print_report(&built, &fixture.inputs);
+}
+
+fn fixture() -> Fixture {
+    let matrix = read_env_bytes("SUDACHI_TRIE_BENCH_MATRIX", MATRIX);
+    let lexicons = read_lexicons();
+    let inputs = build_inputs(&lexicons);
+    let (profile_path, generated_profile) = external_profile_path(&inputs.hits);
+    Fixture {
+        matrix,
+        lexicons,
+        inputs,
+        profile_path,
+        _generated_profile: generated_profile,
+    }
+}
+
+fn variants(profile_path: &Path) -> Vec<Variant> {
+    vec![
+        Variant {
+            name: "classic_yada",
+            strategy: TrieBuildStrategy::ClassicYada,
+        },
+        Variant {
+            name: "cache_aware_uniform",
+            strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions {
+                profile_mode: TrieProfileMode::Uniform,
+                ..CacheAwareOptions::default()
+            }),
+        },
+        Variant {
+            name: "cache_aware_prefix",
+            strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions::default()),
+        },
+        Variant {
+            name: "cache_aware_external_profile",
+            strategy: TrieBuildStrategy::CacheAware(CacheAwareOptions {
+                profile_mode: TrieProfileMode::ExternalKeyProfile(profile_path.to_owned()),
+                ..CacheAwareOptions::default()
+            }),
+        },
+    ]
+}
+
+fn read_env_bytes(env_name: &str, fallback: &[u8]) -> Vec<u8> {
+    env::var_os(env_name)
+        .map(|path| fs::read(path).expect("failed to read benchmark input file"))
+        .unwrap_or_else(|| fallback.to_vec())
+}
+
+fn read_lexicons() -> Vec<Vec<u8>> {
+    if let Some(paths) = env::var_os("SUDACHI_TRIE_BENCH_LEXICONS") {
+        return env::split_paths(&paths)
+            .map(|path| fs::read(path).expect("failed to read benchmark lexicon"))
+            .collect();
+    }
+    if let Some(path) = env::var_os("SUDACHI_TRIE_BENCH_LEXICON") {
+        return vec![fs::read(path).expect("failed to read benchmark lexicon")];
+    }
+    vec![LEXICON.to_vec()]
+}
+
+fn build_inputs(lexicons: &[Vec<u8>]) -> Inputs {
+    let limit = env::var("SUDACHI_TRIE_REPORT_INPUT_LIMIT")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_INPUT_LIMIT);
+    let mut hits = sample_inputs(index_forms(lexicons), limit);
+    if hits.is_empty() {
+        hits.push("東京都".to_owned());
+    }
+
+    let misses: Vec<String> = hits
+        .iter()
+        .map(|input| format!("{input}\u{e000}"))
+        .collect();
+    let mixed = env::var_os("SUDACHI_TRIE_BENCH_INPUTS")
+        .map(|path| read_inputs(PathBuf::from(path), limit))
+        .unwrap_or_else(|| {
+            let mut inputs = Vec::new();
+            inputs.extend(hits.iter().take(limit / 2).cloned());
+            inputs.extend(misses.iter().take(limit / 2).cloned());
+            dedup(inputs)
+        });
+
+    Inputs {
+        hits,
+        misses,
+        mixed,
+    }
+}
+
+fn read_inputs(path: PathBuf, limit: usize) -> Vec<String> {
+    fs::read_to_string(path)
+        .expect("failed to read benchmark inputs")
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .take(limit)
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn index_forms(lexicons: &[Vec<u8>]) -> Vec<String> {
+    let mut forms = Vec::new();
+    for lexicon in lexicons {
+        let mut reader = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .from_reader(lexicon.as_slice());
+        for record in reader.records().flatten() {
+            let Some(form) = record.get(0) else {
+                continue;
+            };
+            if !form.is_empty() {
+                forms.push(form.to_owned());
+            }
+        }
+    }
+    dedup(forms)
+}
+
+fn sample_inputs(mut inputs: Vec<String>, limit: usize) -> Vec<String> {
+    inputs.sort();
+    inputs.dedup();
+    if inputs.len() <= limit {
+        return inputs;
+    }
+
+    (0..limit)
+        .map(|i| {
+            let index = i * inputs.len() / limit;
+            inputs[index].clone()
+        })
+        .collect()
+}
+
+fn dedup(inputs: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    inputs
+        .into_iter()
+        .filter(|input| seen.insert(input.clone()))
+        .collect()
+}
+
+fn external_profile_path(hits: &[String]) -> (PathBuf, Option<NamedTempFile>) {
+    if let Some(path) = env::var_os("SUDACHI_TRIE_BENCH_PROFILE") {
+        return (PathBuf::from(path), None);
+    }
+    let mut file = NamedTempFile::new().expect("failed to create benchmark profile");
+    let max = hits.len();
+    for (rank, input) in hits.iter().enumerate() {
+        write_profile_key(&mut file, input.as_bytes());
+        writeln!(file, "\t{}", max - rank).expect("failed to write benchmark profile");
+    }
+    (file.path().to_owned(), Some(file))
+}
+
+fn write_profile_key<W: Write>(writer: &mut W, bytes: &[u8]) {
+    writer
+        .write_all(b"hex:")
+        .expect("failed to write benchmark profile");
+    for byte in bytes {
+        write!(writer, "{byte:02X}").expect("failed to write benchmark profile");
+    }
+}
+
+fn compile(fixture: &Fixture, strategy: TrieBuildStrategy) -> Vec<u8> {
+    let mut builder = DictBuilder::new_system();
+    builder.set_trie_build_strategy(strategy);
+    builder.read_conn(fixture.matrix.as_slice()).unwrap();
+    for lexicon in &fixture.lexicons {
+        builder.read_lexicon(lexicon.as_slice()).unwrap();
+    }
+    builder.resolve().unwrap();
+
+    let mut bytes = Vec::new();
+    builder.compile(&mut bytes).unwrap();
+    bytes
+}
+
+fn validate(built: &[Built], inputs: &Inputs) {
+    let baseline = &built[0];
+    for input in all_inputs(inputs) {
+        let expected = trie_entries(baseline, &input);
+        for variant in built.iter().skip(1) {
+            let actual = trie_entries(variant, &input);
+            assert_eq!(
+                actual, expected,
+                "variant {} disagrees with classic_yada for input {input:?}",
+                variant.name
+            );
+        }
+    }
+}
+
+fn all_inputs(inputs: &Inputs) -> Vec<String> {
+    let mut result = Vec::new();
+    result.extend(inputs.hits.iter().cloned());
+    result.extend(inputs.misses.iter().cloned());
+    result.extend(inputs.mixed.iter().cloned());
+    dedup(result)
+}
+
+fn trie_entries(variant: &Built, input: &str) -> Vec<(u32, usize)> {
+    variant
+        .dictionary
+        .lexicon
+        .trie
+        .common_prefix_iterator(input.as_bytes(), 0)
+        .map(|entry| (entry.value, entry.end))
+        .collect()
+}
+
+fn print_report(built: &[Built], inputs: &Inputs) {
+    println!(
+        "variant\tbuild_ms\tdict_bytes\ttrie_bytes\thit_ns_per_batch\tmiss_ns_per_batch\tmixed_ns_per_batch\thit_entries\tmiss_entries\tmixed_entries"
+    );
+    for variant in built {
+        let (hit_ns, hit_entries) = measure_lookup(variant, &inputs.hits);
+        let (miss_ns, miss_entries) = measure_lookup(variant, &inputs.misses);
+        let (mixed_ns, mixed_entries) = measure_lookup(variant, &inputs.mixed);
+        println!(
+            "{}\t{:.3}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            variant.name,
+            variant.build_time.as_secs_f64() * 1000.0,
+            variant.dict_bytes,
+            variant.trie_bytes,
+            hit_ns,
+            miss_ns,
+            mixed_ns,
+            hit_entries,
+            miss_entries,
+            mixed_entries
+        );
+    }
+}
+
+fn measure_lookup(variant: &Built, inputs: &[String]) -> (u128, usize) {
+    let started = Instant::now();
+    let mut total = 0usize;
+    for _ in 0..LOOKUP_ROUNDS {
+        for input in inputs {
+            total += variant
+                .dictionary
+                .lexicon
+                .trie
+                .common_prefix_iterator(input.as_bytes(), 0)
+                .count();
+        }
+    }
+    let per_batch = started.elapsed().as_nanos() / LOOKUP_ROUNDS as u128;
+    (per_batch, total)
+}

--- a/sudachi/src/analysis/stateful_tokenizer.rs
+++ b/sudachi/src/analysis/stateful_tokenizer.rs
@@ -21,6 +21,7 @@ use crate::analysis::node::{LatticeNode, ResultNode};
 use crate::analysis::stateless_tokenizer::{dump_path, split_path};
 use crate::analysis::Mode;
 use crate::dic::connect::ConnectionMatrix;
+use crate::dic::lexicon::LexiconEntry;
 use crate::dic::lexicon_set::LexiconSet;
 use crate::dic::subset::InfoSubset;
 use crate::dic::word_info::WordInfo;
@@ -40,6 +41,11 @@ pub struct StatefulTokenizer<D> {
     top_path_ids: Vec<NodeIdx>,
     top_path: Option<Vec<ResultNode>>,
     subset: InfoSubset,
+    /// Per-boundary dictionary-match cache, reused across sentences, for the
+    /// pipelined-prefetch lattice path (issue #117).
+    match_cache: Vec<Vec<LexiconEntry>>,
+    /// Use the pipelined + prefetched dictionary lookup in `build_lattice`.
+    pipelined_lookup: bool,
 }
 
 impl<D: DictionaryAccess + Clone> StatefulTokenizer<D> {
@@ -67,7 +73,20 @@ impl<D: DictionaryAccess> StatefulTokenizer<D> {
             top_path_ids: Vec::new(),
             top_path: Some(Vec::new()),
             subset: InfoSubset::all(),
+            match_cache: Vec::new(),
+            // Pipelined + prefetched dictionary lookup is the default: it is
+            // byte-for-byte identical to the scalar path and ~8-12% faster
+            // end-to-end on real SudachiDict tiers (issue #117).
+            pipelined_lookup: true,
         }
+    }
+
+    /// Enable or disable the pipelined + prefetched dictionary lookup in lattice
+    /// construction (issue #117). Returns the previous value. The result is
+    /// byte-for-byte identical to the scalar path; this only changes lookup
+    /// performance and is intended for benchmarking and tuning.
+    pub fn set_pipelined_lookup(&mut self, enabled: bool) -> bool {
+        std::mem::replace(&mut self.pipelined_lookup, enabled)
     }
 
     /// Set debug flag and returns the current one
@@ -228,6 +247,8 @@ impl<D: DictionaryAccess> StatefulTokenizer<D> {
             oov_providers: self.dictionary.oov_provider_plugins(),
             lexicon: self.dictionary.lexicon(),
             input: &self.input,
+            match_cache: &mut self.match_cache,
+            pipelined: self.pipelined_lookup,
         };
         builder.build_lattice()
     }
@@ -255,12 +276,25 @@ struct LatticeBuilder<'a> {
     input: &'a InputBuffer,
     lexicon: &'a LexiconSet<'a>,
     oov_providers: &'a [Box<dyn OovProviderPlugin + Sync + Send>],
+    match_cache: &'a mut Vec<Vec<LexiconEntry>>,
+    pipelined: bool,
 }
 
 impl<'a> LatticeBuilder<'a> {
     #[inline]
     fn build_lattice(&mut self) -> SudachiResult<()> {
         self.lattice.reset(self.input.current_chars().len());
+        if self.pipelined {
+            self.build_lattice_pipelined()
+        } else {
+            self.build_lattice_scalar()
+        }
+    }
+
+    /// Original lattice builder: one scalar common-prefix walk per reachable
+    /// boundary, interleaved with node insertion.
+    #[inline]
+    fn build_lattice_scalar(&mut self) -> SudachiResult<()> {
         let input_bytes = self.input.current().as_bytes();
 
         for (ch_off, &byte_off) in self.input.curr_byte_offsets().iter().enumerate() {
@@ -290,24 +324,94 @@ impl<'a> LatticeBuilder<'a> {
                 self.lattice.insert(node, self.matrix);
             }
 
-            // OOV
-            if self.input.can_oov_bow(ch_off) {
-                for provider in self.oov_providers {
-                    created = self.provide_oovs(ch_off, created, provider.as_ref())?;
-                }
-            }
-
-            if created.is_empty() {
-                let provider = self.oov_providers.last().unwrap();
-                created = self.provide_oovs(ch_off, created, provider.as_ref())?;
-            }
-
-            if created.is_empty() {
-                return Err(SudachiError::EosBosDisconnect);
-            }
+            self.insert_oovs(ch_off, created)?;
         }
         self.lattice.connect_eos(self.matrix)?;
 
+        Ok(())
+    }
+
+    /// Pipelined + prefetched lattice builder (issue #117): pre-compute every
+    /// boundary's dictionary matches with overlapped trie memory latency, then
+    /// insert nodes for reachable boundaries in the same order as the scalar
+    /// path. The trie walks depend only on the input, not on the lattice, so
+    /// precomputing all boundaries is exact; reachability still gates insertion.
+    #[inline]
+    fn build_lattice_pipelined(&mut self) -> SudachiResult<()> {
+        let input_bytes = self.input.current().as_bytes();
+
+        {
+            let lexicon = self.lexicon;
+            let starts = self.input.curr_byte_offsets();
+            let cache = &mut *self.match_cache;
+            if cache.len() < starts.len() {
+                cache.resize_with(starts.len(), Vec::new);
+            }
+            for bucket in cache.iter_mut() {
+                bucket.clear();
+            }
+            lexicon.lookup_batch(input_bytes, starts, |bucket, entry| {
+                cache[bucket].push(entry);
+            });
+        }
+
+        let boundaries = self.input.curr_byte_offsets().len();
+        for ch_off in 0..boundaries {
+            if !self.lattice.has_previous_node(ch_off) {
+                continue;
+            }
+
+            self.node_buffer.clear();
+            let mut created = CreatedWords::default();
+            // Indexed access keeps each `match_cache` borrow transient so it does
+            // not conflict with the node_buffer/lattice mutations below.
+            let count = self.match_cache[ch_off].len();
+            for idx in 0..count {
+                let end = self.match_cache[ch_off][idx].end;
+                let word_id = self.match_cache[ch_off][idx].word_id;
+                if (end < input_bytes.len()) && !self.input.can_bow(end) {
+                    continue;
+                }
+                let (left_id, right_id, cost) = self.lexicon.get_word_param(word_id);
+                let end_c = self.input.ch_idx(end);
+                let node = Node::new(
+                    ch_off as u16,
+                    end_c as u16,
+                    left_id as u16,
+                    right_id as u16,
+                    cost,
+                    word_id,
+                );
+                created = created.add_word((end_c - ch_off) as i64);
+                self.node_buffer.push(node.clone());
+                self.lattice.insert(node, self.matrix);
+            }
+
+            self.insert_oovs(ch_off, created)?;
+        }
+        self.lattice.connect_eos(self.matrix)?;
+
+        Ok(())
+    }
+
+    /// OOV handling shared by both lattice builders. Mirrors the original
+    /// in-loop logic exactly.
+    #[inline]
+    fn insert_oovs(&mut self, ch_off: usize, mut created: CreatedWords) -> SudachiResult<()> {
+        if self.input.can_oov_bow(ch_off) {
+            for provider in self.oov_providers {
+                created = self.provide_oovs(ch_off, created, provider.as_ref())?;
+            }
+        }
+
+        if created.is_empty() {
+            let provider = self.oov_providers.last().unwrap();
+            created = self.provide_oovs(ch_off, created, provider.as_ref())?;
+        }
+
+        if created.is_empty() {
+            return Err(SudachiError::EosBosDisconnect);
+        }
         Ok(())
     }
 

--- a/sudachi/src/dic/build.rs
+++ b/sudachi/src/dic/build.rs
@@ -27,6 +27,7 @@ use crate::dic::build::util::default_signature;
 use crate::dic::description::Block;
 use crate::dic::grammar::Grammar;
 use crate::dic::lexicon_set::LexiconSet;
+use crate::dic::word_id::WordId;
 use crate::dic::{DescriptionAccess, DictionaryAccess, LexiconAccess, ReferenceIdAccess};
 use crate::error::SudachiResult;
 use crate::plugin::input_text::InputTextPlugin;
@@ -45,6 +46,8 @@ mod resolve;
 #[cfg(test)]
 mod test;
 mod util;
+
+pub use self::index::{CacheAwareOptions, LayoutScoring, TrieBuildStrategy, TrieProfileMode};
 
 const MAX_POS_IDS: usize = i16::MAX as usize;
 const MAX_DIC_STRING_LEN: usize = i16::MAX as usize;
@@ -156,6 +159,7 @@ pub struct DictBuilder<D> {
     stage: BuilderStage,
     prebuilt: Option<D>,
     reporter: Reporter,
+    trie_build_strategy: TrieBuildStrategy,
 }
 
 impl DictBuilder<NoDic> {
@@ -179,6 +183,7 @@ impl<D: DictionaryAccess + ReferenceIdAccess> DictBuilder<D> {
             stage: BuilderStage::Grammar,
             prebuilt: None,
             reporter: Reporter::new(),
+            trie_build_strategy: TrieBuildStrategy::default(),
         }
     }
 }
@@ -221,6 +226,15 @@ impl<D: DictionaryAccess + ReferenceIdAccess> DictBuilder<D> {
     /// Set the dictionary description
     pub fn set_description<T: Into<String>>(&mut self, description: T) {
         self.description = description.into()
+    }
+
+    /// Set the trie layout strategy used while compiling the dictionary.
+    ///
+    /// The default strategy is [`TrieBuildStrategy::ClassicYada`], preserving
+    /// the current dictionary bytes unless callers explicitly opt in to a
+    /// different layout.
+    pub fn set_trie_build_strategy(&mut self, strategy: TrieBuildStrategy) {
+        self.trie_build_strategy = strategy;
     }
 
     /// Read the connection matrix from either a file or an in-memory buffer
@@ -496,14 +510,15 @@ impl<D: DictionaryAccess + ReferenceIdAccess> DictBuilder<D> {
     }
 
     fn build_index_data(&mut self) -> SudachiResult<(Vec<u8>, Vec<u8>)> {
-        let mut index = IndexBuilder::new();
+        let mut index = IndexBuilder::with_trie_build_strategy(self.trie_build_strategy.clone());
+        self.fill_index_builder(&mut index)?;
+        let word_id_table = index.build_word_id_table(&self.non_indexed_word_ids())?;
+        let trie = index.build_trie()?;
+        Ok((trie, word_id_table))
+    }
+
+    fn fill_index_builder<'a>(&'a self, index: &mut IndexBuilder<'a>) -> SudachiResult<()> {
         let entry_ids = self.lexicon.row_word_ids(0);
-        // Keep non-indexed, non-phantom entries in the word-id table as a
-        // trailing list. This preserves compatibility with the Java
-        // dictionary format, where callers can enumerate all public entries
-        // from WordIdTable even if some of them are intentionally absent from
-        // the trie. Phantom entries stay internal to reference resolution.
-        let mut non_indexed = Vec::new();
         for (e, wid) in self
             .lexicon
             .resolved_entries()
@@ -512,14 +527,26 @@ impl<D: DictionaryAccess + ReferenceIdAccess> DictBuilder<D> {
         {
             if e.should_index() {
                 index.add(e.index_form(), wid);
-            } else if !e.is_phantom() {
-                non_indexed.push(wid);
             }
         }
+        Ok(())
+    }
 
-        let word_id_table = index.build_word_id_table(&non_indexed)?;
-        let trie = index.build_trie()?;
-        Ok((trie, word_id_table))
+    fn non_indexed_word_ids(&self) -> Vec<WordId> {
+        // Keep non-indexed, non-phantom entries in the word-id table as a
+        // trailing list. This preserves compatibility with the Java dictionary
+        // format, where callers can enumerate all public entries from
+        // WordIdTable even if some of them are intentionally absent from the
+        // trie. Phantom entries stay internal to reference resolution.
+        let entry_ids = self.lexicon.row_word_ids(0);
+        self.lexicon
+            .resolved_entries()
+            .iter()
+            .zip(entry_ids)
+            .filter_map(|(entry, word_id)| {
+                (!entry.should_index() && !entry.is_phantom()).then_some(word_id)
+            })
+            .collect()
     }
 
     fn serialize_description(

--- a/sudachi/src/dic/build/error.rs
+++ b/sudachi/src/dic/build/error.rs
@@ -94,6 +94,12 @@ pub enum BuildFailure {
     #[error("Failed to build trie")]
     TrieBuildFailure,
 
+    #[error("Invalid trie build profile: {0}")]
+    InvalidTrieProfile(String),
+
+    #[error("Trie value {value} exceeds the 31-bit Yada value limit in {entry}")]
+    TrieValueLimitExceeded { entry: String, value: u32 },
+
     #[error(
         "Invalid string pointer during dictionary compilation: length={length}, offset={offset}, alignment={alignment}"
     )]

--- a/sudachi/src/dic/build/index.rs
+++ b/sudachi/src/dic/build/index.rs
@@ -19,6 +19,68 @@ use crate::dic::word_id::WordId;
 use crate::error::{SudachiError, SudachiResult};
 use crate::util::fxhash::FxBuildHasher;
 use indexmap::map::IndexMap;
+use std::path::PathBuf;
+
+mod cache_aware;
+
+const MAX_TRIE_VALUE: u32 = (1 << 31) - 1;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TrieBuildStrategy {
+    ClassicYada,
+    CacheAware(CacheAwareOptions),
+}
+
+impl Default for TrieBuildStrategy {
+    fn default() -> Self {
+        Self::ClassicYada
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CacheAwareOptions {
+    pub cache_line_bytes: usize,
+    pub candidate_window_blocks: usize,
+    pub profile_mode: TrieProfileMode,
+    pub scoring: LayoutScoring,
+}
+
+impl Default for CacheAwareOptions {
+    fn default() -> Self {
+        Self {
+            cache_line_bytes: 64,
+            candidate_window_blocks: 16,
+            profile_mode: TrieProfileMode::DictionaryPrefixCount,
+            scoring: LayoutScoring::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TrieProfileMode {
+    Uniform,
+    DictionaryPrefixCount,
+    ExternalKeyProfile(PathBuf),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LayoutScoring {
+    pub cache_line_weight: u32,
+    pub distance_weight: u32,
+    pub spread_weight: u32,
+    pub density_weight: u32,
+}
+
+impl Default for LayoutScoring {
+    fn default() -> Self {
+        Self {
+            cache_line_weight: 10_000,
+            distance_weight: 32,
+            spread_weight: 8,
+            density_weight: 1,
+        }
+    }
+}
 
 pub struct IndexEntry {
     ids: Vec<WordId>,
@@ -38,12 +100,19 @@ pub struct IndexBuilder<'a> {
     // Insertion order matters for the built dictionary,
     // so using IndexMap here instead of a simple HashMap
     data: IndexMap<&'a str, IndexEntry, FxBuildHasher>,
+    trie_build_strategy: TrieBuildStrategy,
 }
 
 impl<'a> IndexBuilder<'a> {
+    #[cfg(test)]
     pub fn new() -> Self {
+        Self::with_trie_build_strategy(TrieBuildStrategy::default())
+    }
+
+    pub fn with_trie_build_strategy(trie_build_strategy: TrieBuildStrategy) -> Self {
         Self {
             data: IndexMap::default(),
+            trie_build_strategy,
         }
     }
 
@@ -80,31 +149,72 @@ impl<'a> IndexBuilder<'a> {
     }
 
     pub fn build_trie(&mut self) -> SudachiResult<Vec<u8>> {
-        let mut trie_entries: Vec<(&str, u32)> = Vec::new();
-        for (k, v) in self.data.drain(..) {
+        let trie_entries = self.trie_entries()?;
+        self.data.clear();
+        self.data.shrink_to_fit();
+
+        match &self.trie_build_strategy {
+            TrieBuildStrategy::ClassicYada => {
+                let trie_entries: Vec<_> = trie_entries
+                    .iter()
+                    .map(|(key, value)| (key.as_str(), *value))
+                    .collect();
+                let trie = yada::builder::DoubleArrayBuilder::build(&trie_entries);
+                match trie {
+                    Some(t) => Ok(t),
+                    None => Err(DicBuildError {
+                        file: "<trie>".to_owned(),
+                        line: 0,
+                        cause: BuildFailure::TrieBuildFailure,
+                    }
+                    .into()),
+                }
+            }
+            TrieBuildStrategy::CacheAware(options) => {
+                let trie_entries: Vec<_> = trie_entries
+                    .iter()
+                    .map(|(key, value)| (key.as_str(), *value))
+                    .collect();
+                cache_aware::CacheAwareDartsBuilder::build(&trie_entries, options.clone()).map_err(
+                    |cause| {
+                        DicBuildError {
+                            file: "<trie>".to_owned(),
+                            line: 0,
+                            cause,
+                        }
+                        .into()
+                    },
+                )
+            }
+        }
+    }
+
+    fn trie_entries(&self) -> SudachiResult<Vec<(String, u32)>> {
+        let mut trie_entries = Vec::new();
+        for (k, v) in self.data.iter() {
             if v.offset > u32::MAX as _ {
                 return Err(DicBuildError {
-                    file: format!("entry {}", k),
+                    file: format!("entry {k}"),
                     line: 0,
                     cause: BuildFailure::WordIdTableNotBuilt,
                 }
                 .into());
             }
-            trie_entries.push((k, v.offset as u32));
-        }
-        self.data.shrink_to_fit();
-        trie_entries.sort_by(|(a, _), (b, _)| a.cmp(b));
-
-        let trie = yada::builder::DoubleArrayBuilder::build(&trie_entries);
-        match trie {
-            Some(t) => Ok(t),
-            None => Err(DicBuildError {
-                file: "<trie>".to_owned(),
-                line: 0,
-                cause: BuildFailure::TrieBuildFailure,
+            if v.offset as u32 > MAX_TRIE_VALUE {
+                return Err(DicBuildError {
+                    file: format!("entry {k}"),
+                    line: 0,
+                    cause: BuildFailure::TrieValueLimitExceeded {
+                        entry: (*k).to_owned(),
+                        value: v.offset as u32,
+                    },
+                }
+                .into());
             }
-            .into()),
+            trie_entries.push(((*k).to_owned(), v.offset as u32));
         }
+        trie_entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+        Ok(trie_entries)
     }
 }
 
@@ -194,5 +304,90 @@ mod test {
                 EntryId::new(16),
             ]
         );
+    }
+
+    fn trie_for_strategy(strategy: TrieBuildStrategy) -> Trie<'static> {
+        let entries = [
+            ("a", 0),
+            ("ab", 1),
+            ("aba", 2),
+            ("ac", 3),
+            ("ba", 4),
+            ("京都", 5),
+            ("京都府", 6),
+            ("東京都", 7),
+            ("東京", 8),
+        ];
+        let mut bldr = IndexBuilder::with_trie_build_strategy(strategy);
+        for (key, raw_id) in entries {
+            bldr.add(key, WordId::new(0, raw_id));
+        }
+        let _ = bldr.build_word_id_table(&[]).unwrap();
+        make_trie(bldr.build_trie().unwrap())
+    }
+
+    #[test]
+    fn cache_aware_trie_matches_classic_lookup_semantics() {
+        let classic = trie_for_strategy(TrieBuildStrategy::ClassicYada);
+        let cache_aware =
+            trie_for_strategy(TrieBuildStrategy::CacheAware(CacheAwareOptions::default()));
+
+        for input in [
+            b"abacus".as_slice(),
+            b"ac".as_slice(),
+            b"bad".as_slice(),
+            "京都府庁".as_bytes(),
+            "東京都".as_bytes(),
+            "東京湾".as_bytes(),
+        ] {
+            let expected: Vec<_> = classic.common_prefix_iterator(input, 0).collect();
+            let actual: Vec<_> = cache_aware.common_prefix_iterator(input, 0).collect();
+            assert_eq!(actual, expected, "input={:?}", input);
+        }
+    }
+
+    #[test]
+    fn cache_aware_trie_build_is_deterministic() {
+        let mut first = IndexBuilder::with_trie_build_strategy(TrieBuildStrategy::CacheAware(
+            CacheAwareOptions::default(),
+        ));
+        let mut second = IndexBuilder::with_trie_build_strategy(TrieBuildStrategy::CacheAware(
+            CacheAwareOptions::default(),
+        ));
+        for (key, raw_id) in [
+            ("alpha", 0),
+            ("alphabet", 1),
+            ("alpine", 2),
+            ("beta", 3),
+            ("betamax", 4),
+            ("京都", 5),
+        ] {
+            first.add(key, WordId::new(0, raw_id));
+            second.add(key, WordId::new(0, raw_id));
+        }
+        let _ = first.build_word_id_table(&[]).unwrap();
+        let _ = second.build_word_id_table(&[]).unwrap();
+
+        assert_eq!(first.build_trie().unwrap(), second.build_trie().unwrap());
+    }
+
+    #[test]
+    fn cache_aware_trie_accepts_external_profile() {
+        use std::io::Write;
+
+        let mut profile = tempfile::NamedTempFile::new().unwrap();
+        writeln!(profile, "ab\t100").unwrap();
+        writeln!(profile, "hex:E4BAACE983BD\t50").unwrap();
+
+        let options = CacheAwareOptions {
+            profile_mode: TrieProfileMode::ExternalKeyProfile(profile.path().to_owned()),
+            ..CacheAwareOptions::default()
+        };
+        let trie = trie_for_strategy(TrieBuildStrategy::CacheAware(options));
+        let actual: Vec<_> = trie
+            .common_prefix_iterator("京都府".as_bytes(), 0)
+            .collect();
+
+        assert_eq!(actual.len(), 2);
     }
 }

--- a/sudachi/src/dic/build/index/cache_aware.rs
+++ b/sudachi/src/dic/build/index/cache_aware.rs
@@ -1,0 +1,487 @@
+/*
+ *  Copyright (c) 2026 Works Applications Co., Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+use super::{CacheAwareOptions, TrieProfileMode, MAX_TRIE_VALUE};
+use crate::dic::build::error::BuildFailure;
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use yada::unit::Unit;
+
+const BLOCK_SIZE: usize = 256;
+const MAX_OFFSET: u32 = 1 << 29;
+const MAX_EXTENDED_OFFSET_LOW_BITS: u32 = 0xff;
+
+pub(super) struct CacheAwareDartsBuilder;
+
+impl CacheAwareDartsBuilder {
+    pub(super) fn build<T>(
+        keyset: &[(T, u32)],
+        options: CacheAwareOptions,
+    ) -> Result<Vec<u8>, BuildFailure>
+    where
+        T: AsRef<[u8]>,
+    {
+        for (key, value) in keyset {
+            if *value > MAX_TRIE_VALUE {
+                return Err(BuildFailure::TrieValueLimitExceeded {
+                    entry: String::from_utf8_lossy(key.as_ref()).into_owned(),
+                    value: *value,
+                });
+            }
+        }
+
+        let child_weights = build_child_weights(keyset, &options.profile_mode)?;
+
+        let mut state = BuilderState::new(options, child_weights);
+        state.reserve(0)?;
+        if !keyset.is_empty() {
+            state.build_recursive(keyset, 0, 0, keyset.len(), 0)?;
+        }
+        Ok(state.into_bytes())
+    }
+}
+
+struct BuilderState {
+    options: CacheAwareOptions,
+    units: Vec<Unit>,
+    occupied: Vec<bool>,
+    block_occupied: Vec<u16>,
+    used_offsets: HashSet<u32>,
+    child_weights: ChildWeights,
+}
+
+impl BuilderState {
+    fn new(options: CacheAwareOptions, child_weights: ChildWeights) -> Self {
+        let mut state = Self {
+            options,
+            units: Vec::new(),
+            occupied: Vec::new(),
+            block_occupied: Vec::new(),
+            used_offsets: HashSet::new(),
+            child_weights,
+        };
+        state.extend_block();
+        state
+    }
+
+    fn build_recursive<T>(
+        &mut self,
+        keyset: &[(T, u32)],
+        depth: usize,
+        begin: usize,
+        end: usize,
+        unit_id: usize,
+    ) -> Result<(), BuildFailure>
+    where
+        T: AsRef<[u8]>,
+    {
+        let mut children = collect_children(keyset, &self.child_weights, depth, begin, end)?;
+        children.sort_by(hot_first);
+
+        let offset = self.find_offset(unit_id, &children)?;
+        let has_leaf = children.iter().any(|child| child.label == 0);
+        {
+            let parent = self
+                .units
+                .get_mut(unit_id)
+                .ok_or(BuildFailure::TrieBuildFailure)?;
+            if parent.offset() != 0 {
+                return Err(BuildFailure::TrieBuildFailure);
+            }
+            parent.set_offset(offset ^ unit_id as u32);
+            parent.set_has_leaf(has_leaf);
+        }
+
+        for child in &children {
+            let child_id = (offset ^ child.label as u32) as usize;
+            self.reserve(child_id)?;
+            let unit = self
+                .units
+                .get_mut(child_id)
+                .ok_or(BuildFailure::TrieBuildFailure)?;
+            if unit.offset() != 0 || unit.label() != 0 || unit.value() != 0 || unit.has_leaf() {
+                return Err(BuildFailure::TrieBuildFailure);
+            }
+            if child.label == 0 {
+                let value = child.value.ok_or(BuildFailure::TrieBuildFailure)?;
+                unit.set_value(value);
+            } else {
+                unit.set_label(child.label);
+            }
+        }
+
+        for child in children {
+            if child.label == 0 {
+                continue;
+            }
+            let child_id = (offset ^ child.label as u32) as usize;
+            self.build_recursive(keyset, depth + 1, child.begin, child.end, child_id)?;
+        }
+
+        Ok(())
+    }
+
+    fn reserve(&mut self, unit_id: usize) -> Result<(), BuildFailure> {
+        while unit_id >= self.units.len() {
+            self.extend_block();
+        }
+        if self.occupied[unit_id] {
+            return Err(BuildFailure::TrieBuildFailure);
+        }
+        self.occupied[unit_id] = true;
+        self.block_occupied[unit_id / BLOCK_SIZE] += 1;
+        Ok(())
+    }
+
+    fn extend_block(&mut self) {
+        self.units
+            .resize(self.units.len() + BLOCK_SIZE, Unit::new());
+        self.occupied
+            .resize(self.occupied.len() + BLOCK_SIZE, false);
+        self.block_occupied.push(0);
+    }
+
+    fn find_offset(&mut self, unit_id: usize, children: &[Child]) -> Result<u32, BuildFailure> {
+        loop {
+            if let Some(offset) = self.find_offset_in_existing_blocks(unit_id, children) {
+                self.used_offsets.insert(offset);
+                return Ok(offset);
+            }
+            self.extend_block();
+            if self.units.len() / BLOCK_SIZE >= (MAX_OFFSET as usize / BLOCK_SIZE) {
+                return Err(BuildFailure::TrieBuildFailure);
+            }
+        }
+    }
+
+    fn find_offset_in_existing_blocks(&self, unit_id: usize, children: &[Child]) -> Option<u32> {
+        let mut best: Option<Candidate> = None;
+        for block_id in self.candidate_blocks(unit_id) {
+            if self.block_occupied[block_id] as usize == BLOCK_SIZE {
+                continue;
+            }
+            let block_base = block_id * BLOCK_SIZE;
+            for low in 0..BLOCK_SIZE {
+                let offset = (block_base + low) as u32;
+                if !self.is_valid_offset(unit_id, offset, children) {
+                    continue;
+                }
+                let score = self.score_offset(unit_id, offset, children);
+                let candidate = Candidate {
+                    offset,
+                    block_id,
+                    score,
+                };
+                if best.as_ref().map_or(true, |current| candidate < *current) {
+                    best = Some(candidate);
+                }
+            }
+        }
+        best.map(|candidate| candidate.offset)
+    }
+
+    fn candidate_blocks(&self, unit_id: usize) -> Vec<usize> {
+        let mut blocks = Vec::new();
+        let parent_block = unit_id / BLOCK_SIZE;
+        if parent_block < self.block_occupied.len() {
+            blocks.push(parent_block);
+        }
+
+        let window = self.options.candidate_window_blocks.max(1);
+        let start = self.block_occupied.len().saturating_sub(window);
+        for block_id in start..self.block_occupied.len() {
+            if !blocks.contains(&block_id) {
+                blocks.push(block_id);
+            }
+        }
+        blocks
+    }
+
+    fn is_valid_offset(&self, unit_id: usize, offset: u32, children: &[Child]) -> bool {
+        if offset >= MAX_OFFSET || self.used_offsets.contains(&offset) {
+            return false;
+        }
+
+        let relative_offset = unit_id as u32 ^ offset;
+        if relative_offset >= MAX_OFFSET {
+            return false;
+        }
+        if relative_offset >= (1 << 21) && (relative_offset & MAX_EXTENDED_OFFSET_LOW_BITS) != 0 {
+            return false;
+        }
+
+        children.iter().all(|child| {
+            let child_id = (offset ^ child.label as u32) as usize;
+            self.occupied
+                .get(child_id)
+                .is_some_and(|is_occupied| !*is_occupied)
+        })
+    }
+
+    fn score_offset(&self, unit_id: usize, offset: u32, children: &[Child]) -> u128 {
+        let line_units = (self.options.cache_line_bytes / std::mem::size_of::<u32>()).max(1);
+        let parent_line = unit_id / line_units;
+        let mut cache_lines = Vec::with_capacity(children.len());
+        let mut weighted_distance = 0u128;
+        let mut min_pos = usize::MAX;
+        let mut max_pos = 0usize;
+
+        for child in children {
+            let pos = (offset ^ child.label as u32) as usize;
+            let line = pos / line_units;
+            if !cache_lines.contains(&line) {
+                cache_lines.push(line);
+            }
+            let distance = line.abs_diff(parent_line) as u128;
+            weighted_distance += distance * child.weight as u128;
+            min_pos = min_pos.min(pos);
+            max_pos = max_pos.max(pos);
+        }
+
+        let block_id = offset as usize / BLOCK_SIZE;
+        let occupied = self.block_occupied[block_id] as u128;
+        let free_after = (BLOCK_SIZE as u128)
+            .saturating_sub(occupied)
+            .saturating_sub(children.len() as u128);
+        let spread = max_pos.saturating_sub(min_pos) as u128;
+
+        cache_lines.len() as u128 * self.options.scoring.cache_line_weight as u128
+            + weighted_distance * self.options.scoring.distance_weight as u128
+            + spread * self.options.scoring.spread_weight as u128
+            + free_after * self.options.scoring.density_weight as u128
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(self.units.len() * std::mem::size_of::<u32>());
+        for unit in self.units {
+            bytes.extend_from_slice(&unit.as_u32().to_le_bytes());
+        }
+        bytes
+    }
+}
+
+#[derive(Debug)]
+struct Child {
+    label: u8,
+    begin: usize,
+    end: usize,
+    value: Option<u32>,
+    weight: u64,
+    entries: usize,
+}
+
+fn collect_children<T>(
+    keyset: &[(T, u32)],
+    child_weights: &ChildWeights,
+    depth: usize,
+    begin: usize,
+    end: usize,
+) -> Result<Vec<Child>, BuildFailure>
+where
+    T: AsRef<[u8]>,
+{
+    let mut children = Vec::with_capacity(16);
+    let mut i = begin;
+    while i < end {
+        let label = label_at(keyset[i].0.as_ref(), depth)?;
+        let child_begin = i;
+        let mut value = None;
+        if label == 0 {
+            value = Some(keyset[i].1);
+            i += 1;
+            if i < end && label_at(keyset[i].0.as_ref(), depth)? == 0 {
+                return Err(BuildFailure::TrieBuildFailure);
+            }
+        } else {
+            while i < end && label_at(keyset[i].0.as_ref(), depth)? == label {
+                i += 1;
+            }
+        }
+        let weight = child_weights.child_weight(child_begin, i);
+        let entries = child_weights.child_entries(child_begin, i);
+        children.push(Child {
+            label,
+            begin: child_begin,
+            end: i,
+            value,
+            weight,
+            entries,
+        });
+    }
+    Ok(children)
+}
+
+fn label_at(key: &[u8], depth: usize) -> Result<u8, BuildFailure> {
+    if depth == key.len() {
+        Ok(0)
+    } else {
+        key.get(depth)
+            .copied()
+            .ok_or(BuildFailure::TrieBuildFailure)
+    }
+}
+
+fn hot_first(left: &Child, right: &Child) -> std::cmp::Ordering {
+    right
+        .weight
+        .cmp(&left.weight)
+        .then_with(|| right.entries.cmp(&left.entries))
+        .then_with(|| (right.label == 0).cmp(&(left.label == 0)))
+        .then_with(|| left.label.cmp(&right.label))
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+struct Candidate {
+    offset: u32,
+    block_id: usize,
+    score: u128,
+}
+
+impl PartialOrd for Candidate {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Candidate {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.score
+            .cmp(&other.score)
+            .then_with(|| self.block_id.cmp(&other.block_id))
+            .then_with(|| self.offset.cmp(&other.offset))
+    }
+}
+
+enum ChildWeights {
+    Uniform,
+    PrefixCount,
+    ExternalProfile(Vec<u64>),
+}
+
+impl ChildWeights {
+    fn child_weight(&self, begin: usize, end: usize) -> u64 {
+        match self {
+            Self::Uniform => 1,
+            Self::PrefixCount => (end - begin) as u64,
+            Self::ExternalProfile(weight_prefix) => {
+                weight_prefix[end].saturating_sub(weight_prefix[begin])
+            }
+        }
+    }
+
+    fn child_entries(&self, begin: usize, end: usize) -> usize {
+        match self {
+            Self::Uniform => 1,
+            Self::PrefixCount | Self::ExternalProfile(_) => end - begin,
+        }
+    }
+}
+
+fn build_child_weights<T>(
+    keyset: &[(T, u32)],
+    profile_mode: &TrieProfileMode,
+) -> Result<ChildWeights, BuildFailure>
+where
+    T: AsRef<[u8]>,
+{
+    match profile_mode {
+        TrieProfileMode::Uniform => Ok(ChildWeights::Uniform),
+        TrieProfileMode::DictionaryPrefixCount => Ok(ChildWeights::PrefixCount),
+        TrieProfileMode::ExternalKeyProfile(path) => {
+            let profile = read_external_profile(path)?;
+            let weights = keyset
+                .iter()
+                .map(|(key, _)| profile.get(key.as_ref()).copied().unwrap_or(1))
+                .collect();
+            Ok(ChildWeights::ExternalProfile(weight_prefix(weights)))
+        }
+    }
+}
+
+fn weight_prefix(weights: Vec<u64>) -> Vec<u64> {
+    let mut prefix = Vec::with_capacity(weights.len() + 1);
+    prefix.push(0);
+    for weight in weights {
+        let next = prefix
+            .last()
+            .copied()
+            .unwrap_or(0u64)
+            .saturating_add(weight);
+        prefix.push(next);
+    }
+    prefix
+}
+
+fn read_external_profile(path: &std::path::Path) -> Result<HashMap<Vec<u8>, u64>, BuildFailure> {
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut result = HashMap::new();
+    for (line_no, line) in reader.lines().enumerate() {
+        let line = line?;
+        if line.trim().is_empty() || line.trim_start().starts_with('#') {
+            continue;
+        }
+        let (key, weight) = line.split_once('\t').ok_or_else(|| {
+            BuildFailure::InvalidTrieProfile(format!(
+                "{}:{}: expected <surface-or-hex>\\t<count>",
+                path.display(),
+                line_no + 1
+            ))
+        })?;
+        let weight = weight.trim().parse::<u64>().map_err(|e| {
+            BuildFailure::InvalidTrieProfile(format!(
+                "{}:{}: invalid count: {}",
+                path.display(),
+                line_no + 1,
+                e
+            ))
+        })?;
+        let key = parse_profile_key(key).map_err(|e| {
+            BuildFailure::InvalidTrieProfile(format!("{}:{}: {}", path.display(), line_no + 1, e))
+        })?;
+        result.insert(key, weight);
+    }
+    Ok(result)
+}
+
+fn parse_profile_key(raw: &str) -> Result<Vec<u8>, &'static str> {
+    let Some(hex) = raw.strip_prefix("hex:") else {
+        if raw.is_empty() {
+            return Err("empty key");
+        }
+        return Ok(raw.as_bytes().to_vec());
+    };
+    if hex.is_empty() || hex.len() % 2 != 0 {
+        return Err("hex key must contain an even number of digits");
+    }
+    let mut result = Vec::with_capacity(hex.len() / 2);
+    for chunk in hex.as_bytes().chunks_exact(2) {
+        let high = decode_hex_digit(chunk[0])?;
+        let low = decode_hex_digit(chunk[1])?;
+        result.push((high << 4) | low);
+    }
+    Ok(result)
+}
+
+fn decode_hex_digit(byte: u8) -> Result<u8, &'static str> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err("hex key contains a non-hex digit"),
+    }
+}

--- a/sudachi/src/dic/lexicon.rs
+++ b/sudachi/src/dic/lexicon.rs
@@ -129,6 +129,29 @@ impl<'a> Lexicon<'a> {
             })
     }
 
+    /// Pipelined + prefetched batch form of [`Lexicon::lookup`] (issue #117).
+    ///
+    /// Calls `emit(bucket, entry)` for every match, where `bucket` is the index
+    /// into `starts`. For each bucket the entries are emitted in exactly the
+    /// order [`Lexicon::lookup`]`(input, starts[bucket])` would yield them, so
+    /// grouping by `bucket` reproduces the scalar result. Overlaps the trie
+    /// memory latency of the independent walks via software pipelining.
+    #[inline]
+    pub fn lookup_batch<F: FnMut(usize, LexiconEntry)>(
+        &self,
+        input: &[u8],
+        starts: &[usize],
+        mut emit: F,
+    ) {
+        debug_assert!(self.lex_id < MAX_DICTIONARIES as u8);
+        self.trie
+            .common_prefix_batch(input, starts, |bucket, value, end| {
+                for eid in self.word_id_table.entries(value as usize) {
+                    emit(bucket, LexiconEntry::new(self.word_id(eid.as_raw()), end));
+                }
+            });
+    }
+
     /// Returns end offsets of trie prefixes that match given input.
     #[inline]
     pub(crate) fn lookup_prefix_ends(

--- a/sudachi/src/dic/lexicon/trie.rs
+++ b/sudachi/src/dic/lexicon/trie.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025 Works Applications Co., Ltd.
+ * Copyright (c) 2021-2026 Works Applications Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 use crate::util::cow_array::CowArray;
+use crate::util::prefetch::prefetch_l1;
 use std::iter::FusedIterator;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -43,41 +44,26 @@ pub struct TrieEntryIter<'a> {
     offset: usize,
 }
 
-impl<'a> TrieEntryIter<'a> {
-    #[inline(always)]
-    fn get(&self, index: usize) -> u32 {
-        debug_assert!(index < self.trie.len());
-        // UB if out of bounds
-        // Should we panic in release builds here instead?
-        // Safe version is not optimized away
-        *unsafe { self.trie.get_unchecked(index) }
-    }
-}
-
 impl<'a> Iterator for TrieEntryIter<'a> {
     type Item = TrieEntry;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let mut node_pos = self.node_pos;
-        let mut unit;
 
         for i in self.offset..self.data.len() {
             // Unwrap is safe: access is always in bounds
             // It is optimized away: https://rust.godbolt.org/z/va9K3az4n
-            let k = self.data.get(i).unwrap();
-            node_pos ^= *k as usize;
-            unit = self.get(node_pos) as usize;
-            if Trie::label(unit) != *k as usize {
-                return None;
-            }
-
-            node_pos ^= Trie::offset(unit);
-            if Trie::has_leaf(unit) {
-                let r = TrieEntry::new(Trie::value(self.get(node_pos)), i + 1);
-                self.offset = r.end;
-                self.node_pos = node_pos;
-                return Some(r);
+            let k = *self.data.get(i).unwrap();
+            match step_once(self.trie, k, &mut node_pos) {
+                Step::Dead => return None,
+                Step::Continue => {}
+                Step::Match { value } => {
+                    let r = TrieEntry::new(value, i + 1);
+                    self.offset = r.end;
+                    self.node_pos = node_pos;
+                    return Some(r);
+                }
             }
         }
         None
@@ -86,7 +72,67 @@ impl<'a> Iterator for TrieEntryIter<'a> {
 
 impl FusedIterator for TrieEntryIter<'_> {}
 
+/// Outcome of consuming one input byte during a double-array trie walk.
+enum Step {
+    /// The current node has no transition for this byte; the walk is finished.
+    Dead,
+    /// The transition exists but is not a word end; continue with the next byte.
+    Continue,
+    /// The transition exists and ends a word with the given trie value.
+    /// `node_pos` has already been advanced so the walk can continue deeper.
+    Match { value: u32 },
+}
+
+/// Consume one input byte `k` from a double-array node at `node_pos`.
+///
+/// This is the single source of truth for the trie-walk arithmetic shared by
+/// the scalar [`TrieEntryIter`] and the pipelined [`Trie::common_prefix_batch`].
+/// Keeping it in one place guarantees the two paths produce identical results.
+#[inline(always)]
+fn step_once(trie: &[u32], k: u8, node_pos: &mut usize) -> Step {
+    let k = k as usize;
+    *node_pos ^= k;
+    // UB if out of bounds, same contract as the scalar iterator: the trie is
+    // built so that every reachable index is valid.
+    let unit = *unsafe { trie.get_unchecked(*node_pos) } as usize;
+    if Trie::label(unit) != k {
+        return Step::Dead;
+    }
+    *node_pos ^= Trie::offset(unit);
+    if Trie::has_leaf(unit) {
+        Step::Match {
+            value: Trie::value(*unsafe { trie.get_unchecked(*node_pos) }),
+        }
+    } else {
+        Step::Continue
+    }
+}
+
+/// Speculatively prefetch the cache line a walk will load next.
+///
+/// `node_pos ^ input[pos]` is exactly the index `step_once` will dereference on
+/// the next visit of this lane, so the prefetched line is the one we will need.
+/// The index is clamped into the array as belt-and-suspenders; the prefetch is
+/// only a hint and never faults, so mis-speculation is harmless (issue #117).
+#[inline(always)]
+fn prefetch_lane(trie: &[u32], input: &[u8], node_pos: usize, pos: usize) {
+    if pos < input.len() {
+        let k = *unsafe { input.get_unchecked(pos) } as usize;
+        let idx = (node_pos ^ k).min(trie.len().saturating_sub(1));
+        prefetch_l1(unsafe { trie.as_ptr().add(idx) });
+    }
+}
+
 impl<'a> Trie<'a> {
+    /// Number of independent walks kept in flight by [`Trie::common_prefix_batch`].
+    /// 4 is the measured sweet spot on real SudachiDict tiers: enough
+    /// memory-level parallelism to hide L2/L3 misses on core/full, while keeping
+    /// the per-lane scheduler state small enough to stay in registers. See
+    /// `docs/trie-prefetch.md`.
+    pub const DEFAULT_PREFETCH_LANES: usize = 4;
+    /// Upper bound on lanes so the scheduler can keep lane state on the stack.
+    pub const MAX_PREFETCH_LANES: usize = 16;
+
     pub fn from_bytes(data: &'a [u8]) -> Trie<'a> {
         Trie {
             array: CowArray::from_bytes(data, 0, data.len() / std::mem::size_of::<u32>()),
@@ -124,6 +170,158 @@ impl<'a> Trie<'a> {
         }
     }
 
+    /// Run common-prefix search from many start positions, overlapping their
+    /// memory latency via software pipelining + speculative prefetch.
+    ///
+    /// `emit(bucket, value, end)` is called once per prefix match, where
+    /// `bucket` is the index into `starts`. For each `bucket`, the `(value, end)`
+    /// matches are emitted in exactly the order that
+    /// [`Trie::common_prefix_iterator`]`(input, starts[bucket])` would yield
+    /// them, so grouping the output by `bucket` reproduces the scalar result.
+    /// Matches from different buckets are interleaved in time.
+    ///
+    /// Uses [`Trie::DEFAULT_PREFETCH_LANES`] lanes with prefetch enabled.
+    #[inline]
+    pub fn common_prefix_batch<F: FnMut(usize, u32, usize)>(
+        &self,
+        input: &[u8],
+        starts: &[usize],
+        emit: F,
+    ) {
+        self.common_prefix_batch_cfg(input, starts, Self::DEFAULT_PREFETCH_LANES, true, emit)
+    }
+
+    /// [`Trie::common_prefix_batch`] with an explicit lane count and prefetch
+    /// toggle. Used by benchmarks to sweep lane counts and to isolate the
+    /// effect of explicit prefetch hints from the software pipelining itself.
+    ///
+    /// `lanes` is rounded to the nearest compile-time-specialized lane count so
+    /// the scheduler can keep lane state in registers; values above
+    /// [`Trie::MAX_PREFETCH_LANES`] are clamped.
+    #[inline]
+    pub fn common_prefix_batch_cfg<F: FnMut(usize, u32, usize)>(
+        &self,
+        input: &[u8],
+        starts: &[usize],
+        lanes: usize,
+        prefetch: bool,
+        emit: F,
+    ) {
+        // Specialize on (lane count, prefetch) so both are compile-time constants
+        // in the hot loop: the per-lane state arrays are fixed-size and the
+        // prefetch branch folds away.
+        macro_rules! dispatch {
+            ($k:literal) => {
+                if prefetch {
+                    self.batch_impl::<$k, true, F>(input, starts, emit)
+                } else {
+                    self.batch_impl::<$k, false, F>(input, starts, emit)
+                }
+            };
+        }
+        match lanes {
+            0..=2 => dispatch!(2),
+            3..=4 => dispatch!(4),
+            5..=6 => dispatch!(6),
+            7..=8 => dispatch!(8),
+            9..=12 => dispatch!(12),
+            _ => dispatch!(16),
+        }
+    }
+
+    fn batch_impl<const K: usize, const PF: bool, F: FnMut(usize, u32, usize)>(
+        &self,
+        input: &[u8],
+        starts: &[usize],
+        mut emit: F,
+    ) {
+        if starts.is_empty() {
+            return;
+        }
+        let trie: &[u32] = &self.array;
+        let root = Trie::offset(self.get(0) as usize);
+        let n_in = input.len();
+
+        // Structure-of-arrays lane state. With `K` a constant these are
+        // fixed-size and the per-lane loop unrolls, so the hot fields stay in
+        // registers instead of generating stack traffic that would compete with
+        // the very trie loads we are trying to hide.
+        let mut node = [0usize; K];
+        let mut pos = [0usize; K];
+        let mut bucket = [0usize; K];
+        let mut active = [false; K];
+        let mut next_start = 0usize;
+        let mut live = 0usize;
+
+        for i in 0..K {
+            if next_start < starts.len() {
+                node[i] = root;
+                pos[i] = starts[next_start];
+                bucket[i] = next_start;
+                active[i] = true;
+                next_start += 1;
+                live += 1;
+                if PF {
+                    prefetch_lane(trie, input, root, pos[i]);
+                }
+            }
+        }
+
+        while live > 0 {
+            for i in 0..K {
+                if !active[i] {
+                    continue;
+                }
+                // Advance lane `i` by one byte. `advanced` stays true while the
+                // walk continues; false means it hit a dead end or the input
+                // end and the lane slot is free to refill.
+                let advanced = if pos[i] < n_in {
+                    let k = *unsafe { input.get_unchecked(pos[i]) };
+                    let mut np = node[i];
+                    match step_once(trie, k, &mut np) {
+                        Step::Dead => false,
+                        Step::Continue => {
+                            node[i] = np;
+                            pos[i] += 1;
+                            if PF {
+                                prefetch_lane(trie, input, np, pos[i]);
+                            }
+                            true
+                        }
+                        Step::Match { value } => {
+                            let end = pos[i] + 1;
+                            emit(bucket[i], value, end);
+                            node[i] = np;
+                            pos[i] = end;
+                            if PF {
+                                prefetch_lane(trie, input, np, end);
+                            }
+                            true
+                        }
+                    }
+                } else {
+                    false
+                };
+
+                if !advanced {
+                    // Refill the slot in place from the start queue, or retire it.
+                    if next_start < starts.len() {
+                        node[i] = root;
+                        pos[i] = starts[next_start];
+                        bucket[i] = next_start;
+                        next_start += 1;
+                        if PF {
+                            prefetch_lane(trie, input, root, pos[i]);
+                        }
+                    } else {
+                        active[i] = false;
+                        live -= 1;
+                    }
+                }
+            }
+        }
+    }
+
     #[inline(always)]
     fn get(&self, index: usize) -> u32 {
         debug_assert!(index < self.array.len());
@@ -151,5 +349,92 @@ impl<'a> Trie<'a> {
     #[inline(always)]
     fn offset(unit: usize) -> usize {
         (unit >> 10) << ((unit & (1 << 9)) >> 6)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Trie;
+
+    /// Build a Yada/Darts double array from sorted `(key, value)` pairs, the
+    /// same format the production builder emits.
+    fn build_trie(mut keys: Vec<(&str, u32)>) -> Vec<u8> {
+        keys.sort_by(|a, b| a.0.cmp(b.0));
+        yada::builder::DoubleArrayBuilder::build(&keys).expect("trie build failed")
+    }
+
+    /// Per-start reference output of the scalar iterator.
+    fn scalar_reference(trie: &Trie, input: &[u8], starts: &[usize]) -> Vec<Vec<(u32, usize)>> {
+        starts
+            .iter()
+            .map(|&s| {
+                trie.common_prefix_iterator(input, s)
+                    .map(|e| (e.value, e.end))
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn batch_grouped(
+        trie: &Trie,
+        input: &[u8],
+        starts: &[usize],
+        lanes: usize,
+        prefetch: bool,
+    ) -> Vec<Vec<(u32, usize)>> {
+        let mut got: Vec<Vec<(u32, usize)>> = vec![Vec::new(); starts.len()];
+        trie.common_prefix_batch_cfg(input, starts, lanes, prefetch, |bucket, value, end| {
+            got[bucket].push((value, end));
+        });
+        got
+    }
+
+    #[test]
+    fn batch_matches_scalar_across_lanes_and_prefetch() {
+        // Keys chosen to exercise shared prefixes, a key that is a prefix of
+        // another (leaf node with children), multibyte UTF-8, and misses.
+        let bytes = build_trie(vec![
+            ("a", 1),
+            ("ab", 2),
+            ("abc", 3),
+            ("abd", 4),
+            ("b", 5),
+            ("bc", 6),
+            ("東", 7),
+            ("東京", 8),
+            ("東京都", 9),
+        ]);
+        let trie = Trie::from_bytes(&bytes);
+
+        for text in ["abcabd b 東京都 abZ", "東京", "", "zzz", "ab東京都bca"] {
+            let input = text.as_bytes();
+            let starts: Vec<usize> = (0..=input.len()).collect();
+            let reference = scalar_reference(&trie, input, &starts);
+            for &lanes in &[1usize, 2, 3, 8, 16] {
+                for &prefetch in &[false, true] {
+                    let got = batch_grouped(&trie, input, &starts, lanes, prefetch);
+                    assert_eq!(
+                        got, reference,
+                        "mismatch for text {text:?} lanes={lanes} prefetch={prefetch}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn batch_handles_sparse_and_unordered_starts() {
+        let bytes = build_trie(vec![("ab", 2), ("abc", 3), ("xy", 10)]);
+        let trie = Trie::from_bytes(&bytes);
+        let input = b"abcxyab";
+        // Non-contiguous, repeated, and out-of-order starts.
+        let starts = [6usize, 0, 3, 0, 3];
+        let reference = scalar_reference(&trie, input, &starts);
+        for &lanes in &[1usize, 2, 16] {
+            for &prefetch in &[false, true] {
+                let got = batch_grouped(&trie, input, &starts, lanes, prefetch);
+                assert_eq!(got, reference, "lanes={lanes} prefetch={prefetch}");
+            }
+        }
     }
 }

--- a/sudachi/src/dic/lexicon_set.rs
+++ b/sudachi/src/dic/lexicon_set.rs
@@ -128,6 +128,29 @@ impl LexiconSet<'_> {
             .flat_map(move |l| l.lookup(input, offset))
     }
 
+    /// Pipelined + prefetched batch form of [`LexiconSet::lookup`] (issue #117).
+    ///
+    /// Calls `emit(bucket, entry)` for every match at every start, where
+    /// `bucket` indexes into `starts`. For each bucket the entries are emitted
+    /// in exactly the order repeated [`LexiconSet::lookup`] calls would yield
+    /// (user dictionaries first, then system, each in trie-walk order), so
+    /// grouping by `bucket` reproduces the scalar result. The trie walks of the
+    /// independent starts are overlapped to hide memory latency.
+    #[inline]
+    pub fn lookup_batch<F: FnMut(usize, LexiconEntry)>(
+        &self,
+        input: &[u8],
+        starts: &[usize],
+        mut emit: F,
+    ) {
+        // Dictionaries are processed in the same reverse order as lookup(), and
+        // sequentially, so each bucket accumulates one lexicon's matches fully
+        // before the next lexicon's — matching lookup()'s flat_map order.
+        for lexicon in self.lexicons.iter().rev() {
+            lexicon.lookup_batch(input, starts, &mut emit);
+        }
+    }
+
     /// Checks prefix end offsets in the same dictionary order as lookup(), but
     /// without expanding trie leaves into word IDs.
     #[inline]

--- a/sudachi/src/util.rs
+++ b/sudachi/src/util.rs
@@ -17,6 +17,7 @@
 pub mod check_params;
 pub mod cow_array;
 pub mod fxhash;
+pub mod prefetch;
 #[cfg(test)]
 pub(crate) mod testing;
 pub mod user_pos;

--- a/sudachi/src/util/prefetch.rs
+++ b/sudachi/src/util/prefetch.rs
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2026 Works Applications Co., Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! Portable software-prefetch hint.
+//!
+//! `prefetch_l1` asks the CPU to start pulling the cache line containing `ptr`
+//! into the L1 data cache. It is only a *hint*: the hardware is free to ignore
+//! it and it never faults, so passing a speculative (even out-of-bounds)
+//! address is sound. This is what lets the trie matcher prefetch the next
+//! symbol's node "even with not 100% accuracy" (see issue #117).
+
+/// Issue a temporal L1 read-prefetch for the cache line containing `ptr`.
+///
+/// The hint never dereferences `ptr`, so it is safe for any address. On
+/// architectures without a stable prefetch primitive this compiles to nothing.
+#[inline(always)]
+pub fn prefetch_l1<T>(ptr: *const T) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        // SAFETY: `_mm_prefetch` is a hint and never dereferences the pointer.
+        unsafe {
+            core::arch::x86_64::_mm_prefetch::<{ core::arch::x86_64::_MM_HINT_T0 }>(
+                ptr as *const i8,
+            );
+        }
+    }
+
+    #[cfg(target_arch = "x86")]
+    {
+        // SAFETY: `_mm_prefetch` is a hint and never dereferences the pointer.
+        unsafe {
+            core::arch::x86::_mm_prefetch::<{ core::arch::x86::_MM_HINT_T0 }>(ptr as *const i8);
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        // SAFETY: `prfm` is a hint instruction; it does not fault on a bad
+        // address and writes no memory. `readonly` keeps it from inserting a
+        // write barrier in the hot loop; omitting `pure` keeps it from being
+        // optimized away despite the unused result.
+        unsafe {
+            core::arch::asm!(
+                "prfm pldl1keep, [{p}]",
+                p = in(reg) ptr,
+                options(nostack, preserves_flags, readonly),
+            );
+        }
+    }
+
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))]
+    {
+        // No stable prefetch primitive on this target; the hint is a no-op.
+        let _ = ptr;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prefetch_l1;
+
+    #[test]
+    fn prefetch_valid_pointer_is_noop_observable() {
+        let data = [1u32, 2, 3, 4];
+        // Prefetching a valid address must not change observable state.
+        prefetch_l1(data.as_ptr());
+        prefetch_l1(unsafe { data.as_ptr().add(3) });
+        assert_eq!(data, [1, 2, 3, 4]);
+    }
+}

--- a/sudachi/tests/pipelined_lookup_parity.rs
+++ b/sudachi/tests/pipelined_lookup_parity.rs
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Works Applications Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Differential parity for the issue #117 pipelined+prefetched lattice lookup.
+//! The pipelined path must produce byte-for-byte identical tokenization to the
+//! scalar path; only lookup performance differs.
+
+extern crate sudachi;
+
+use sudachi::prelude::Mode;
+
+mod common;
+use crate::common::TestStatefulTokenizer;
+
+/// A comparable snapshot of one analysis result: enough fields to pin the exact
+/// lattice path (segmentation + the dictionary entry chosen for each morpheme).
+type Snapshot = Vec<(usize, usize, String, Vec<String>, String, String)>;
+
+fn snapshot(tok: &mut TestStatefulTokenizer, text: &str) -> Snapshot {
+    let ms = tok.tokenize(text);
+    (0..ms.len())
+        .map(|i| {
+            let m = ms.get(i);
+            let surface = m.surface().to_string();
+            let pos = m.part_of_speech().to_vec();
+            let normalized = m.normalized_form().to_string();
+            let word_id = format!("{:?}", m.word_id());
+            (m.begin(), m.end(), surface, pos, normalized, word_id)
+        })
+        .collect()
+}
+
+const SENTENCES: &[&str] = &[
+    "",
+    "京都",
+    "東京都に住む",
+    "すもももももももものうち",
+    "10時に2人で会う。",
+    "AIによる形態素解析は楽しい",
+    "ABCＡＢＣ",
+    "ぴらる",
+    "外国人参政権について議論する",
+    "きゃりーぱみゅぱみゅ",
+    "プログラミング言語Rustで書かれた辞書",
+    "！？「テスト」…",
+    "東京特許許可局局長",
+    "私はご飯を食べました。とても美味しかったです。",
+    "アルゴリズムとデータ構造",
+];
+
+fn assert_parity_for_mode(mode: Mode) {
+    let mut tok = TestStatefulTokenizer::new_built(mode);
+    for &sentence in SENTENCES {
+        tok.tok.set_pipelined_lookup(false);
+        let scalar = snapshot(&mut tok, sentence);
+        tok.tok.set_pipelined_lookup(true);
+        let pipelined = snapshot(&mut tok, sentence);
+        assert_eq!(
+            scalar, pipelined,
+            "pipelined lookup diverged from scalar for {sentence:?} in mode {mode:?}"
+        );
+    }
+}
+
+#[test]
+fn pipelined_lookup_matches_scalar_mode_a() {
+    assert_parity_for_mode(Mode::A);
+}
+
+#[test]
+fn pipelined_lookup_matches_scalar_mode_b() {
+    assert_parity_for_mode(Mode::B);
+}
+
+#[test]
+fn pipelined_lookup_matches_scalar_mode_c() {
+    assert_parity_for_mode(Mode::C);
+}


### PR DESCRIPTION
## What

A **runtime** answer to #117: a software-pipelined, prefetch-assisted common-prefix search. It is **on by default**, produces **byte-for-byte identical** output, and is **+8.5–9.5% faster end-to-end** on real SudachiDict small/core/full — with **no change to the serialized dictionary format** and **zero build-time cost**.

## How

Sudachi runs one independent trie walk per character boundary, and each walk's next node address is known one step ahead. So `K = 4` walks are kept in flight and each lane's next node is `prefetch`ed while the others run (group prefetching / AMAC). New `Trie::common_prefix_batch` + `Lexicon`/`LexiconSet::lookup_batch`, wired into `build_lattice` while preserving the reachability gate, OOV handling, the `can_bow` filter, and lookup order. A shared `step_once` makes the scalar and pipelined paths identical by construction. Portable hint: `_mm_prefetch` (x86) / `prfm pldl1keep` (aarch64) / no-op elsewhere — stable Rust only.

## Measured (Apple M4 Max, median of 31 runs, CV < 2%)

| tier | scalar | pipelined | speedup |
|---|---:|---:|---:|
| small | 182.8 ms | 168.3 ms | **+8.6%** |
| core | 189.6 ms | 174.8 ms | **+8.5%** |
| full | 197.5 ms | 180.5 ms | **+9.5%** |

Parity: unit tests across lane counts {1..16} + a differential tokenization test (modes A/B/C) + the full existing suite, all green on the pipelined path.

## Also in this PR

- `docs/performance-investigation.md` — a measured study including **negative results**: prefetching the connection matrix *hurts* (it is volume-bound, not miss-bound), and an alternative trie backend (Crawdad/Daachorse) is only ~+3–5% end-to-end for a dictionary-format break.
- Batch parallelism scales **~8.9× on 16 cores** (the dictionary is `Send + Sync`, shared via `Arc`); see `examples/tokenize_parallel_bench`.
- The earlier **build-time** node relayout (`--trie-layout cache-aware`) is kept strictly **opt-in** (~14× build time for ≤1.10× lookup — not default-worthy).
- The cross-method comparison crates (daachorse/crawdad/fst/rsmarisa) are gated behind `--features matcher-comparison`, so they stay out of the default build/CI graph.

Benchmarks reproduce with `examples/tokenize_pipeline_bench` (single-thread A/B, reports median/CV) and `examples/tokenize_parallel_bench` (scaling) — no extra dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
