### PR TITLE
Fix builds for Android and 32-bit targets

### DIFF
--- a/sudachi/src/plugin/loader.rs
+++ b/sudachi/src/plugin/loader.rs
@@ -71,12 +71,16 @@ fn make_system_specific_name(s: &str) -> Option<String> {
     target_os = "ios",
     target_os = "tvos",
     target_os = "watchos",
-    target_os = "visionos"
+    target_os = "visionos",
+    target_os = "android"
 ))]
 // Apple embedded platforms do not support dynamic library loading (DSO plugins)
 // due to platform security restrictions. Returning None here
 // effectively disables loading plugins from DSOs, while still allowing
 // plugins bundled with the application/binary to work as expected.
+// Android is handled the same way: applications ship native code bundled
+// inside the app package, so resolving external plugin DSOs by
+// platform-specific file name does not apply there either.
 fn make_system_specific_name(_s: &str) -> Option<String> {
     None
 }

--- a/sudachi/src/util/fxhash.rs
+++ b/sudachi/src/util/fxhash.rs
@@ -58,6 +58,9 @@ const SEED32: u32 = 0x9e_37_79_b9;
 #[cfg(target_pointer_width = "64")]
 const SEED: usize = SEED64 as usize;
 
+#[cfg(target_pointer_width = "32")]
+const SEED: usize = SEED32 as usize;
+
 trait HashWord {
     fn hash_word(&mut self, _: Self);
 }


### PR DESCRIPTION
Two small portability fixes, both hit while building sudachi for Android (which ships 4 ABIs, so both 64- and 32-bit targets must compile).

## 1. `target_os = "android"` hits no cfg arm in `plugin/loader.rs`

```
$ cargo build --target aarch64-linux-android
error[E0425]: cannot find value `make_system_specific_name` in this scope
  --> sudachi/src/plugin/loader.rs:92:23
   |
92 |             .and_then(make_system_specific_name);
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
```

`make_system_specific_name` is defined for `linux`/`freebsd`, `windows`, `macos`, and the Apple embedded platforms — `android` falls into none of them.

Fixed by adding `target_os = "android"` to the group that returns `None`, mirroring the existing Apple-embedded handling: Android applications ship native code bundled inside the app package, so resolving external plugin DSOs by platform-specific file name does not apply there; bundled plugins keep working as expected.

If you would rather treat Android like Linux (`lib{}.so`, since Android does technically support `dlopen`), happy to change it — `None` seemed truer to how Android apps are actually distributed.

## 2. `util/fxhash.rs` seeds `usize` only on 64-bit

```
$ cargo build --target armv7-linux-androideabi
error[E0425]: cannot find value `SEED` in this scope
  --> sudachi/src/util/fxhash.rs:78:25
   |
78 | impl_hash_word!(usize = SEED, u32 = SEED32, u64 = SEED64);
   |                         ^^^^ not found in this scope
```

`const SEED: usize` is declared under `#[cfg(target_pointer_width = "64")]` only, so **every 32-bit target** fails — armv7/i686 Android here, but equally 32-bit ARM/x86 Linux and wasm32. (rustc's "constant `crate::hash::SEED` exists but is inaccessible" note points at an unrelated same-named const in `hash.rs`; it is a red herring.)

Fixed by adding the 32-bit counterpart seeded from `SEED32`, mirroring the existing 64-bit line and matching what the upstream `fxhash` crate does for `usize` on 32-bit.

## Verification

`cargo build` with NDK r28c compiles the whole crate tree cleanly for both `aarch64-linux-android` and `armv7-linux-androideabi`, producing valid Android ELFs; only pre-existing warnings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)