### PR TITLE
Add Python TextNormalizer API

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -10,6 +10,7 @@ Also check [rust changelog](../CHANGELOG.md).
 
 - Add `Morpheme.dictionary_form_morpheme()` and `Morpheme.normalized_form_morpheme()`.
 - Added `Dictionary.entries()` and `Dictionary.lookup_all_entries()`.
+- Added `TextNormalizer` and `Dictionary.text_normalizer()`.
 
 ### Changed
 

--- a/python/docs/source/api/sudachipy.rst
+++ b/python/docs/source/api/sudachipy.rst
@@ -16,6 +16,13 @@ Dictionary
    :members:
 
 
+TextNormalizer
+----------------------
+
+.. autoclass:: sudachipy.TextNormalizer
+   :members:
+
+
 SplitMode
 ----------------------
 
@@ -52,4 +59,3 @@ WordInfo
 .. autoclass:: sudachipy.WordInfo
    :members:
    :undoc-members:
-

--- a/python/docs/source/api/sudachipy.rst
+++ b/python/docs/source/api/sudachipy.rst
@@ -19,8 +19,9 @@ Dictionary
 TextNormalizer
 ----------------------
 
-``TextNormalizer`` applies dictionary input-text plugins to raw input text.
+``TextNormalizer`` applies input-text plugins to raw input text.
 It does not perform morphological analysis or return morpheme normalized forms.
+Without a dictionary, it uses the default input-text normalization.
 
 .. autoclass:: sudachipy.TextNormalizer
    :members:

--- a/python/docs/source/api/sudachipy.rst
+++ b/python/docs/source/api/sudachipy.rst
@@ -19,6 +19,9 @@ Dictionary
 TextNormalizer
 ----------------------
 
+``TextNormalizer`` applies dictionary input-text plugins to raw input text.
+It does not perform morphological analysis or return morpheme normalized forms.
+
 .. autoclass:: sudachipy.TextNormalizer
    :members:
 

