### PR TITLE
Update PyO3 and drop Python 3.13t support

### DIFF
--- a/.github/workflows/python-upload-test.yml
+++ b/.github/workflows/python-upload-test.yml
@@ -151,7 +151,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
-        target: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
+        target: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
         include:
           - os: "ubuntu-latest"
             target: "sdist"
@@ -160,8 +160,6 @@ jobs:
             target: "sdist"
             python-version: "3.14"
         exclude:
-          - os: "windows-latest"
-            target: "3.13t"
           - os: "windows-latest"
             target: "3.14t"
 
@@ -189,10 +187,10 @@ jobs:
         # this must be after sudachipy install
         run: uv pip install --system sudachidict_core
       - name: Install dependencies (test pretokenizer)
-        if: ${{ !(runner.os == 'macOS' && (matrix.target == '3.13t' || matrix.target == '3.14t')) }}
+        if: ${{ !(runner.os == 'macOS' && matrix.target == '3.14t') }}
         run: uv pip install --system tokenizers
       - name: Install dependencies (test pretokenizer, macOS free-threaded)
-        if: ${{ runner.os == 'macOS' && (matrix.target == '3.13t' || matrix.target == '3.14t') }}
+        if: ${{ runner.os == 'macOS' && matrix.target == '3.14t' }}
         env:
           RUSTFLAGS: -C link-arg=-undefined -C link-arg=dynamic_lookup
         run: uv pip install --system tokenizers

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -47,3 +47,16 @@ jobs:
       - name: Build and test
         working-directory: ./python
         run: bash build_and_test.sh
+
+  reject-python-313t:
+    name: Reject Python 3.13t
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Setup Python 3.13t
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.13t"
+      - name: Check explicit ImportError
+        run: python -m unittest discover -s python/tests -p test_unsupported_python.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
  "libc",
  "once_cell",
@@ -660,18 +660,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -691,13 +691,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ include = [
 ]
 
 [tool.cibuildwheel]
-build = "cp310-* cp313t-* cp314t-*"
+build = "cp310-* cp314t-*"
 skip = "*t-win* *-win32 *-musllinux_*"
 enable = ["cpython-prerelease", "cpython-freethreading"]
 build-frontend = "build[uv]"

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -8,6 +8,7 @@ Also check [rust changelog](../CHANGELOG.md).
 
 ### Changed
 
+- Update PyO3 to v0.29.2.
 - Migrate SudachiPy extension builds from setuptools-rust to maturin and produce
   CPython abi3 wheels for Python 3.10 and later.
 - Linux wheels now target `manylinux_2_28`; older distributions with glibc
@@ -15,6 +16,8 @@ Also check [rust changelog](../CHANGELOG.md).
 
 ### Removed
 
+- Remove Python 3.13t support. Importing SudachiPy with Python 3.13t now raises
+  an explicit `ImportError`; regular Python 3.13 and Python 3.14t remain supported.
 - Remove Python 3.9 support.
 
 ## [0.6.11](https://github.com/WorksApplications/sudachi.rs/releases/tag/v0.6.11) (2026-03-06)

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -15,7 +15,7 @@ name = "sudachipy"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28.3", features = ["abi3-py310"] }
+pyo3 = { version = "0.29.2", features = ["abi3-py310"] }
 scopeguard = "1" # Apache 2.0/MIT
 thread_local = "1.1" # Apache 2.0/MIT
 

--- a/python/py_src/sudachipy/__init__.py
+++ b/python/py_src/sudachipy/__init__.py
@@ -1,3 +1,15 @@
+import sys as _sys
+import sysconfig as _sysconfig
+
+if (
+    _sys.version_info[:2] == (3, 13)
+    and _sysconfig.get_config_var("Py_GIL_DISABLED")
+):
+    raise ImportError(
+        "SudachiPy does not support Python 3.13 free-threaded; "
+        "use regular Python 3.13 or Python 3.14 free-threaded instead."
+    )
+
 from .sudachipy import (
     Dictionary,
     Tokenizer,

--- a/python/tests/test_unsupported_python.py
+++ b/python/tests/test_unsupported_python.py
@@ -1,0 +1,23 @@
+import importlib
+import sys
+import sysconfig
+import unittest
+from pathlib import Path
+
+
+@unittest.skipUnless(
+    sys.version_info[:2] == (3, 13)
+    and sysconfig.get_config_var("Py_GIL_DISABLED"),
+    "requires a free-threaded Python 3.13 build",
+)
+class TestUnsupportedPython(unittest.TestCase):
+    def test_import_raises_explicit_error(self):
+        package_source = Path(__file__).resolve().parents[1] / "py_src"
+        sys.path.insert(0, str(package_source))
+        self.addCleanup(sys.path.remove, str(package_source))
+
+        with self.assertRaisesRegex(
+            ImportError,
+            "SudachiPy does not support Python 3.13 free-threaded",
+        ):
+            importlib.import_module("sudachipy")

--- a/python/verify-dist-artifacts.py
+++ b/python/verify-dist-artifacts.py
@@ -42,11 +42,6 @@ EXPECTED_WHEEL_TAGS = {
     "cp310-abi3-manylinux_2_28_aarch64",
     "cp310-abi3-manylinux_2_28_x86_64",
     "cp310-abi3-win_amd64",
-    "cp313-cp313t-macosx_10_13_universal2",
-    "cp313-cp313t-macosx_10_13_x86_64",
-    "cp313-cp313t-macosx_11_0_arm64",
-    "cp313-cp313t-manylinux_2_28_aarch64",
-    "cp313-cp313t-manylinux_2_28_x86_64",
     "cp314-cp314t-macosx_10_15_universal2",
     "cp314-cp314t-macosx_10_15_x86_64",
     "cp314-cp314t-macosx_11_0_arm64",
@@ -89,7 +84,6 @@ def check_wheel(path: Path) -> None:
 
     if not (
         "cp310-abi3" in path.name
-        or "cp313-cp313t" in path.name
         or "cp314-cp314t" in path.name
     ):
         fail(f"{path.name} has an unexpected Python ABI tag")


### PR DESCRIPTION
## Summary

- Upgrade PyO3 from 0.28.3 to 0.29.2.
- Drop Python 3.13t wheel builds as agreed in #359 and make `import sudachipy` raise an explicit `ImportError` there.
- Keep Python 3.14t wheels and regular CPython 3.10+ ABI3 wheels.
- Update the TestPyPI matrix and distribution-artifact expectations consistently.

This follows the maintainer direction in #359 to remove 3.13t support with this update while rejecting that runtime deliberately at the public import boundary.

## Tests

- `cargo test --workspace --locked --offline`
- `cargo fmt --all --check`
- Python 3.14.3: built and imported `cp310-abi3-macosx_11_0_arm64`; 80 tests passed (2 skipped)
- Python 3.14.7t: built and imported `cp314-cp314t-macosx_11_0_arm64`; 80 tests passed (1 skipped), including the GIL-disabled import test
- Python 3.13.15t: focused rejection test passed and packaged import raised the expected `ImportError`
- Python 3.13.15: regular ABI3 import smoke passed
- Distribution verifier passed for the updated synthetic full matrix: 11 wheels and 1 built sdist
- `python python/check_version_consistency.py`
- workflow YAML and TOML parse checks
- `git diff --check`

AI assistance: Codex was used to help implement and verify this change; I reviewed and own the result.

Fixes #359
