### PR TITLE
Issue318 align factory methods

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -16,6 +16,7 @@ Also check [rust changelog](../CHANGELOG.md).
 
 - Changed `Dictionary.lookup()` to normalize queries before indexed lookup,
   matching Java Sudachi behavior.
+- Deprecate `Dictionary.create()` in favor of `Dictionary.tokenizer()`.
 
 ### Fixed
 

--- a/python/README.md
+++ b/python/README.md
@@ -43,7 +43,7 @@ EOS
 ```python
 from sudachipy import Dictionary, SplitMode
 
-tokenizer = Dictionary().create()
+tokenizer = Dictionary().tokenizer()
 
 morphemes = tokenizer.tokenize("国会議事堂前駅")
 print(morphemes[0].surface())  # '国会議事堂前駅'
@@ -157,7 +157,7 @@ See [API reference page](https://worksapplications.github.io/sudachi.rs/python/)
 ```python
 from sudachipy import Dictionary, SplitMode
 
-tokenizer_obj = Dictionary().create()
+tokenizer_obj = Dictionary().tokenizer()
 ```
 
 ```python
@@ -246,19 +246,19 @@ class Dictionary(config=None, resource_dir=None, dict=None)
 from sudachipy import Dictionary
 
 # default: sudachidict_core
-tokenizer_obj = Dictionary().create()
+tokenizer_obj = Dictionary().tokenizer()
 
 # The dictionary given by the `systemDict` key in the config file (/path/to/sudachi.json) will be used
-tokenizer_obj = Dictionary(config="/path/to/sudachi.json").create()
+tokenizer_obj = Dictionary(config="/path/to/sudachi.json").tokenizer()
 
 # The dictionary specified by `dict` will be used.
-tokenizer_obj = Dictionary(dict="core").create()  # sudachidict_core (same as default)
-tokenizer_obj = Dictionary(dict="small").create()  # sudachidict_small
-tokenizer_obj = Dictionary(dict="full").create()  # sudachidict_full
+tokenizer_obj = Dictionary(dict="core").tokenizer()  # sudachidict_core (same as default)
+tokenizer_obj = Dictionary(dict="small").tokenizer()  # sudachidict_small
+tokenizer_obj = Dictionary(dict="full").tokenizer()  # sudachidict_full
 
 # The dictionary specified by `dict` overrides those defined in the config.
 # In the following code, `sudachidict_full` will be used regardless of a dictionary defined in the config file.