--- a/python/py_src/sudachipy/__init__.py
+++ b/python/py_src/sudachipy/__init__.py
@@ -1,5 +1,6 @@
 from .sudachipy import (
     Dictionary,
+    TextNormalizer,
     Tokenizer,
     SplitMode,
     MorphemeList,

--- a/python/py_src/sudachipy/sudachipy.pyi
+++ b/python/py_src/sudachipy/sudachipy.pyi
@@ -114,6 +114,15 @@ class Dictionary:
         """
         ...
 
+    def text_normalizer(self) -> TextNormalizer:
+        """
+        Creates a text normalizer from this dictionary.
+
+        The returned normalizer applies the same input-text plugins that this
+        dictionary uses before tokenization.
+        """
+        ...
+
     def pos_matcher(self, target: Union[Iterable[PartialPOS], Callable[[POS], bool]]) -> PosMatcher:
         """
         Creates a new POS matcher.
@@ -219,6 +228,32 @@ class Dictionary:
         :param reading: reading form of the morpheme
         :param normalized_form: normalized form of the morpheme
         :param dictionary_form: dictionary form of the morpheme
+        """
+        ...
+
+
+class TextNormalizer:
+    """
+    A text normalizer.
+
+    Create using ``Dictionary.text_normalizer()`` or by passing a ``Dictionary``
+    to this class.
+    """
+
+    def __init__(self, dictionary: Dictionary) -> None:
+        """
+        Creates a text normalizer from a dictionary.
+
+        The normalizer applies the same input-text plugins that the dictionary
+        uses before tokenization.
+        """
+        ...
+
+    def normalize(self, text: str) -> str:
+        """
+        Normalize text using dictionary input-text plugins.
+
+        :param text: text to normalize.
         """
         ...
 

--- a/python/py_src/sudachipy/sudachipy.pyi
+++ b/python/py_src/sudachipy/sudachipy.pyi
@@ -119,8 +119,7 @@ class Dictionary:
         Creates a text normalizer from this dictionary.
 
         The returned normalizer applies the same input-text plugins that this
-        dictionary uses before tokenization. It can keep normalizing text after
-        this dictionary is closed.
+        dictionary uses before tokenization.
         """
         ...
 
@@ -237,26 +236,27 @@ class TextNormalizer:
     """
     A text normalizer.
 
-    Applies dictionary input-text plugins to raw input text. This does not
-    perform morphological analysis or return morpheme normalized forms.
+    Applies input-text plugins to raw input text. This does not perform
+    morphological analysis or return morpheme normalized forms.
 
     Create using ``Dictionary.text_normalizer()`` or by passing a ``Dictionary``
-    to this class.
+    to this class. Without a dictionary, this uses the default input-text
+    normalization.
     """
 
-    def __init__(self, dictionary: Dictionary) -> None:
+    def __init__(self, dictionary: Dictionary | None = None) -> None:
         """
-        Creates a text normalizer from a dictionary.
+        Creates a text normalizer.
 
-        The normalizer applies the same input-text plugins that the dictionary
-        uses before tokenization. It can keep normalizing text after the source
-        dictionary is closed.
+        When dictionary is provided, this applies the same input-text plugins
+        used by that dictionary before tokenization. Without a dictionary, this
+        applies the default input-text normalization.
         """
         ...
 
     def normalize(self, text: str) -> str:
         """
-        Normalize text using dictionary input-text plugins.
+        Normalize text using input-text plugins.
 
         This normalizes tokenizer input text, not the dictionary-normalized form
         returned by ``Morpheme.normalized_form()``.

--- a/python/py_src/sudachipy/sudachipy.pyi
+++ b/python/py_src/sudachipy/sudachipy.pyi
@@ -119,7 +119,8 @@ class Dictionary:
         Creates a text normalizer from this dictionary.
 
         The returned normalizer applies the same input-text plugins that this
-        dictionary uses before tokenization.
+        dictionary uses before tokenization. It can keep normalizing text after
+        this dictionary is closed.
         """
         ...
 
@@ -236,6 +237,9 @@ class TextNormalizer:
     """
     A text normalizer.
 
+    Applies dictionary input-text plugins to raw input text. This does not
+    perform morphological analysis or return morpheme normalized forms.
+
     Create using ``Dictionary.text_normalizer()`` or by passing a ``Dictionary``
     to this class.
     """
@@ -245,13 +249,17 @@ class TextNormalizer:
         Creates a text normalizer from a dictionary.
 
         The normalizer applies the same input-text plugins that the dictionary
-        uses before tokenization.
+        uses before tokenization. It can keep normalizing text after the source
+        dictionary is closed.
         """
         ...
 
     def normalize(self, text: str) -> str:
         """
         Normalize text using dictionary input-text plugins.
+
+        This normalizes tokenizer input text, not the dictionary-normalized form
+        returned by ``Morpheme.normalized_form()``.
 
         :param text: text to normalize.
         """

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -367,8 +367,7 @@ impl PyDictionary {
     /// Creates a text normalizer from this dictionary.
     ///
     /// The returned normalizer applies the same input-text plugins that this
-    /// dictionary uses before tokenization. It can keep normalizing text after
-    /// this dictionary is closed.
+    /// dictionary uses before tokenization.
     #[pyo3(text_signature = "(self, /) -> TextNormalizer")]
     fn text_normalizer(&self) -> PyTextNormalizer {
         PyTextNormalizer::from_dictionary(self.data())

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -370,7 +370,7 @@ impl PyDictionary {
     /// dictionary uses before tokenization.
     #[pyo3(text_signature = "(self, /) -> TextNormalizer")]
     fn text_normalizer(&self) -> PyTextNormalizer {
-        PyTextNormalizer::from_dictionary(self.data())
+        PyTextNormalizer::from_dictionary(self)
     }
 
     /// Creates a POS matcher object

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -367,7 +367,8 @@ impl PyDictionary {
     /// Creates a text normalizer from this dictionary.
     ///
     /// The returned normalizer applies the same input-text plugins that this
-    /// dictionary uses before tokenization.
+    /// dictionary uses before tokenization. It can keep normalizing text after
+    /// this dictionary is closed.
     #[pyo3(text_signature = "(self, /) -> TextNormalizer")]
     fn text_normalizer(&self) -> PyTextNormalizer {
         PyTextNormalizer::from_dictionary(self.data())

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -43,6 +43,7 @@ use crate::morpheme::{PyMorpheme, PyMorphemeListWrapper};
 use crate::pos_matcher::PyPosMatcher;
 use crate::pretokenizer::PyPretokenizer;
 use crate::projection::{pyprojection, PyProjector};
+use crate::text_normalizer::PyTextNormalizer;
 use crate::tokenizer::{PySplitMode, PyTokenizer};
 
 pub(crate) struct PyDicData {
@@ -81,6 +82,12 @@ impl LexiconAccess for PyDicData {
 impl PyDicData {
     pub fn pos_of(&self, pos_id: u16) -> &Py<PyTuple> {
         &self.pos[pos_id as usize]
+    }
+}
+
+impl PyDictionary {
+    pub(crate) fn data(&self) -> Arc<PyDicData> {
+        self.dictionary.as_ref().unwrap().clone()
     }
 }
 
@@ -355,6 +362,15 @@ impl PyDictionary {
 
         let tok = PyTokenizer::new(dict, mode, fields | required_fields, projection);
         Ok(tok)
+    }
+
+    /// Creates a text normalizer from this dictionary.
+    ///
+    /// The returned normalizer applies the same input-text plugins that this
+    /// dictionary uses before tokenization.
+    #[pyo3(text_signature = "(self, /) -> TextNormalizer")]
+    fn text_normalizer(&self) -> PyTextNormalizer {
+        PyTextNormalizer::from_dictionary(self.data())
     }
 
     /// Creates a POS matcher object

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -23,6 +23,7 @@ mod morpheme;
 mod pos_matcher;
 mod pretokenizer;
 mod projection;
+mod text_normalizer;
 mod tokenizer;
 
 /// SudachiPy raw module root.
@@ -32,6 +33,7 @@ mod tokenizer;
 fn sudachipy(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<dictionary::PyDictionary>()?;
     m.add_class::<dictionary::PyDictionaryEntryIterator>()?;
+    m.add_class::<text_normalizer::PyTextNormalizer>()?;
     m.add_class::<tokenizer::PySplitMode>()?;
     m.add_class::<tokenizer::PyTokenizer>()?;
     m.add_class::<morpheme::PyMorphemeListWrapper>()?;

--- a/python/src/text_normalizer.rs
+++ b/python/src/text_normalizer.rs
@@ -21,42 +21,65 @@ use pyo3::prelude::*;
 use sudachi::dic::DictionaryAccess;
 use sudachi::error::SudachiResult;
 use sudachi::input_text::InputBuffer;
+use sudachi::text_normalizer::TextNormalizer;
 
 use crate::dictionary::{PyDicData, PyDictionary};
 use crate::errors;
 
 /// A text normalizer.
 ///
-/// This applies dictionary input-text plugins to raw input text. It does not
-/// perform morphological analysis or return morpheme normalized forms.
+/// This applies input-text plugins to raw input text. It does not perform
+/// morphological analysis or return morpheme normalized forms.
 ///
 /// Create using ``Dictionary.text_normalizer()`` or by passing a
-/// ``Dictionary`` to this class.
+/// ``Dictionary`` to this class. Without a dictionary, this uses the default
+/// input-text normalization.
 #[pyclass(module = "sudachipy", name = "TextNormalizer")]
 pub struct PyTextNormalizer {
-    dict: Arc<PyDicData>,
+    inner: PyTextNormalizerInner,
+}
+
+enum PyTextNormalizerInner {
+    Default(TextNormalizer<'static>),
+    Dictionary {
+        dict: Arc<PyDicData>,
+        buffer: InputBuffer,
+    },
 }
 
 impl PyTextNormalizer {
     pub(crate) fn from_dictionary(dict: Arc<PyDicData>) -> Self {
-        Self { dict }
+        Self {
+            inner: PyTextNormalizerInner::Dictionary {
+                dict,
+                buffer: InputBuffer::new(),
+            },
+        }
     }
 }
 
 #[pymethods]
 impl PyTextNormalizer {
-    /// Creates a text normalizer from a dictionary.
+    /// Creates a text normalizer.
     ///
-    /// The normalizer applies the same input-text plugins that the dictionary
-    /// uses before tokenization. The normalizer can keep normalizing text after
-    /// the source dictionary is closed.
+    /// When dictionary is provided, this applies the same input-text plugins
+    /// used by that dictionary before tokenization. Without a dictionary, this
+    /// applies the default input-text normalization.
     #[new]
-    #[pyo3(text_signature = "(dictionary) -> TextNormalizer")]
-    fn new(dictionary: PyRef<'_, PyDictionary>) -> PyTextNormalizer {
-        PyTextNormalizer::from_dictionary(dictionary.data())
+    #[pyo3(
+        signature = (dictionary=None),
+        text_signature = "(dictionary=None) -> TextNormalizer"
+    )]
+    fn new(dictionary: Option<PyRef<'_, PyDictionary>>) -> PyResult<PyTextNormalizer> {
+        match dictionary {
+            Some(dictionary) => Ok(PyTextNormalizer::from_dictionary(dictionary.data())),
+            None => Ok(Self {
+                inner: PyTextNormalizerInner::Default(errors::wrap(TextNormalizer::default())?),
+            }),
+        }
     }
 
-    /// Normalize text using dictionary input-text plugins.
+    /// Normalize text using input-text plugins.
     ///
     /// This normalizes tokenizer input text, not the dictionary-normalized form
     /// returned by ``Morpheme.normalized_form()``.
@@ -64,20 +87,34 @@ impl PyTextNormalizer {
     /// :param text: text to normalize.
     /// :type text: str
     #[pyo3(text_signature = "(self, /, text: str) -> str")]
-    fn normalize(&self, py: Python<'_>, text: &str) -> PyResult<String> {
+    fn normalize(&mut self, py: Python<'_>, text: &str) -> PyResult<String> {
         errors::wrap_ctx(
-            py.detach(|| normalize_with_dictionary(&self.dict, text)),
+            py.detach(|| self.normalize_inner(text)),
             "Error during text normalization",
         )
     }
 }
 
-fn normalize_with_dictionary(dict: &PyDicData, text: &str) -> SudachiResult<String> {
-    let mut buffer = InputBuffer::new();
+impl PyTextNormalizer {
+    fn normalize_inner(&mut self, text: &str) -> SudachiResult<String> {
+        match &mut self.inner {
+            PyTextNormalizerInner::Default(normalizer) => normalizer.normalize(text),
+            PyTextNormalizerInner::Dictionary { dict, buffer } => {
+                normalize_with_dictionary(dict.as_ref(), buffer, text)
+            }
+        }
+    }
+}
+
+fn normalize_with_dictionary(
+    dict: &PyDicData,
+    buffer: &mut InputBuffer,
+    text: &str,
+) -> SudachiResult<String> {
     buffer.reset().push_str(text);
     buffer.start_build()?;
     for plugin in dict.input_text_plugins() {
-        plugin.rewrite(&mut buffer)?;
+        plugin.rewrite(buffer)?;
     }
     Ok(buffer.current().to_owned())
 }

--- a/python/src/text_normalizer.rs
+++ b/python/src/text_normalizer.rs
@@ -14,11 +14,13 @@
  *  limitations under the License.
  */
 
+use std::sync::Arc;
+
 use pyo3::prelude::*;
 
 use sudachi::text_normalizer::TextNormalizer;
 
-use crate::dictionary::PyDictionary;
+use crate::dictionary::{PyDicData, PyDictionary};
 use crate::errors;
 
 /// A text normalizer.
@@ -31,13 +33,20 @@ use crate::errors;
 /// input-text normalization.
 #[pyclass(module = "sudachipy", name = "TextNormalizer")]
 pub struct PyTextNormalizer {
-    normalizer: TextNormalizer<'static>,
+    normalizer: PyTextNormalizerInner,
+}
+
+enum PyTextNormalizerInner {
+    Default(TextNormalizer),
+    Dictionary(TextNormalizer<Arc<PyDicData>>),
 }
 
 impl PyTextNormalizer {
     pub(crate) fn from_dictionary(dictionary: &PyDictionary) -> Self {
         Self {
-            normalizer: TextNormalizer::from_shared_dictionary(dictionary.data()),
+            normalizer: PyTextNormalizerInner::Dictionary(TextNormalizer::from_shared_dictionary(
+                dictionary.data(),
+            )),
         }
     }
 }
@@ -58,7 +67,9 @@ impl PyTextNormalizer {
         match dictionary {
             Some(dictionary) => Ok(PyTextNormalizer::from_dictionary(&dictionary)),
             None => Ok(Self {
-                normalizer: errors::wrap(TextNormalizer::default())?,
+                normalizer: PyTextNormalizerInner::Default(errors::wrap(
+                    TextNormalizer::try_default(),
+                )?),
             }),
         }
     }
@@ -73,7 +84,10 @@ impl PyTextNormalizer {
     #[pyo3(text_signature = "(self, /, text: str) -> str")]
     fn normalize(&mut self, py: Python<'_>, text: &str) -> PyResult<String> {
         errors::wrap_ctx(
-            py.detach(|| self.normalizer.normalize(text)),
+            py.detach(|| match &mut self.normalizer {
+                PyTextNormalizerInner::Default(normalizer) => normalizer.normalize(text),
+                PyTextNormalizerInner::Dictionary(normalizer) => normalizer.normalize(text),
+            }),
             "Error during text normalization",
         )
     }

--- a/python/src/text_normalizer.rs
+++ b/python/src/text_normalizer.rs
@@ -14,16 +14,11 @@
  *  limitations under the License.
  */
 
-use std::sync::Arc;
-
 use pyo3::prelude::*;
 
-use sudachi::dic::DictionaryAccess;
-use sudachi::error::SudachiResult;
-use sudachi::input_text::InputBuffer;
 use sudachi::text_normalizer::TextNormalizer;
 
-use crate::dictionary::{PyDicData, PyDictionary};
+use crate::dictionary::PyDictionary;
 use crate::errors;
 
 /// A text normalizer.
@@ -36,24 +31,13 @@ use crate::errors;
 /// input-text normalization.
 #[pyclass(module = "sudachipy", name = "TextNormalizer")]
 pub struct PyTextNormalizer {
-    inner: PyTextNormalizerInner,
-}
-
-enum PyTextNormalizerInner {
-    Default(TextNormalizer<'static>),
-    Dictionary {
-        dict: Arc<PyDicData>,
-        buffer: InputBuffer,
-    },
+    normalizer: TextNormalizer<'static>,
 }
 
 impl PyTextNormalizer {
-    pub(crate) fn from_dictionary(dict: Arc<PyDicData>) -> Self {
+    pub(crate) fn from_dictionary(dictionary: &PyDictionary) -> Self {
         Self {
-            inner: PyTextNormalizerInner::Dictionary {
-                dict,
-                buffer: InputBuffer::new(),
-            },
+            normalizer: TextNormalizer::from_shared_dictionary(dictionary.data()),
         }
     }
 }
@@ -72,9 +56,9 @@ impl PyTextNormalizer {
     )]
     fn new(dictionary: Option<PyRef<'_, PyDictionary>>) -> PyResult<PyTextNormalizer> {
         match dictionary {
-            Some(dictionary) => Ok(PyTextNormalizer::from_dictionary(dictionary.data())),
+            Some(dictionary) => Ok(PyTextNormalizer::from_dictionary(&dictionary)),
             None => Ok(Self {
-                inner: PyTextNormalizerInner::Default(errors::wrap(TextNormalizer::default())?),
+                normalizer: errors::wrap(TextNormalizer::default())?,
             }),
         }
     }
@@ -89,32 +73,8 @@ impl PyTextNormalizer {
     #[pyo3(text_signature = "(self, /, text: str) -> str")]
     fn normalize(&mut self, py: Python<'_>, text: &str) -> PyResult<String> {
         errors::wrap_ctx(
-            py.detach(|| self.normalize_inner(text)),
+            py.detach(|| self.normalizer.normalize(text)),
             "Error during text normalization",
         )
     }
-}
-
-impl PyTextNormalizer {
-    fn normalize_inner(&mut self, text: &str) -> SudachiResult<String> {
-        match &mut self.inner {
-            PyTextNormalizerInner::Default(normalizer) => normalizer.normalize(text),
-            PyTextNormalizerInner::Dictionary { dict, buffer } => {
-                normalize_with_dictionary(dict.as_ref(), buffer, text)
-            }
-        }
-    }
-}
-
-fn normalize_with_dictionary(
-    dict: &PyDicData,
-    buffer: &mut InputBuffer,
-    text: &str,
-) -> SudachiResult<String> {
-    buffer.reset().push_str(text);
-    buffer.start_build()?;
-    for plugin in dict.input_text_plugins() {
-        plugin.rewrite(buffer)?;
-    }
-    Ok(buffer.current().to_owned())
 }

--- a/python/src/text_normalizer.rs
+++ b/python/src/text_normalizer.rs
@@ -27,6 +27,9 @@ use crate::errors;
 
 /// A text normalizer.
 ///
+/// This applies dictionary input-text plugins to raw input text. It does not
+/// perform morphological analysis or return morpheme normalized forms.
+///
 /// Create using ``Dictionary.text_normalizer()`` or by passing a
 /// ``Dictionary`` to this class.
 #[pyclass(module = "sudachipy", name = "TextNormalizer")]
@@ -45,7 +48,8 @@ impl PyTextNormalizer {
     /// Creates a text normalizer from a dictionary.
     ///
     /// The normalizer applies the same input-text plugins that the dictionary
-    /// uses before tokenization.
+    /// uses before tokenization. The normalizer can keep normalizing text after
+    /// the source dictionary is closed.
     #[new]
     #[pyo3(text_signature = "(dictionary) -> TextNormalizer")]
     fn new(dictionary: PyRef<'_, PyDictionary>) -> PyTextNormalizer {
@@ -53,6 +57,9 @@ impl PyTextNormalizer {
     }
 
     /// Normalize text using dictionary input-text plugins.
+    ///
+    /// This normalizes tokenizer input text, not the dictionary-normalized form
+    /// returned by ``Morpheme.normalized_form()``.
     ///
     /// :param text: text to normalize.
     /// :type text: str

--- a/python/src/text_normalizer.rs
+++ b/python/src/text_normalizer.rs
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2026 Works Applications Co., Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use pyo3::prelude::*;
+
+use sudachi::dic::DictionaryAccess;
+use sudachi::error::SudachiResult;
+use sudachi::input_text::InputBuffer;
+
+use crate::dictionary::{PyDicData, PyDictionary};
+use crate::errors;
+
+/// A text normalizer.
+///
+/// Create using ``Dictionary.text_normalizer()`` or by passing a
+/// ``Dictionary`` to this class.
+#[pyclass(module = "sudachipy", name = "TextNormalizer")]
+pub struct PyTextNormalizer {
+    dict: Arc<PyDicData>,
+}
+
+impl PyTextNormalizer {
+    pub(crate) fn from_dictionary(dict: Arc<PyDicData>) -> Self {
+        Self { dict }
+    }
+}
+
+#[pymethods]
+impl PyTextNormalizer {
+    /// Creates a text normalizer from a dictionary.
+    ///
+    /// The normalizer applies the same input-text plugins that the dictionary
+    /// uses before tokenization.
+    #[new]
+    #[pyo3(text_signature = "(dictionary) -> TextNormalizer")]
+    fn new(dictionary: PyRef<'_, PyDictionary>) -> PyTextNormalizer {
+        PyTextNormalizer::from_dictionary(dictionary.data())
+    }
+
+    /// Normalize text using dictionary input-text plugins.
+    ///
+    /// :param text: text to normalize.
+    /// :type text: str
+    #[pyo3(text_signature = "(self, /, text: str) -> str")]
+    fn normalize(&self, py: Python<'_>, text: &str) -> PyResult<String> {
+        errors::wrap_ctx(
+            py.detach(|| normalize_with_dictionary(&self.dict, text)),
+            "Error during text normalization",
+        )
+    }
+}
+
+fn normalize_with_dictionary(dict: &PyDicData, text: &str) -> SudachiResult<String> {
+    let mut buffer = InputBuffer::new();
+    buffer.reset().push_str(text);
+    buffer.start_build()?;
+    for plugin in dict.input_text_plugins() {
+        plugin.rewrite(&mut buffer)?;
+    }
+    Ok(buffer.current().to_owned())
+}

--- a/python/tests/test_import.py
+++ b/python/tests/test_import.py
@@ -27,3 +27,7 @@ class TestImport(unittest.TestCase):
     def test_import_morphemelist(self):
         from sudachipy.morphemelist import MorphemeList
         self.assertIsNotNone(MorphemeList)
+
+    def test_import_text_normalizer(self):
+        from sudachipy import TextNormalizer
+        self.assertIsNotNone(TextNormalizer)

--- a/python/tests/test_text_normalizer.py
+++ b/python/tests/test_text_normalizer.py
@@ -43,6 +43,26 @@ class TestTextNormalizer(unittest.TestCase):
         normalizer = TextNormalizer(self.dict_)
         self.assertEqual("abc", normalizer.normalize("ＡＢＣ"))
 
+    def test_repeated_calls_and_empty_text(self):
+        normalizer = self.dict_.text_normalizer()
+        self.assertEqual("", normalizer.normalize(""))
+        self.assertEqual("abc", normalizer.normalize("ＡＢＣ"))
+        self.assertEqual(NORMALIZED_TEXT, normalizer.normalize(ORIGINAL_TEXT))
+
+    def test_normalizer_outlives_dictionary_close(self):
+        normalizer = self.dict_.text_normalizer()
+        self.dict_.close()
+        self.assertEqual("abc", normalizer.normalize("ＡＢＣ"))
+
+    def test_normalize_rejects_non_string_input(self):
+        normalizer = self.dict_.text_normalizer()
+        with self.assertRaises(TypeError):
+            normalizer.normalize(1)
+
+    def test_normalize_is_not_morpheme_normalized_form(self):
+        normalizer = self.dict_.text_normalizer()
+        self.assertEqual("附属", normalizer.normalize("附属"))
+
     def test_uses_dictionary_input_text_plugins(self):
         dictionary = Dictionary(config=Config(
             system=str(self.resource_dir / "system.dic.test"),

--- a/python/tests/test_text_normalizer.py
+++ b/python/tests/test_text_normalizer.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Works Applications Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from pathlib import Path
+
+from sudachipy import Config, Dictionary, TextNormalizer
+
+
+ORIGINAL_TEXT = "ÂＢΓД㈱ｶﾞウ゛⼼Ⅲ"
+NORMALIZED_TEXT = "âbγд(株)ガヴ⼼ⅲ"
+
+
+class TestTextNormalizer(unittest.TestCase):
+    def setUp(self):
+        self.resource_dir = Path(__file__).parent / "resources"
+        self.dict_ = Dictionary(
+            os.path.join(self.resource_dir, "sudachi.json"),
+            resource_dir=self.resource_dir,
+        )
+
+    def tearDown(self):
+        self.dict_.close()
+
+    def test_dictionary_text_normalizer(self):
+        normalizer = self.dict_.text_normalizer()
+        self.assertIsInstance(normalizer, TextNormalizer)
+        self.assertEqual(NORMALIZED_TEXT, normalizer.normalize(ORIGINAL_TEXT))
+
+    def test_text_normalizer_constructor(self):
+        normalizer = TextNormalizer(self.dict_)
+        self.assertEqual("abc", normalizer.normalize("ＡＢＣ"))
+
+    def test_uses_dictionary_input_text_plugins(self):
+        dictionary = Dictionary(config=Config(
+            system=str(self.resource_dir / "system.dic.test"),
+            characterDefinitionFile=str(self.resource_dir / "char.def"),
+            inputTextPlugin=[
+                {"class": "com.worksap.nlp.sudachi.DefaultInputTextPlugin"},
+                {"class": "com.worksap.nlp.sudachi.IgnoreYomiganaPlugin",
+                 "leftBrackets": ["(", "（"],
+                 "rightBrackets": [")", "）"],
+                 "maxYomiganaLength": 4},
+            ],
+            oovProviderPlugin=[
+                {"class": "com.worksap.nlp.sudachi.SimpleOovPlugin",
+                 "oovPOS": ["名詞", "普通名詞", "一般", "*", "*", "*"],
+                 "leftId": 8,
+                 "rightId": 8,
+                 "cost": 6000},
+            ],
+            pathRewritePlugin=[],
+        ))
+        try:
+            normalizer = dictionary.text_normalizer()
+            self.assertEqual("京都", normalizer.normalize("京都（キョウト）"))
+        finally:
+            dictionary.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_text_normalizer.py
+++ b/python/tests/test_text_normalizer.py
@@ -85,6 +85,7 @@ class TestTextNormalizer(unittest.TestCase):
         try:
             normalizer = dictionary.text_normalizer()
             self.assertEqual("京都", normalizer.normalize("京都（キョウト）"))
+            self.assertEqual("京都", TextNormalizer(dictionary).normalize("京都（キョウト）"))
         finally:
             dictionary.close()
 

--- a/python/tests/test_text_normalizer.py
+++ b/python/tests/test_text_normalizer.py
@@ -39,6 +39,10 @@ class TestTextNormalizer(unittest.TestCase):
         self.assertIsInstance(normalizer, TextNormalizer)
         self.assertEqual(NORMALIZED_TEXT, normalizer.normalize(ORIGINAL_TEXT))
 
+    def test_default_text_normalizer(self):
+        normalizer = TextNormalizer()
+        self.assertEqual(NORMALIZED_TEXT, normalizer.normalize(ORIGINAL_TEXT))
+
     def test_text_normalizer_constructor(self):
         normalizer = TextNormalizer(self.dict_)
         self.assertEqual("abc", normalizer.normalize("ＡＢＣ"))
@@ -48,11 +52,6 @@ class TestTextNormalizer(unittest.TestCase):
         self.assertEqual("", normalizer.normalize(""))
         self.assertEqual("abc", normalizer.normalize("ＡＢＣ"))
         self.assertEqual(NORMALIZED_TEXT, normalizer.normalize(ORIGINAL_TEXT))
-
-    def test_normalizer_outlives_dictionary_close(self):
-        normalizer = self.dict_.text_normalizer()
-        self.dict_.close()
-        self.assertEqual("abc", normalizer.normalize("ＡＢＣ"))
 
     def test_normalize_rejects_non_string_input(self):
         normalizer = self.dict_.text_normalizer()

--- a/sudachi-cli/src/build.rs
+++ b/sudachi-cli/src/build.rs
@@ -385,7 +385,7 @@ fn dump_word_info<W: Write>(
             word_ids.push(entry);
         }
     }
-    let normalizer = TextNormalizer::new(&grammar)?;
+    let mut normalizer = TextNormalizer::new(&grammar)?;
     let ctx = WordInfoDumpCtx {
         grammar,
         lexicon,

--- a/sudachi-fuzz/Cargo.toml
+++ b/sudachi-fuzz/Cargo.toml
@@ -14,3 +14,6 @@ arbitrary = "1"
 
 [target.'cfg(unix)'.dependencies]
 honggfuzz = "0.5"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/sudachi/src/dic/connect.rs
+++ b/sudachi/src/dic/connect.rs
@@ -101,3 +101,13 @@ impl<'a> ConnectionMatrix<'a> {
         self.num_right
     }
 }
+
+impl ConnectionMatrix<'static> {
+    pub fn empty() -> Self {
+        ConnectionMatrix {
+            data: CowArray::from_owned(Vec::new()),
+            num_left: 0,
+            num_right: 0,
+        }
+    }
+}

--- a/sudachi/src/dic/grammar.rs
+++ b/sudachi/src/dic/grammar.rs
@@ -153,6 +153,12 @@ impl<'a> Grammar<'a> {
     }
 }
 
+impl Grammar<'static> {
+    pub fn empty() -> Self {
+        Self::from_parts(PosList::default(), ConnectionMatrix::empty())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sudachi/src/test.rs
+++ b/sudachi/src/test.rs
@@ -15,18 +15,12 @@
  */
 
 use crate::dic::character_category::CharacterCategory;
-use crate::dic::connect::ConnectionMatrix;
 use crate::dic::grammar::Grammar;
-use crate::dic::pos::PosList;
 use lazy_static::lazy_static;
-
-const ZERO_CONNECTION_BYTES: &[u8] = &[0, 0, 0, 0];
 
 /// Returns Grammar with empty data
 pub fn zero_grammar() -> Grammar<'static> {
-    let connection = ConnectionMatrix::from_bytes(ZERO_CONNECTION_BYTES)
-        .expect("Failed to make connection matrix");
-    Grammar::from_parts(PosList::default(), connection)
+    Grammar::empty()
 }
 
 const TEST_CHAR_DEF: &[u8] = include_bytes!("../tests/resources/char.def");

--- a/sudachi/src/text_normalizer.rs
+++ b/sudachi/src/text_normalizer.rs
@@ -28,7 +28,10 @@ use crate::prelude::*;
 
 const ZERO_CONNECTION_BYTES: &[u8] = &[0, 0, 0, 0];
 
-/// Applies the same default input-text normalization used by tokenizer input processing.
+/// Applies input-text normalization used by tokenizer input processing.
+///
+/// By default, this uses `DefaultInputTextPlugin`. When built from a dictionary,
+/// it applies that dictionary's configured input-text plugins.
 pub struct TextNormalizer<'a> {
     source: TextNormalizerSource<'a>,
     input: InputBuffer,

--- a/sudachi/src/text_normalizer.rs
+++ b/sudachi/src/text_normalizer.rs
@@ -15,32 +15,177 @@
  */
 
 use crate::config::ConfigBuilder;
+use crate::dic::connect::ConnectionMatrix;
 use crate::dic::grammar::Grammar;
+use crate::dic::pos::PosList;
+use crate::dic::DictionaryAccess;
 use crate::input_text::InputBuffer;
 use crate::plugin::input_text::default_input_text::DefaultInputTextPlugin;
 use crate::plugin::input_text::InputTextPlugin;
 use crate::prelude::*;
 
+const ZERO_CONNECTION_BYTES: &[u8] = &[0, 0, 0, 0];
+
 /// Applies the same default input-text normalization used by tokenizer input processing.
-pub struct TextNormalizer {
-    plugin: DefaultInputTextPlugin,
+pub struct TextNormalizer<'a> {
+    source: TextNormalizerSource<'a>,
+    input: InputBuffer,
 }
 
-impl TextNormalizer {
+enum TextNormalizerSource<'a> {
+    Default(DefaultInputTextPlugin),
+    Dictionary(&'a (dyn DictionaryAccess + Sync)),
+}
+
+impl<'a> TextNormalizer<'a> {
+    /// Create a text normalizer using the default input-text plugin.
     pub fn new(grammar: &Grammar) -> SudachiResult<Self> {
-        let mut plugin = DefaultInputTextPlugin::default();
-        let cfg = ConfigBuilder::empty().push_embedded().build();
-        plugin.set_up(
-            &serde_json::Value::Object(serde_json::Map::default()),
-            &cfg,
-            grammar,
-        )?;
-        Ok(Self { plugin })
+        Ok(Self {
+            source: TextNormalizerSource::Default(set_up_default_plugin(grammar)?),
+            input: InputBuffer::new(),
+        })
     }
 
-    pub fn normalize(&self, text: &str) -> SudachiResult<String> {
-        let mut input = InputBuffer::from(text);
-        self.plugin.rewrite(&mut input)?;
-        Ok(input.current().to_string())
+    /// Create a text normalizer using the default input-text plugin and an empty grammar.
+    pub fn default() -> SudachiResult<Self> {
+        let grammar = empty_grammar()?;
+        Self::new(&grammar)
+    }
+
+    /// Create a text normalizer using the input-text plugins from a dictionary.
+    pub fn from_dictionary<D>(dictionary: &'a D) -> Self
+    where
+        D: DictionaryAccess + Sync + 'a,
+    {
+        Self {
+            source: TextNormalizerSource::Dictionary(dictionary),
+            input: InputBuffer::new(),
+        }
+    }
+
+    pub fn normalize(&mut self, text: &str) -> SudachiResult<String> {
+        self.input.reset().push_str(text);
+        self.input.start_build()?;
+        match &self.source {
+            TextNormalizerSource::Default(plugin) => plugin.rewrite(&mut self.input)?,
+            TextNormalizerSource::Dictionary(dictionary) => {
+                for plugin in dictionary.input_text_plugins() {
+                    plugin.rewrite(&mut self.input)?;
+                }
+            }
+        }
+        Ok(self.input.current().to_owned())
+    }
+}
+
+fn set_up_default_plugin(grammar: &Grammar) -> SudachiResult<DefaultInputTextPlugin> {
+    let mut plugin = DefaultInputTextPlugin::default();
+    let cfg = ConfigBuilder::empty().push_embedded().build();
+    plugin.set_up(
+        &serde_json::Value::Object(serde_json::Map::default()),
+        &cfg,
+        grammar,
+    )?;
+    Ok(plugin)
+}
+
+fn empty_grammar() -> SudachiResult<Grammar<'static>> {
+    let connection = ConnectionMatrix::from_bytes(ZERO_CONNECTION_BYTES)?;
+    Ok(Grammar::from_parts(PosList::default(), connection))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::*;
+    use crate::config::Config;
+    use crate::dic::lexicon_set::LexiconSet;
+    use crate::dic::LexiconAccess;
+    use crate::input_text::InputEditor;
+    use crate::plugin::oov::OovProviderPlugin;
+    use crate::plugin::path_rewrite::PathRewritePlugin;
+
+    struct ReplaceAllPlugin;
+
+    impl InputTextPlugin for ReplaceAllPlugin {
+        fn set_up(
+            &mut self,
+            _settings: &Value,
+            _config: &Config,
+            _grammar: &Grammar,
+        ) -> SudachiResult<()> {
+            Ok(())
+        }
+
+        #[allow(deprecated)]
+        fn rewrite_impl<'a>(
+            &'a self,
+            input: &InputBuffer,
+            mut edit: InputEditor<'a>,
+        ) -> SudachiResult<InputEditor<'a>> {
+            edit.replace_ref(0..input.current().len(), "rewritten");
+            Ok(edit)
+        }
+    }
+
+    struct MockDictionary {
+        grammar: Grammar<'static>,
+        input_text_plugins: Vec<Box<dyn InputTextPlugin + Sync + Send>>,
+        oov_provider_plugins: Vec<Box<dyn OovProviderPlugin + Sync + Send>>,
+        path_rewrite_plugins: Vec<Box<dyn PathRewritePlugin + Sync + Send>>,
+    }
+
+    impl MockDictionary {
+        fn new(input_text_plugins: Vec<Box<dyn InputTextPlugin + Sync + Send>>) -> Self {
+            Self {
+                grammar: empty_grammar().unwrap(),
+                input_text_plugins,
+                oov_provider_plugins: Vec::new(),
+                path_rewrite_plugins: Vec::new(),
+            }
+        }
+    }
+
+    impl LexiconAccess for MockDictionary {
+        fn lexicon(&self) -> &LexiconSet<'_> {
+            unimplemented!("text normalization does not use lexicon access")
+        }
+    }
+
+    impl DictionaryAccess for MockDictionary {
+        fn grammar(&self) -> &Grammar<'_> {
+            &self.grammar
+        }
+
+        fn input_text_plugins(&self) -> &[Box<dyn InputTextPlugin + Sync + Send>] {
+            &self.input_text_plugins
+        }
+
+        fn oov_provider_plugins(&self) -> &[Box<dyn OovProviderPlugin + Sync + Send>] {
+            &self.oov_provider_plugins
+        }
+
+        fn path_rewrite_plugins(&self) -> &[Box<dyn PathRewritePlugin + Sync + Send>] {
+            &self.path_rewrite_plugins
+        }
+    }
+
+    #[test]
+    fn default_normalizer_reuses_buffer() {
+        let mut normalizer = TextNormalizer::default().unwrap();
+
+        assert_eq!("abc", normalizer.normalize("ＡＢＣ").unwrap());
+        assert_eq!("", normalizer.normalize("").unwrap());
+        assert_eq!("ガヴ", normalizer.normalize("ｶﾞウ゛").unwrap());
+    }
+
+    #[test]
+    fn dictionary_normalizer_uses_dictionary_plugins() {
+        let dictionary = MockDictionary::new(vec![Box::new(ReplaceAllPlugin)]);
+        let mut normalizer = TextNormalizer::from_dictionary(&dictionary);
+
+        assert_eq!("rewritten", normalizer.normalize("abc").unwrap());
+        assert_eq!("rewritten", normalizer.normalize("ＡＢＣ").unwrap());
     }
 }

--- a/sudachi/src/text_normalizer.rs
+++ b/sudachi/src/text_normalizer.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use std::sync::Arc;
+
 use crate::config::ConfigBuilder;
 use crate::dic::connect::ConnectionMatrix;
 use crate::dic::grammar::Grammar;
@@ -34,7 +36,8 @@ pub struct TextNormalizer<'a> {
 
 enum TextNormalizerSource<'a> {
     Default(DefaultInputTextPlugin),
-    Dictionary(&'a (dyn DictionaryAccess + Sync)),
+    BorrowedDictionary(&'a (dyn DictionaryAccess + Sync)),
+    SharedDictionary(Arc<dyn DictionaryAccess + Sync + Send>),
 }
 
 impl<'a> TextNormalizer<'a> {
@@ -58,7 +61,19 @@ impl<'a> TextNormalizer<'a> {
         D: DictionaryAccess + Sync + 'a,
     {
         Self {
-            source: TextNormalizerSource::Dictionary(dictionary),
+            source: TextNormalizerSource::BorrowedDictionary(dictionary),
+            input: InputBuffer::new(),
+        }
+    }
+
+    /// Create a text normalizer using the input-text plugins from a shared dictionary handle.
+    pub fn from_shared_dictionary<D>(dictionary: Arc<D>) -> TextNormalizer<'static>
+    where
+        D: DictionaryAccess + Sync + Send + 'static,
+    {
+        let dictionary: Arc<dyn DictionaryAccess + Sync + Send> = dictionary;
+        TextNormalizer {
+            source: TextNormalizerSource::SharedDictionary(dictionary),
             input: InputBuffer::new(),
         }
     }
@@ -68,10 +83,11 @@ impl<'a> TextNormalizer<'a> {
         self.input.start_build()?;
         match &self.source {
             TextNormalizerSource::Default(plugin) => plugin.rewrite(&mut self.input)?,
-            TextNormalizerSource::Dictionary(dictionary) => {
-                for plugin in dictionary.input_text_plugins() {
-                    plugin.rewrite(&mut self.input)?;
-                }
+            TextNormalizerSource::BorrowedDictionary(dictionary) => {
+                rewrite_with_dictionary(*dictionary, &mut self.input)?;
+            }
+            TextNormalizerSource::SharedDictionary(dictionary) => {
+                rewrite_with_dictionary(dictionary.as_ref(), &mut self.input)?;
             }
         }
         Ok(self.input.current().to_owned())
@@ -92,6 +108,16 @@ fn set_up_default_plugin(grammar: &Grammar) -> SudachiResult<DefaultInputTextPlu
 fn empty_grammar() -> SudachiResult<Grammar<'static>> {
     let connection = ConnectionMatrix::from_bytes(ZERO_CONNECTION_BYTES)?;
     Ok(Grammar::from_parts(PosList::default(), connection))
+}
+
+fn rewrite_with_dictionary<D>(dictionary: &D, input: &mut InputBuffer) -> SudachiResult<()>
+where
+    D: DictionaryAccess + ?Sized,
+{
+    for plugin in dictionary.input_text_plugins() {
+        plugin.rewrite(input)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -184,6 +210,15 @@ mod tests {
     fn dictionary_normalizer_uses_dictionary_plugins() {
         let dictionary = MockDictionary::new(vec![Box::new(ReplaceAllPlugin)]);
         let mut normalizer = TextNormalizer::from_dictionary(&dictionary);
+
+        assert_eq!("rewritten", normalizer.normalize("abc").unwrap());
+        assert_eq!("rewritten", normalizer.normalize("ＡＢＣ").unwrap());
+    }
+
+    #[test]
+    fn shared_dictionary_normalizer_uses_dictionary_plugins() {
+        let dictionary = Arc::new(MockDictionary::new(vec![Box::new(ReplaceAllPlugin)]));
+        let mut normalizer = TextNormalizer::from_shared_dictionary(dictionary);
 
         assert_eq!("rewritten", normalizer.normalize("abc").unwrap());
         assert_eq!("rewritten", normalizer.normalize("ＡＢＣ").unwrap());

--- a/sudachi/src/text_normalizer.rs
+++ b/sudachi/src/text_normalizer.rs
@@ -17,66 +17,53 @@
 use std::sync::Arc;
 
 use crate::config::ConfigBuilder;
-use crate::dic::connect::ConnectionMatrix;
 use crate::dic::grammar::Grammar;
-use crate::dic::pos::PosList;
 use crate::dic::DictionaryAccess;
 use crate::input_text::InputBuffer;
 use crate::plugin::input_text::default_input_text::DefaultInputTextPlugin;
 use crate::plugin::input_text::InputTextPlugin;
 use crate::prelude::*;
 
-const ZERO_CONNECTION_BYTES: &[u8] = &[0, 0, 0, 0];
-
 /// Applies input-text normalization used by tokenizer input processing.
 ///
 /// By default, this uses `DefaultInputTextPlugin`. When built from a dictionary,
 /// it applies that dictionary's configured input-text plugins.
-pub struct TextNormalizer<'a> {
-    source: TextNormalizerSource<'a>,
+pub struct TextNormalizer<D = DefaultInputTextPlugin> {
+    source: D,
     input: InputBuffer,
 }
 
-enum TextNormalizerSource<'a> {
-    Default(DefaultInputTextPlugin),
-    BorrowedDictionary(&'a (dyn DictionaryAccess + Sync)),
-    SharedDictionary(Arc<dyn DictionaryAccess + Sync + Send>),
-}
-
-impl<'a> TextNormalizer<'a> {
+impl TextNormalizer<DefaultInputTextPlugin> {
     /// Create a text normalizer using the default input-text plugin.
     pub fn new(grammar: &Grammar) -> SudachiResult<Self> {
         Ok(Self {
-            source: TextNormalizerSource::Default(set_up_default_plugin(grammar)?),
+            source: set_up_default_plugin(grammar)?,
             input: InputBuffer::new(),
         })
     }
 
     /// Create a text normalizer using the default input-text plugin and an empty grammar.
-    pub fn default() -> SudachiResult<Self> {
-        let grammar = empty_grammar()?;
+    pub fn try_default() -> SudachiResult<Self> {
+        let grammar = Grammar::empty();
         Self::new(&grammar)
     }
 
-    /// Create a text normalizer using the input-text plugins from a dictionary.
-    pub fn from_dictionary<D>(dictionary: &'a D) -> Self
-    where
-        D: DictionaryAccess + Sync + 'a,
-    {
-        Self {
-            source: TextNormalizerSource::BorrowedDictionary(dictionary),
-            input: InputBuffer::new(),
-        }
+    pub fn normalize(&mut self, text: &str) -> SudachiResult<String> {
+        self.input.reset().push_str(text);
+        self.input.start_build()?;
+        self.source.rewrite(&mut self.input)?;
+        Ok(self.input.current().to_owned())
     }
+}
 
-    /// Create a text normalizer using the input-text plugins from a shared dictionary handle.
-    pub fn from_shared_dictionary<D>(dictionary: Arc<D>) -> TextNormalizer<'static>
-    where
-        D: DictionaryAccess + Sync + Send + 'static,
-    {
-        let dictionary: Arc<dyn DictionaryAccess + Sync + Send> = dictionary;
-        TextNormalizer {
-            source: TextNormalizerSource::SharedDictionary(dictionary),
+impl<D> TextNormalizer<D>
+where
+    D: DictionaryAccess,
+{
+    /// Create a text normalizer using the input-text plugins from a dictionary.
+    pub fn from_dictionary(dictionary: D) -> Self {
+        Self {
+            source: dictionary,
             input: InputBuffer::new(),
         }
     }
@@ -84,16 +71,18 @@ impl<'a> TextNormalizer<'a> {
     pub fn normalize(&mut self, text: &str) -> SudachiResult<String> {
         self.input.reset().push_str(text);
         self.input.start_build()?;
-        match &self.source {
-            TextNormalizerSource::Default(plugin) => plugin.rewrite(&mut self.input)?,
-            TextNormalizerSource::BorrowedDictionary(dictionary) => {
-                rewrite_with_dictionary(*dictionary, &mut self.input)?;
-            }
-            TextNormalizerSource::SharedDictionary(dictionary) => {
-                rewrite_with_dictionary(dictionary.as_ref(), &mut self.input)?;
-            }
-        }
+        rewrite_with_dictionary(&self.source, &mut self.input)?;
         Ok(self.input.current().to_owned())
+    }
+}
+
+impl<D> TextNormalizer<Arc<D>>
+where
+    D: DictionaryAccess + ?Sized,
+{
+    /// Create a text normalizer using the input-text plugins from a shared dictionary handle.
+    pub fn from_shared_dictionary(dictionary: Arc<D>) -> Self {
+        TextNormalizer::from_dictionary(dictionary)
     }
 }
 
@@ -106,11 +95,6 @@ fn set_up_default_plugin(grammar: &Grammar) -> SudachiResult<DefaultInputTextPlu
         grammar,
     )?;
     Ok(plugin)
-}
-
-fn empty_grammar() -> SudachiResult<Grammar<'static>> {
-    let connection = ConnectionMatrix::from_bytes(ZERO_CONNECTION_BYTES)?;
-    Ok(Grammar::from_parts(PosList::default(), connection))
 }
 
 fn rewrite_with_dictionary<D>(dictionary: &D, input: &mut InputBuffer) -> SudachiResult<()>
@@ -168,7 +152,7 @@ mod tests {
     impl MockDictionary {
         fn new(input_text_plugins: Vec<Box<dyn InputTextPlugin + Sync + Send>>) -> Self {
             Self {
-                grammar: empty_grammar().unwrap(),
+                grammar: Grammar::empty(),
                 input_text_plugins,
                 oov_provider_plugins: Vec::new(),
                 path_rewrite_plugins: Vec::new(),
@@ -201,8 +185,8 @@ mod tests {
     }
 
     #[test]
-    fn default_normalizer_reuses_buffer() {
-        let mut normalizer = TextNormalizer::default().unwrap();
+    fn default_normalizer_works() {
+        let mut normalizer = TextNormalizer::try_default().unwrap();
 
         assert_eq!("abc", normalizer.normalize("ＡＢＣ").unwrap());
         assert_eq!("", normalizer.normalize("").unwrap());


### PR DESCRIPTION
## Summary
- Add `sudachipy.TextNormalizer` with `normalize(text)`.
- Add `Dictionary.text_normalizer()` so normalization uses the same dictionary input-text plugin set as tokenization.
- Export the API in Python, update type stubs, docs, changelog, and tests.

## Maintainer note
This follows the Java `TextNormalizer` shape from `develop-v0.8`: the dictionary-backed constructor path reuses the dictionary grammar and configured input-text plugins, so custom plugins such as `IgnoreYomiganaPlugin` are reflected in `normalize()`.

`TextNormalizer` normalizes raw input text through input-text plugins. It does not perform morphological analysis or return the dictionary-normalized forms exposed by `Morpheme.normalized_form()`.

This PR targets `develop-v0.7`, so I am using a reference instead of a closing keyword for the issue link.

Refs #339.

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace`
- `.env-py3/bin/python -m pip install -e '.[tests]'`
- `.env-py3/bin/python -m unittest`
- `PATH="$PWD/.env-py3/bin:$PATH" bash build_and_test.sh`
- `.env-py3/bin/python -m py_compile py_src/sudachipy/__init__.py py_src/sudachipy/sudachipy.pyi tests/test_import.py tests/test_text_normalizer.py`
- `cargo test -p sudachipy`
- `git diff --check`