-tokenizer_obj = Dictionary(config="/path/to/sudachi.json", dict="full").create()
+tokenizer_obj = Dictionary(config="/path/to/sudachi.json", dict="full").tokenizer()
 ```
 
 ### Dictionary in The Setting File

--- a/python/docs/source/topics/out_param.rst
+++ b/python/docs/source/topics/out_param.rst
@@ -8,7 +8,7 @@ Instead, it is possible to reuse MorphemeLists for multiple analysis runs.
 The basic usage pattern is to pass a :py:class:`sudachipy.MorphemeList` as an out parameter to
 :py:meth:`sudachipy.Tokenizer.tokenize()` method::
 
-    tok = dic.create(Mode.A)
+    tok = dic.tokenizer(Mode.A)
     morphemes = tok.tokenize("")
     for line in data:
         tok.tokenize(line, out=morphemes)

--- a/python/docs/source/topics/subsetting.rst
+++ b/python/docs/source/topics/subsetting.rst
@@ -2,7 +2,7 @@ WordInfo subsetting
 ===================
 
 It is possible to ask Suachi to return only a subset of fields in the WordInfo.
-To do that, you can use the ``fields`` parameter of the :py:meth:`sudachipy.Dictionary.create()` method.
+To do that, you can use the ``fields`` parameter of the :py:meth:`sudachipy.Dictionary.tokenizer()` method.
 The parameter accepts a set of strings, each one representing a field to be returned.
 By default, all fields are returned.
 
@@ -27,12 +27,12 @@ Allowed values:
 You need to load splits if you want to use :py:meth:`sudachipy.Morpheme.split` method.
 If performing the tokenization with non-default mode, the required splits will be loaded automatically and can be omitted.::
 
-    dic.create(SplitMode.B, fields=set()) # implicitly becomes fields={'split_b'}
+    dic.tokenizer(SplitMode.B, fields=set()) # implicitly becomes fields={'split_b'}
 
 To access user-defined dictionary data when field subsetting is enabled, load
 ``user_data`` explicitly.::
 
-    tokenizer = dic.create(fields={"surface", "user_data"})
+    tokenizer = dic.tokenizer(fields={"surface", "user_data"})
     morpheme = tokenizer.tokenize("すだち")[0]
     assert morpheme.user_data() == "徳島県産"
 

--- a/python/py_src/sudachipy/command_line.py
+++ b/python/py_src/sudachipy/command_line.py
@@ -120,7 +120,7 @@ def _command_tokenize(args, print_usage):
         # precompute output POS strings
         pos_list = [",".join(ms) for ms in all_pos_matcher]
 
-        tokenizer_obj = dict_.create(mode=args.mode)
+        tokenizer_obj = dict_.tokenizer(mode=args.mode)
         input_ = fileinput.input(
             args.in_files, openhook=fileinput.hook_encoded("utf-8"))
         run(tokenizer_obj, input_, output, print_all,

--- a/python/py_src/sudachipy/sudachipy.pyi
+++ b/python/py_src/sudachipy/sudachipy.pyi
@@ -99,6 +99,21 @@ class Dictionary:
         """
         ...
 
+    def tokenizer(self,
+                  mode: Union[SplitMode, SplitModeStr, None] = SplitMode.C,
+                  fields: Optional[FieldSet] = None,
+                  *,
+                  projection: Optional[str] = None) -> Tokenizer:
+        """
+        Creates a sudachi tokenizer.
+
+        :param mode: sets the analysis mode for this Tokenizer
+        :param fields: load only a subset of fields.
+            See https://worksapplications.github.io/sudachi.rs/python/topics/subsetting.html.
+        :param projection: Projection override for created Tokenizer. See Config.projection for values.
+        """
+        ...
+
     def create(self,
                mode: Union[SplitMode, SplitModeStr, None] = SplitMode.C,
                fields: Optional[FieldSet] = None,
@@ -106,6 +121,9 @@ class Dictionary:
                projection: Optional[str] = None) -> Tokenizer:
         """
         Creates a sudachi tokenizer.
+
+        .. deprecated::
+            Use ``Dictionary.tokenizer()`` instead.
 
         :param mode: sets the analysis mode for this Tokenizer
         :param fields: load only a subset of fields.
@@ -438,7 +456,7 @@ class Tokenizer:
     """
     A sudachi tokenizer
 
-    Create using Dictionary.create method.
+    Create using Dictionary.tokenizer method.
     """
     SplitMode: ClassVar[SplitMode] = ...
 

--- a/python/src/dictionary.rs
+++ b/python/src/dictionary.rs
@@ -195,6 +195,39 @@ pub struct PyDictionary {
     pub config: Config,
 }
 
+impl PyDictionary {
+    fn create_tokenizer<'py>(
+        &'py self,
+        mode: Option<&Bound<'py, PyAny>>,
+        fields: Option<&Bound<'py, PySet>>,
+        projection: Option<&Bound<'py, PyString>>,
+    ) -> PyResult<PyTokenizer> {
+        let mode = match mode {
+            Some(m) => extract_mode(m)?,
+            None => Mode::C,
+        };
+        let fields = parse_field_subset(fields)?;
+        let dict = self.dictionary.as_ref().unwrap().clone();
+
+        let (projection, required_fields) = if let Some(s) = projection {
+            let projection = errors::wrap(SurfaceProjection::try_from(s.to_str()?))?;
+            (pyprojection(projection, &dict), projection.required_subset())
+        } else {
+            (
+                dict.projection.clone(),
+                self.config.projection.required_subset(),
+            )
+        };
+
+        Ok(PyTokenizer::new(
+            dict,
+            mode,
+            fields | required_fields,
+            projection,
+        ))
+    }
+}
+
 #[pymethods]
 impl PyDictionary {
     /// Creates a sudachi dictionary.
@@ -334,34 +367,44 @@ impl PyDictionary {
         text_signature="(self, /, mode=SplitMode.C, fields=None, *, projection=None) -> Tokenizer",
         signature=(mode=None, fields=None, *, projection=None)
     )]
-    fn create<'py>(
+    fn tokenizer<'py>(
         &'py self,
+        _py: Python<'py>,
         mode: Option<&Bound<'py, PyAny>>,
         fields: Option<&Bound<'py, PySet>>,
         projection: Option<&Bound<'py, PyString>>,
     ) -> PyResult<PyTokenizer> {
-        let mode = match mode {
-            Some(m) => extract_mode(m)?,
-            None => Mode::C,
-        };
-        let fields = parse_field_subset(fields)?;
-        let dict = self.dictionary.as_ref().unwrap().clone();
+        self.create_tokenizer(mode, fields, projection)
+    }
 
-        let (projection, required_fields) = if let Some(s) = projection {
-            let projection = errors::wrap(SurfaceProjection::try_from(s.to_str()?))?;
-            (
-                pyprojection(projection, &dict),
-                projection.required_subset(),
-            )
-        } else {
-            (
-                dict.projection.clone(),
-                self.config.projection.required_subset(),
-            )
-        };
-
-        let tok = PyTokenizer::new(dict, mode, fields | required_fields, projection);
-        Ok(tok)
+    /// Creates a sudachi tokenizer.
+    ///
+    /// This method is deprecated, use :py:meth:`Dictionary.tokenizer` instead.
+    ///
+    /// :param mode: sets the analysis mode for this Tokenizer
+    /// :param fields: load only a subset of fields.
+    ///     See https://worksapplications.github.io/sudachi.rs/python/topics/subsetting.html.
+    /// :param projection: Projection override for created Tokenizer. See Config.projection for values.
+    ///
+    /// :type mode: SplitMode | str | None
+    /// :type fields: set[str] | None
+    /// :type projection: str | None
+    #[pyo3(
+        text_signature="(self, /, mode=SplitMode.C, fields=None, *, projection=None) -> Tokenizer",
+        signature=(mode=None, fields=None, *, projection=None)
+    )]
+    fn create<'py>(
+        &'py self,
+        py: Python<'py>,
+        mode: Option<&Bound<'py, PyAny>>,
+        fields: Option<&Bound<'py, PySet>>,
+        projection: Option<&Bound<'py, PyString>>,
+    ) -> PyResult<PyTokenizer> {
+        errors::warn_deprecation(
+            py,
+            c_str!("Dictionary.create() is deprecated, use Dictionary.tokenizer() instead"),
+        )?;
+        self.create_tokenizer(mode, fields, projection)
     }
 
     /// Creates a text normalizer from this dictionary.

--- a/python/tests/test_build.py
+++ b/python/tests/test_build.py
@@ -69,7 +69,7 @@ class MyTestCase(unittest.TestCase):
         self.assertIsNotNone(stats)
         cfg = replace(CFG_TEMPLATE, system=out_tmp)
         dict = sudachipy.Dictionary(config_path=cfg)
-        tok = dict.create()
+        tok = dict.tokenizer()
         result = tok.tokenize("東京にいく")
         self.assertEqual(result.size(), 3)
 
@@ -89,13 +89,13 @@ class MyTestCase(unittest.TestCase):
 
         cfg = replace(CFG_TEMPLATE, system=sys_dic, user=[u1_dic])
         dict = sudachipy.Dictionary(config=cfg)
-        tok = dict.create()
+        tok = dict.tokenizer()
         result = tok.tokenize("すだちにいく")
         self.assertEqual(result.size(), 3)
         self.assertEqual(result[0].dictionary_id(), 1)
         self.assertEqual(result[0].user_data(), "徳島県産")
 
-        subset_tok = dict.create(fields={"user_data"})
+        subset_tok = dict.tokenizer(fields={"user_data"})
         subset_result = subset_tok.tokenize("すだちにいく")
         self.assertEqual(subset_result[0].user_data(), "徳島県産")
 
@@ -122,7 +122,7 @@ class MyTestCase(unittest.TestCase):
 
         cfg = replace(CFG_TEMPLATE, system=sys_dic, user=[u1_dic, u2_dic])
         dict = sudachipy.Dictionary(config_path=cfg)
-        tok = dict.create()
+        tok = dict.tokenizer()
         result = tok.tokenize("かぼすにいく")
         self.assertEqual(result.size(), 3)
         self.assertEqual(result[0].dictionary_id(), 2)

--- a/python/tests/test_dictionary.py
+++ b/python/tests/test_dictionary.py
@@ -44,8 +44,8 @@ class TestDictionary(unittest.TestCase):
     def tearDown(self) -> None:
         self.dict_.close()
 
-    def test_create(self):
-        self.assertEqual(Tokenizer, type(self.dict_.create()))
+    def test_tokenizer(self):
+        self.assertEqual(Tokenizer, type(self.dict_.tokenizer()))
 
     def test_pos_of(self):
         self.assertIsNotNone(self.dict_.pos_of(0))

--- a/python/tests/test_morpheme.py
+++ b/python/tests/test_morpheme.py
@@ -29,7 +29,7 @@ class TestTokenizer(unittest.TestCase):
             os.path.abspath(__file__)), 'resources')
         self.dict_ = Dictionary(os.path.join(
             resource_dir, 'sudachi.json'), resource_dir)
-        self.tokenizer_obj = self.dict_.create()
+        self.tokenizer_obj = self.dict_.tokenizer()
 
     def test_empty_list(self):
         ms = self.tokenizer_obj.tokenize('')
@@ -153,13 +153,13 @@ class TestTokenizer(unittest.TestCase):
             with open(config_path, 'w', encoding='utf-8') as out:
                 json.dump(config, out, ensure_ascii=False)
 
-            tokenizer = Dictionary(config_path, resource_dir).create()
+            tokenizer = Dictionary(config_path, resource_dir).tokenizer()
             m = tokenizer.tokenize('首都旧')[0]
             nf = m.normalized_form_morpheme()
             splits = nf.split(SplitMode.A, add_single=True)
             out = self.tokenizer_obj.tokenize('')
             out_result = nf.split(SplitMode.A, out=out, add_single=True)
-            surface_tokenizer = Dictionary(config_path, resource_dir).create(
+            surface_tokenizer = Dictionary(config_path, resource_dir).tokenizer(
                 fields={'surface', 'normalized_form', 'split_a'})
             surface_nf = surface_tokenizer.tokenize(
                 '首都旧')[0].normalized_form_morpheme()
@@ -198,7 +198,7 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(nf.surface(), m.surface())
 
     def test_form_morpheme_with_surface_subset(self):
-        tokenizer = self.dict_.create(
+        tokenizer = self.dict_.tokenizer(
             fields={'surface', 'dictionary_form', 'normalized_form'})
         m = tokenizer.tokenize('行っ')[0]
         df = m.dictionary_form_morpheme()
@@ -210,7 +210,7 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(nf.raw_surface(), '行く')
 
     def test_form_morpheme_with_reading_subset(self):
-        tokenizer = self.dict_.create(
+        tokenizer = self.dict_.tokenizer(
             fields={
                 'surface',
                 'reading_form',
@@ -227,7 +227,7 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(nf.reading_form(), 'イク')
 
     def test_single_backed_form_morpheme_uses_projection(self):
-        tokenizer = self.dict_.create(
+        tokenizer = self.dict_.tokenizer(
             fields={'dictionary_form'}, projection='reading')
         m = tokenizer.tokenize('行っ')[0]
         df = m.dictionary_form_morpheme()
@@ -325,7 +325,7 @@ class TestTokenizer(unittest.TestCase):
         m = self.tokenizer_obj.tokenize('京都')[0]
         self.assertEqual(m.user_data(), '')
 
-        tokenizer = self.dict_.create(fields={'user_data'})
+        tokenizer = self.dict_.tokenizer(fields={'user_data'})
         m = tokenizer.tokenize('すだち')[0]
         self.assertEqual(m.user_data(), '徳島県産')
 

--- a/python/tests/test_pos_matcher.py
+++ b/python/tests/test_pos_matcher.py
@@ -25,7 +25,7 @@ class PosMatcherTestCase(unittest.TestCase):
             os.path.abspath(__file__)), 'resources')
         self.dict = Dictionary(os.path.join(
             resource_dir, 'sudachi.json'), resource_dir)
-        self.tokenizer_obj = self.dict.create()
+        self.tokenizer_obj = self.dict.tokenizer()
 
     def test_create_fn(self):
         m = self.dict.pos_matcher(lambda p: p[0] == "名詞")
@@ -62,7 +62,7 @@ class PosMatcherTestCase(unittest.TestCase):
                                    ('動詞', '非自立可能', '*', '*', '五段-カ行', '終止形-一般')])
 
     def test_match_nouns(self):
-        tok = self.dict.create(mode=sudachipy.SplitMode.A)
+        tok = self.dict.tokenizer(mode=sudachipy.SplitMode.A)
         m = self.dict.pos_matcher([("名詞",)])
         data = [x.surface() for x in tok.tokenize("東京に行く") if m(x)]
         self.assertEqual(data, ["東京"])

--- a/python/tests/test_projection.py
+++ b/python/tests/test_projection.py
@@ -36,7 +36,7 @@ class MyTestCase(unittest.TestCase):
         return config, resource_dir
 
     def test_projection_surface_override(self):
-        tok = self.dict.create(projection="surface")
+        tok = self.dict.tokenizer(projection="surface")
         morphs = tok.tokenize("酒を飲む人")
         self.assertEqual(4, morphs.size())
         self.assertEqual("酒", morphs[0].surface())
@@ -45,7 +45,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual("人", morphs[3].surface())
 
     def test_projection_reading(self):
-        tok = self.dict.create()
+        tok = self.dict.tokenizer()
         morphs = tok.tokenize("酒を飲む人")
         self.assertEqual(4, morphs.size())
         self.assertEqual("サケ", morphs[0].surface())
@@ -54,7 +54,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual("ヒト", morphs[3].surface())
 
     def test_projection_dictionary(self):
-        tok = self.dict.create(projection="dictionary")
+        tok = self.dict.tokenizer(projection="dictionary")
         morphs = tok.tokenize("酒を飲まなかった人")
         self.assertEqual(6, morphs.size())
         self.assertEqual("酒", morphs[0].surface())
@@ -65,7 +65,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual("人", morphs[5].surface())
 
     def test_projection_normalized(self):
-        tok = self.dict.create(projection="normalized")
+        tok = self.dict.tokenizer(projection="normalized")
         morphs = tok.tokenize("MEGAへ行く")
         self.assertEqual(3, morphs.size())
         self.assertEqual("メガ", morphs[0].surface())
@@ -74,7 +74,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual("行く", morphs[2].surface())
 
     def test_projection_dictionary_and_surface(self):
-        tok = self.dict.create(projection="dictionary_and_surface")
+        tok = self.dict.tokenizer(projection="dictionary_and_surface")
         morphs = tok.tokenize("酒を飲まなかった人")
         self.assertEqual(6, morphs.size())
         self.assertEqual("酒", morphs[0].surface())
@@ -85,7 +85,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual("人", morphs[5].surface())
 
     def test_projection_normalized_and_surface(self):
-        tok = self.dict.create(projection="normalized_and_surface")
+        tok = self.dict.tokenizer(projection="normalized_and_surface")
         morphs = tok.tokenize("MEGAへ行こう")
         self.assertEqual(3, morphs.size())
         self.assertEqual("メガ", morphs[0].surface())
@@ -94,7 +94,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual("行こう", morphs[2].surface())
 
     def test_projection_normalized_nouns(self):
-        tok = self.dict.create(projection="normalized_nouns")
+        tok = self.dict.tokenizer(projection="normalized_nouns")
         morphs = tok.tokenize("MEGAへ行こう")
         self.assertEqual(3, morphs.size())
         self.assertEqual("メガ", morphs[0].surface())

--- a/python/tests/test_tokenizer.py
+++ b/python/tests/test_tokenizer.py
@@ -14,6 +14,7 @@
 
 import os
 import unittest
+import warnings
 
 from sudachipy import Dictionary, SplitMode
 
@@ -25,7 +26,7 @@ class TestTokenizer(unittest.TestCase):
             os.path.abspath(__file__)), 'resources')
         self.dict_ = Dictionary(os.path.join(
             resource_dir, 'sudachi.json'), resource_dir)
-        self.tokenizer_obj = self.dict_.create()
+        self.tokenizer_obj = self.dict_.tokenizer()
 
     def test_split_mode_default(self):
         mode_c = SplitMode()
@@ -44,8 +45,15 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(mode, SplitMode.C)
 
     def test_tokenizer_with_split_mode_str(self):
-        tok_a = self.dict_.create("A")
+        tok_a = self.dict_.tokenizer("A")
         self.assertEqual(tok_a.mode, SplitMode.A)
+
+    def test_create_is_deprecated_alias(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            tok = self.dict_.create("A")
+        self.assertEqual(tok.mode, SplitMode.A)
+        self.assertTrue(any("Dictionary.create() is deprecated" in str(w.message) for w in caught))
 
     def test_tokenize_small_katanana_only(self):
         ms = self.tokenizer_obj.tokenize('ァ')
@@ -153,7 +161,7 @@ class TestTokenizer(unittest.TestCase):
     def test_tokenizer_subset(self):
         ms1 = self.tokenizer_obj.tokenize('東京都')
 
-        tok = self.dict_.create(fields={"pos"})
+        tok = self.dict_.tokenizer(fields={"pos"})
         ms2 = tok.tokenize('東京都')
         self.assertEqual(ms1[0].part_of_speech_id(), ms2[0].part_of_speech_id())
 


### PR DESCRIPTION
Fixes #318 

## What this commit covers

- Add `Dictionary.tokenizer()` as the canonical tokenizer factory method.
- Keep `Dictionary.create()` for backward compatibility, but mark it as deprecated.
- Update Python type stubs, documentation, CLI usage, and tests to use `Dictionary.tokenizer()`.
- Add a regression test to confirm that `Dictionary.create()` still works and emits a deprecation warning.

## What this commit does not cover
- `pos_matcher`
`pos_matcher` was already aligned before this work. 
https://github.com/WorksApplications/sudachi.rs/blob/d7d3870b1763c0d7dc10c68c925ae89815b3bd71/python/CHANGELOG.md?plain=1#L145

- `text_normalizer`
Resolved in #349

